### PR TITLE
Add error message for failure to generate console

### DIFF
--- a/cmd/account/console.go
+++ b/cmd/account/console.go
@@ -83,6 +83,7 @@ func (o *consoleOptions) run() error {
 		aws.String(o.k8sclusterresourcefactory.Awscloudfactory.SessionName), aws.String(fmt.Sprintf("arn:aws:iam::%s:role/%s",
 			o.k8sclusterresourcefactory.AccountID, o.k8sclusterresourcefactory.Awscloudfactory.RoleName)))
 	if err != nil {
+		fmt.Fprintf(o.IOStreams.Out, "Generating console failed. If CCS cluster, customer removed or denied access to the BYOC role.")
 		return err
 	}
 	fmt.Fprintf(o.IOStreams.Out, "The AWS Console URL is:\n%s\n", consoleURL)


### PR DESCRIPTION
Generating a console doesn't print a friendly error. Adding one to help with debugging. 