### PR TITLE
Add dry-run ability to servicelog posting

### DIFF
--- a/docs/command/osdctl_servicelog_post.md
+++ b/docs/command/osdctl_servicelog_post.md
@@ -13,6 +13,7 @@ osdctl servicelog post [flags]
 ### Options
 
 ```
+  -d, --dry-run             Dry-run - print the service log about to be sent but don't send it.
   -h, --help                help for post
   -p, --param stringArray   Specify a key-value pair (eg. -p FOO=BAR) to set/override a parameter value in the template.
   -t, --template string     Message template file or URL


### PR DESCRIPTION
This PR adds a `--dry-run` parameter to `osdctl servicelog post` that prints the contents of the servicelog that would be posted, without actually posting it. 

With some templates featuring multiple parameters comprising a sentence, I've found a dry-run desirable in order to be able to re-read a servicelog before I actually post it to ensure it makes grammatical sense.