### PR TITLE
[OSD-7214] Added account recycle functionality to osdctl command

### DIFF
--- a/cmd/account/reset.go
+++ b/cmd/account/reset.go
@@ -39,8 +39,7 @@ func newCmdReset(streams genericclioptions.IOStreams, flags *genericclioptions.C
 	resetCmd.Flags().BoolVarP(&ops.skipCheck, "skip-check", "y", false,
 		"Skip the prompt check")
 	resetCmd.Flags().BoolVar(&ops.resetLegalEntity, "reset-legalentity", false,
-		`Provides a way to recycle accounts, so that they can be used by other legal entities.
-		This will wipe the legalEntity, claimLink and reused fields.`)
+		`This will wipe the legalEntity, claimLink and reused fields, allowing accounts to be used for different Legal Entities.`)
 
 	// mark this flag hidden because it is not recommended to use
 	_ = resetCmd.Flags().MarkHidden("skip-check")

--- a/cmd/account/reset.go
+++ b/cmd/account/reset.go
@@ -16,6 +16,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/openshift/osdctl/cmd/common"
 	"github.com/openshift/osdctl/pkg/k8s"
 )
@@ -37,6 +38,9 @@ func newCmdReset(streams genericclioptions.IOStreams, flags *genericclioptions.C
 		"The namespace to keep AWS accounts. The default value is aws-account-operator.")
 	resetCmd.Flags().BoolVarP(&ops.skipCheck, "skip-check", "y", false,
 		"Skip the prompt check")
+	resetCmd.Flags().BoolVar(&ops.resetLegalEntity, "reset-legalentity ", false,
+		`Provides a way to recycle accounts, so that they can be used by other legal entities.
+		This will wipe the legalEntity, claimLink and reused fields.`)
 
 	// mark this flag hidden because it is not recommended to use
 	_ = resetCmd.Flags().MarkHidden("skip-check")
@@ -49,7 +53,8 @@ type resetOptions struct {
 	accountName      string
 	accountNamespace string
 
-	skipCheck bool
+	skipCheck        bool
+	resetLegalEntity bool
 
 	flags *genericclioptions.ConfigFlags
 	genericclioptions.IOStreams
@@ -120,6 +125,7 @@ func (o *resetOptions) run() error {
 	account.Spec.ClaimLink = ""
 	account.Spec.ClaimLinkNamespace = ""
 	account.Spec.IAMUserSecret = ""
+	account.Spec.LegalEntity = v1alpha1.LegalEntity{}
 	if err := o.kubeCli.Update(ctx, account, &client.UpdateOptions{}); err != nil {
 		return err
 	}
@@ -132,6 +138,7 @@ func (o *resetOptions) run() error {
 			"rotateConsoleCredentials": false,
 			"claimed":                  false,
 			"state":                    "",
+			"reused":                   false,
 		},
 	})
 

--- a/docs/command/osdctl_account_reset.md
+++ b/docs/command/osdctl_account_reset.md
@@ -14,6 +14,7 @@ osdctl account reset <account name> [flags]
 
 ```
       --account-namespace string   The namespace to keep AWS accounts. The default value is aws-account-operator. (default "aws-account-operator")
+      --reset-legalentity bool     Provides a way to recycle accounts, so that they can be used by other legal entities. This will wipe the legalEntity, claimLink and reused fields.
   -h, --help                       help for reset
 ```
 

--- a/docs/command/osdctl_account_reset.md
+++ b/docs/command/osdctl_account_reset.md
@@ -14,8 +14,8 @@ osdctl account reset <account name> [flags]
 
 ```
       --account-namespace string   The namespace to keep AWS accounts. The default value is aws-account-operator. (default "aws-account-operator")
-      --reset-legalentity bool     Provides a way to recycle accounts, so that they can be used by other legal entities. This will wipe the legalEntity, claimLink and reused fields.
   -h, --help                       help for reset
+      --reset-legalentity          This will wipe the legalEntity, claimLink and reused fields, allowing accounts to be used for different Legal Entities.
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
[OSD-7214](https://issues.redhat.com/browse/OSD-7214)
- Added new flag to account reset to reset Legal Entity ID as well (allows for account reuse for other legal entities)
- [Updated SOP documentation](https://github.com/openshift/ops-sop/pull/1320)