### PR TITLE
Adds release version to output of `osdctl --version`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,7 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - -s -w -X 'github.com/openshift/osdctl/cmd.GitCommit={{.ShortCommit}}'
+      - -s -w -X github.com/openshift/osdctl/cmd.GitCommit={{.ShortCommit}} -X github.com/openshift/osdctl/cmd.Version={{.Version}}
 
 archives:
   - replacements:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -25,6 +26,9 @@ import (
 // GitCommit is the short git commit hash from the environment
 var GitCommit string
 
+// Version is the tag version from the environment
+var Version string
+
 func init() {
 	_ = awsv1alpha1.AddToScheme(scheme.Scheme)
 	_ = routev1.AddToScheme(scheme.Scheme)
@@ -36,7 +40,7 @@ func init() {
 func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:               "osdctl",
-		Version:           GitCommit,
+		Version:           fmt.Sprintf("%s, GitCommit: %s", Version, GitCommit),
 		Short:             "OSD CLI",
 		Long:              `CLI tool to provide OSD related utilities`,
 		DisableAutoGenTag: true,


### PR DESCRIPTION
This adds the release version (ie. git tag for the current release) to
the version string output from the `osdctl --version` tag, to make
version identification more human friendly.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>
