### PR TITLE
Fix error message for failure to assume BYOCAdminAccess role

### DIFF
--- a/cmd/account/cli.go
+++ b/cmd/account/cli.go
@@ -89,7 +89,7 @@ func (o *cliOptions) run() error {
 				o.k8sclusterresourcefactory.AccountID,
 				o.k8sclusterresourcefactory.Awscloudfactory.RoleName)))
 		if err != nil {
-			klog.Error("Failed to get jump-role creds for CCS")
+			klog.Error("Failed to assume BYOC role. Customer either deleted role or denied SREP access")
 			return err
 		}
 	}


### PR DESCRIPTION
If assuming the BYOCAdminAccess role fails, its due to the customer removing our access. Fixed the error message in this case to make it more clear