### PR TITLE
OSD-4804 service-quota --all-regions

### DIFF
--- a/cmd/account/servicequotas/common.go
+++ b/cmd/account/servicequotas/common.go
@@ -6,11 +6,18 @@ import (
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 )
 
-// GetSupportedRegions returns a []string of regions supported
+/*GetSupportedRegions returns a []string of regions supported
+return []string of any regions found
+	if allRegions: return all found regions, ignore filter
+	if !allRegions:
+		filter set: return 1 element if region matches
+		filter == "": return all found regions
+return error if no regions are returned
+*/
 func GetSupportedRegions(filter string, allRegions bool) ([]string, error) {
 	var results []string
 	for i := range awsv1alpha1.CoveredRegions {
-		if (filter != "") && (allRegions == false) {
+		if (filter != "") && !allRegions {
 			if filter == i {
 				results = append(results, i)
 				return results, nil

--- a/cmd/account/servicequotas/common.go
+++ b/cmd/account/servicequotas/common.go
@@ -1,0 +1,29 @@
+package servicequotas
+
+import (
+	"errors"
+
+	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
+)
+
+// GetSupportedRegions returns a []string of regions supported
+func GetSupportedRegions(filter string, allRegions bool) ([]string, error) {
+	var results []string
+	for i := range awsv1alpha1.CoveredRegions {
+		if (filter != "") && (allRegions == false) {
+			if (filter == i) {
+				results = append(results, i)
+				return results, nil
+			}
+			continue
+		}
+
+		results = append(results, i)
+	}
+
+	if (len(results) == 0) {
+		return results, errors.New("Cannot find Supported Region")
+	}
+
+	return results, nil
+}

--- a/cmd/account/servicequotas/common.go
+++ b/cmd/account/servicequotas/common.go
@@ -11,7 +11,7 @@ func GetSupportedRegions(filter string, allRegions bool) ([]string, error) {
 	var results []string
 	for i := range awsv1alpha1.CoveredRegions {
 		if (filter != "") && (allRegions == false) {
-			if (filter == i) {
+			if filter == i {
 				results = append(results, i)
 				return results, nil
 			}
@@ -21,7 +21,7 @@ func GetSupportedRegions(filter string, allRegions bool) ([]string, error) {
 		results = append(results, i)
 	}
 
-	if (len(results) == 0) {
+	if len(results) == 0 {
 		return results, errors.New("Cannot find Supported Region")
 	}
 

--- a/cmd/account/servicequotas/common.go
+++ b/cmd/account/servicequotas/common.go
@@ -6,14 +6,7 @@ import (
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 )
 
-/*GetSupportedRegions returns a []string of regions supported
-return []string of any regions found
-	if allRegions: return all found regions, ignore filter
-	if !allRegions:
-		filter set: return 1 element if region matches
-		filter == "": return all found regions
-return error if no regions are returned
-*/
+// GetSupportedRegions returns a []string of all supported regions if found and an error. Filtering for a single region is also supported.
 func GetSupportedRegions(filter string, allRegions bool) ([]string, error) {
 	var results []string
 	for i := range awsv1alpha1.CoveredRegions {

--- a/cmd/account/servicequotas/common_test.go
+++ b/cmd/account/servicequotas/common_test.go
@@ -1,6 +1,5 @@
 package servicequotas
 
-
 import (
 	"strings"
 	"testing"
@@ -11,68 +10,68 @@ import (
 func TestGetSupportedRegions(t *testing.T) {
 	g := NewGomegaWithT(t)
 	testCases := []struct {
-		title		string
-		region      string
-		allRegions  bool
-		errExpected bool
-		errContent  string
+		title                    string
+		region                   string
+		allRegions               bool
+		errExpected              bool
+		errContent               string
 		expectRegionsMoreThanOne bool
-		expectRegionsOnlyOne bool
-		expectRegionsNone bool
+		expectRegionsOnlyOne     bool
+		expectRegionsNone        bool
 	}{
 		{
-			title:       "no region filter, not all regions, no error, return all",
-			region:       "",
-			allRegions:   false,
-			errExpected:  false,
+			title:                    "no region filter, not all regions, no error, return all",
+			region:                   "",
+			allRegions:               false,
+			errExpected:              false,
 			expectRegionsMoreThanOne: true,
-			expectRegionsOnlyOne: false,
-			expectRegionsNone: false,
+			expectRegionsOnlyOne:     false,
+			expectRegionsNone:        false,
 		},
 		{
-			title:       "no region filter, return all regions, no error, return all",
-			region:       "",
-			allRegions:   true,
-			errExpected:  false,
+			title:                    "no region filter, return all regions, no error, return all",
+			region:                   "",
+			allRegions:               true,
+			errExpected:              false,
 			expectRegionsMoreThanOne: true,
-			expectRegionsOnlyOne: false,
-			expectRegionsNone: false,
+			expectRegionsOnlyOne:     false,
+			expectRegionsNone:        false,
 		},
 		{
-			title:       "us-east-1 region filter, not all regions, should return 1 region",
-			region:       "us-east-1",
-			allRegions:   false,
-			errExpected:  false,
+			title:                    "us-east-1 region filter, not all regions, should return 1 region",
+			region:                   "us-east-1",
+			allRegions:               false,
+			errExpected:              false,
 			expectRegionsMoreThanOne: false,
-			expectRegionsOnlyOne: true,
-			expectRegionsNone: false,
+			expectRegionsOnlyOne:     true,
+			expectRegionsNone:        false,
 		},
 		{
-			title:       "us-east-1 region filter, return all regions, should return all regions",
-			region:       "us-east-1",
-			allRegions:   true,
-			errExpected:  false,
+			title:                    "us-east-1 region filter, return all regions, should return all regions",
+			region:                   "us-east-1",
+			allRegions:               true,
+			errExpected:              false,
 			expectRegionsMoreThanOne: true,
-			expectRegionsOnlyOne: false,
-			expectRegionsNone: false,
+			expectRegionsOnlyOne:     false,
+			expectRegionsNone:        false,
 		},
 		{
-			title:       "us-east-15 region filter, not all regions, should error",
-			region:       "us-east-15",
-			allRegions:   false,
-			errExpected:  true,
+			title:                    "us-east-15 region filter, not all regions, should error",
+			region:                   "us-east-15",
+			allRegions:               false,
+			errExpected:              true,
 			expectRegionsMoreThanOne: false,
-			expectRegionsOnlyOne: false,
-			expectRegionsNone: true,
+			expectRegionsOnlyOne:     false,
+			expectRegionsNone:        true,
 		},
 		{
-			title:       "us-east-15 region filter, return all regions, should return all regions",
-			region:       "us-east-15",
-			allRegions:   true,
-			errExpected:  false,
+			title:                    "us-east-15 region filter, return all regions, should return all regions",
+			region:                   "us-east-15",
+			allRegions:               true,
+			errExpected:              false,
 			expectRegionsMoreThanOne: true,
-			expectRegionsOnlyOne: false,
-			expectRegionsNone: false,
+			expectRegionsOnlyOne:     false,
+			expectRegionsNone:        false,
 		},
 	}
 

--- a/cmd/account/servicequotas/common_test.go
+++ b/cmd/account/servicequotas/common_test.go
@@ -1,0 +1,96 @@
+package servicequotas
+
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestGetSupportedRegions(t *testing.T) {
+	g := NewGomegaWithT(t)
+	testCases := []struct {
+		title		string
+		region      string
+		allRegions  bool
+		errExpected bool
+		errContent  string
+		expectRegionsMoreThanOne bool
+		expectRegionsOnlyOne bool
+		expectRegionsNone bool
+	}{
+		{
+			title:       "no region filter, not all regions, no error, return all",
+			region:       "",
+			allRegions:   false,
+			errExpected:  false,
+			expectRegionsMoreThanOne: true,
+			expectRegionsOnlyOne: false,
+			expectRegionsNone: false,
+		},
+		{
+			title:       "no region filter, return all regions, no error, return all",
+			region:       "",
+			allRegions:   true,
+			errExpected:  false,
+			expectRegionsMoreThanOne: true,
+			expectRegionsOnlyOne: false,
+			expectRegionsNone: false,
+		},
+		{
+			title:       "us-east-1 region filter, not all regions, should return 1 region",
+			region:       "us-east-1",
+			allRegions:   false,
+			errExpected:  false,
+			expectRegionsMoreThanOne: false,
+			expectRegionsOnlyOne: true,
+			expectRegionsNone: false,
+		},
+		{
+			title:       "us-east-1 region filter, return all regions, should return all regions",
+			region:       "us-east-1",
+			allRegions:   true,
+			errExpected:  false,
+			expectRegionsMoreThanOne: true,
+			expectRegionsOnlyOne: false,
+			expectRegionsNone: false,
+		},
+		{
+			title:       "us-east-15 region filter, not all regions, should error",
+			region:       "us-east-15",
+			allRegions:   false,
+			errExpected:  true,
+			expectRegionsMoreThanOne: false,
+			expectRegionsOnlyOne: false,
+			expectRegionsNone: true,
+		},
+		{
+			title:       "us-east-15 region filter, return all regions, should return all regions",
+			region:       "us-east-15",
+			allRegions:   true,
+			errExpected:  false,
+			expectRegionsMoreThanOne: true,
+			expectRegionsOnlyOne: false,
+			expectRegionsNone: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			regions, err := GetSupportedRegions(tc.region, tc.allRegions)
+			if tc.errExpected {
+				g.Expect(err).Should(HaveOccurred())
+				if tc.errContent != "" {
+					g.Expect(true).Should(Equal(strings.Contains(err.Error(), tc.errContent)))
+				}
+			} else {
+				g.Expect(err).ShouldNot(HaveOccurred())
+			}
+
+			g.Expect(tc.expectRegionsMoreThanOne == (len(regions) > 1)).To(BeTrue(), "Should return more than one region")
+			g.Expect(tc.expectRegionsOnlyOne == (len(regions) == 1)).To(BeTrue(), "Should return exactly one region")
+			g.Expect(tc.expectRegionsNone == (len(regions) == 0)).To(BeTrue(), "Should return no regions")
+		})
+	}
+}

--- a/cmd/account/servicequotas/describe.go
+++ b/cmd/account/servicequotas/describe.go
@@ -66,23 +66,20 @@ func newDescribeOptions(streams genericclioptions.IOStreams, flags *genericcliop
 }
 
 func (o *describeOptions) complete(cmd *cobra.Command) error {
-	k8svalid, err1 := o.k8sclusterresourcefactory.ValidateIdentifiers()
-	if !k8svalid {
-		if err1 != nil {
-			return err1
+	if valid, err := o.k8sclusterresourcefactory.ValidateIdentifiers(); !valid {
+		if err != nil {
+			return err
 		}
 	}
 
-	awsvalid, err2 := o.k8sclusterresourcefactory.Awscloudfactory.ValidateIdentifiers()
-	if !awsvalid {
-		if err2 != nil {
-			return err2
+	if valid, err := o.k8sclusterresourcefactory.Awscloudfactory.ValidateIdentifiers(); !valid {
+		if err != nil {
+			return err
 		}
 	}
 
-	_, err3 := GetSupportedRegions(o.k8sclusterresourcefactory.Awscloudfactory.Region, o.allRegions)
-	if err3 != nil {
-		return err3
+	if _, err := GetSupportedRegions(o.k8sclusterresourcefactory.Awscloudfactory.Region, o.allRegions); err != nil {
+		return err
 	}
 
 	return nil
@@ -95,7 +92,9 @@ func (o *describeOptions) run() error {
 	}
 
 	for _, region := range regions {
-		o.runOnceByRegion(region)
+		if err := o.runOnceByRegion(region); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/account/servicequotas/describe.go
+++ b/cmd/account/servicequotas/describe.go
@@ -50,7 +50,7 @@ type describeOptions struct {
 	queryServiceCode string
 	queryQuotaCode   string
 
-	verbose bool
+	verbose    bool
 	allRegions bool
 
 	genericclioptions.IOStreams
@@ -81,7 +81,7 @@ func (o *describeOptions) complete(cmd *cobra.Command) error {
 	}
 
 	_, err3 := GetSupportedRegions(o.k8sclusterresourcefactory.Awscloudfactory.Region, o.allRegions)
-	if (err3 != nil) {
+	if err3 != nil {
 		return err3
 	}
 
@@ -90,7 +90,7 @@ func (o *describeOptions) complete(cmd *cobra.Command) error {
 
 func (o *describeOptions) run() error {
 	regions, error := GetSupportedRegions(o.k8sclusterresourcefactory.Awscloudfactory.Region, o.allRegions)
-	if (error != nil) {
+	if error != nil {
 		return error
 	}
 

--- a/cmd/account/servicequotas/update.go
+++ b/cmd/account/servicequotas/update.go
@@ -67,23 +67,20 @@ func newUpdateOptions(streams genericclioptions.IOStreams, flags *genericcliopti
 }
 
 func (o *updateOptions) complete(cmd *cobra.Command) error {
-	k8svalid, err1 := o.k8sclusterresourcefactory.ValidateIdentifiers()
-	if !k8svalid {
-		if err1 != nil {
-			return err1
+	if valid, err := o.k8sclusterresourcefactory.ValidateIdentifiers(); !valid {
+		if err != nil {
+			return err
 		}
 	}
 
-	awsvalid, err2 := o.k8sclusterresourcefactory.Awscloudfactory.ValidateIdentifiers()
-	if !awsvalid {
-		if err2 != nil {
-			return err2
+	if valid, err := o.k8sclusterresourcefactory.Awscloudfactory.ValidateIdentifiers(); !valid {
+		if err != nil {
+			return err
 		}
 	}
 
-	_, err3 := GetSupportedRegions(o.k8sclusterresourcefactory.Awscloudfactory.Region, o.allRegions)
-	if err3 != nil {
-		return err3
+	if _, err := GetSupportedRegions(o.k8sclusterresourcefactory.Awscloudfactory.Region, o.allRegions); err != nil {
+		return err
 	}
 
 	return nil
@@ -96,7 +93,9 @@ func (o *updateOptions) run() error {
 	}
 
 	for _, region := range regions {
-		o.runOnceByRegion(region)
+		if err := o.runOnceByRegion(region); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/account/servicequotas/update.go
+++ b/cmd/account/servicequotas/update.go
@@ -51,7 +51,7 @@ type updateOptions struct {
 	queryQuotaCode   string
 	desiredValue     float64
 
-	verbose bool
+	verbose    bool
 	allRegions bool
 
 	genericclioptions.IOStreams
@@ -82,7 +82,7 @@ func (o *updateOptions) complete(cmd *cobra.Command) error {
 	}
 
 	_, err3 := GetSupportedRegions(o.k8sclusterresourcefactory.Awscloudfactory.Region, o.allRegions)
-	if (err3 != nil) {
+	if err3 != nil {
 		return err3
 	}
 
@@ -91,7 +91,7 @@ func (o *updateOptions) complete(cmd *cobra.Command) error {
 
 func (o *updateOptions) run() error {
 	regions, error := GetSupportedRegions(o.k8sclusterresourcefactory.Awscloudfactory.Region, o.allRegions)
-	if (error != nil) {
+	if error != nil {
 		return error
 	}
 

--- a/docs/command/osdctl_account_servicequotas_describe.md
+++ b/docs/command/osdctl_account_servicequotas_describe.md
@@ -16,6 +16,7 @@ osdctl account servicequotas describe [flags]
   -i, --account-id string          The AWS account ID we need to create AWS credentials for -- This argument will not work for CCS accounts
   -a, --account-name string        The AWS account CR we need to create a temporary AWS console URL for
       --account-namespace string   The namespace to keep AWS accounts. The default value is aws-account-operator. (default "aws-account-operator")
+      --all-regions                Loop through all supported regions
   -c, --aws-config string          specify AWS config file path
   -p, --aws-profile string         specify AWS profile
   -r, --aws-region string          specify AWS region (default "us-east-1")

--- a/pkg/k8s/clusterresourcefactory.go
+++ b/pkg/k8s/clusterresourcefactory.go
@@ -188,7 +188,7 @@ func (factory *ClusterResourceFactoryOptions) GetCloudProvider(verbose bool) (aw
 		AccessKeyID:     *factory.Awscloudfactory.Credentials.AccessKeyId,
 		SecretAccessKey: *factory.Awscloudfactory.Credentials.SecretAccessKey,
 		SessionToken:    *factory.Awscloudfactory.Credentials.SessionToken,
-		Region:          "us-east-1",
+		Region:          factory.Awscloudfactory.Region,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Allow use of --all-regions to loop through supported regions and apply servicequota commands in sequence