### PR TITLE
Adds goReleaser for release creation and binary builds

### DIFF
--- a/.github/workflows/validate_goreleaser.yml
+++ b/.github/workflows/validate_goreleaser.yml
@@ -1,0 +1,33 @@
+# Validate the goReleaser configuration
+
+name: validate_goreleaser
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  validate_goreleaser:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v2.1.3
+        with:
+          go-version: 1.15.2
+
+      - name: Download GoReleaser
+        run: |
+          curl -sSLf https://github.com/goreleaser/goreleaser/releases/latest/download/goreleaser_Linux_x86_64.tar.gz -o - | tar --extract --gunzip --directory /usr/local/bin goreleaser
+      - name: Check goreleaser validity
+        run: |
+          goreleaser check

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ bin/
 
 # MacOS
 .DS_Store
+
+# goReleaser 
+dist/
+bin/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,48 @@
+# This is an example .goreleaser.yml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+env_files:
+  github_token: ~/.config/goreleaser/token
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    # - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+    ldflags:
+      - -s -w -X 'github.com/openshift/osdctl/cmd.GitCommit={{.ShortCommit}}'
+
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      amd64: x86_64
+
+checksum:
+  name_template: 'sha256sum.txt'
+  algorithm: sha256
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+release:
+  github:
+    owner: "openshift"
+    name: "osdctl"
+  prerelease: auto

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14
 
 WORKDIR /src
 COPY . .
-RUN make build
+RUN make ci-build
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 LABEL io.openshift.managed.name="osdctl" \
       io.openshift.managed.description="OSD related command line utilities"
 
-COPY --from=0 /src/bin/osdctl /bin/osdctl
+COPY --from=0 /src/dist/osdctl_linux_amd64/osdctl /bin/osdctl
 
 ENTRYPOINT ["bin/osdctl"]


### PR DESCRIPTION
Adds [goReleaser](https://goreleaser.com/) support for creating binary builds and releases in a standardized way.

Maintainers need to install the goReleaser binary, and then generate a Github  token with the `repo` scope and save it in `~/.config/goreleaser/token`.  

Then builds can be created by running `make build`, and a release can be created from the most recent tag by running `make release`.

Binaries will be built, a release created in Github, and the binaries added to a *.tar.gz file with any README.md and LICENSE files.

An sha256sum.txt file is generated for each of the artifacts, and added to the release.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
