### PR TITLE
Fixes goReleaser check Github Action

### DIFF
--- a/.github/workflows/validate_goreleaser.yml
+++ b/.github/workflows/validate_goreleaser.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Download GoReleaser
         run: |
-          curl -sSLf https://github.com/goreleaser/goreleaser/releases/latest/download/goreleaser_Linux_x86_64.tar.gz -o - | tar --extract --gunzip --directory /usr/local/bin goreleaser
+          mkdir ./bin && curl -sSLf https://github.com/goreleaser/goreleaser/releases/latest/download/goreleaser_Linux_x86_64.tar.gz -o - | tar --extract --gunzip --directory ./bin goreleaser
       - name: Check goreleaser validity
         run: |
-          goreleaser check
+          ./bin/goreleaser check


### PR DESCRIPTION
This fixes the permission denied error when attempting to download
goReleaser in the validate-goreleaser Github Action.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
