### PR TITLE
Adds support for STS clusters

### DIFF
--- a/cmd/account/cli.go
+++ b/cmd/account/cli.go
@@ -2,7 +2,6 @@ package account
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/spf13/cobra"
@@ -82,7 +81,7 @@ func (o *cliOptions) run() error {
 
 	creds := o.k8sclusterresourcefactory.Awscloudfactory.Credentials
 
-	if strings.Contains(o.k8sclusterresourcefactory.Awscloudfactory.RoleName, "BYOC") {
+	if o.k8sclusterresourcefactory.Awscloudfactory.RoleName != "OrganizationAccountAccessRole" {
 		creds, err = awsprovider.GetAssumeRoleCredentials(awsClient,
 			&o.k8sclusterresourcefactory.Awscloudfactory.ConsoleDuration, aws.String(o.k8sclusterresourcefactory.Awscloudfactory.SessionName),
 			aws.String(fmt.Sprintf("arn:aws:iam::%s:role/%s",
@@ -103,7 +102,7 @@ func (o *cliOptions) run() error {
 	}
 
 	if o.output == "env" {
-		fmt.Fprintf(o.IOStreams.Out, "AWS_ACCESS_KEY_ID=%s\nAWS_SECRET_ACCESS_KEY=%s\nAWS_SESSION_TOKEN=%s\nAWS_DEFAULT_REGION=%s\n",
+		fmt.Fprintf(o.IOStreams.Out, "AWS_ACCESS_KEY_ID=%s \\\nAWS_SECRET_ACCESS_KEY=%s \\\nAWS_SESSION_TOKEN=%s \\\nAWS_DEFAULT_REGION=%s\n",
 			*creds.AccessKeyId,
 			*creds.SecretAccessKey,
 			*creds.SessionToken,

--- a/cmd/account/servicequotas/common.go
+++ b/cmd/account/servicequotas/common.go
@@ -2,14 +2,61 @@ package servicequotas
 
 import (
 	"errors"
-
-	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 )
+
+var coveredRegions = map[string]map[string]string{
+	"us-east-1": {
+		"initializationAMI": "ami-000db10762d0c4c05",
+	},
+	"us-east-2": {
+		"initializationAMI": "ami-094720ddca649952f",
+	},
+	"us-west-1": {
+		"initializationAMI": "ami-04642fc8fca1e8e67",
+	},
+	"us-west-2": {
+		"initializationAMI": "ami-0a7e1ebfee7a4570e",
+	},
+	"ca-central-1": {
+		"initializationAMI": "ami-06ca3c0058d0275b3",
+	},
+	"eu-central-1": {
+		"initializationAMI": "ami-09de4a4c670389e4b",
+	},
+	"eu-west-1": {
+		"initializationAMI": "ami-0202869bdd0fc8c75",
+	},
+	"eu-west-2": {
+		"initializationAMI": "ami-0188c0c5eddd2d032",
+	},
+	"eu-west-3": {
+		"initializationAMI": "ami-0c4224e392ec4e440",
+	},
+	"ap-northeast-1": {
+		"initializationAMI": "ami-00b95502a4d51a07e",
+	},
+	"ap-northeast-2": {
+		"initializationAMI": "ami-041b16ca28f036753",
+	},
+	"ap-south-1": {
+		"initializationAMI": "ami-0963937a03c01ecd4",
+	},
+	"ap-southeast-1": {
+		"initializationAMI": "ami-055c55112e25b1f1f",
+	},
+	"ap-southeast-2": {
+		"initializationAMI": "ami-036b423b657376f5b",
+	},
+	"sa-east-1": {
+		"initializationAMI": "ami-05c1c16cac05a7c0b",
+	},
+}
 
 // GetSupportedRegions returns a []string of all supported regions if found and an error. Filtering for a single region is also supported.
 func GetSupportedRegions(filter string, allRegions bool) ([]string, error) {
 	var results []string
-	for i := range awsv1alpha1.CoveredRegions {
+
+	for i := range coveredRegions {
 		if (filter != "") && !allRegions {
 			if filter == i {
 				results = append(results, i)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/openshift-online/ocm-cli v0.1.47
 	github.com/openshift-online/ocm-sdk-go v0.1.152
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
-	github.com/openshift/aws-account-operator v0.0.0-20200914143350-bbda1c91242b
+	github.com/openshift/aws-account-operator/pkg/apis v0.0.0-20210611151019-01b1df7a3e9e
 	github.com/openshift/hive v1.0.5
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
@@ -24,6 +24,7 @@ require (
 	k8s.io/cli-runtime v0.18.3
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.9.0
 	k8s.io/kubectl v0.18.3
 	k8s.io/utils v0.0.0-20200327001022-6496210b90e8
 	sigs.k8s.io/controller-runtime v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -432,6 +432,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
+github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/zapr v0.1.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-logr/zapr v0.1.1 h1:qXBXPDdNncunGs7XeEpsJt8wCjYBygluzfdLO0G5baE=
 github.com/go-logr/zapr v0.1.1/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
@@ -478,6 +480,8 @@ github.com/go-openapi/spec v0.18.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsd
 github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcsZsD5zxMY=
 github.com/go-openapi/spec v0.19.3 h1:0XRyw8kguri6Yw4SxhsQA/atC88yqrk0+G4YhI2wabc=
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
+github.com/go-openapi/spec v0.19.4 h1:ixzUSnHTd6hCemgtAJgluaTSGYpLNpJY4mA2DIkdOAo=
+github.com/go-openapi/spec v0.19.4/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.19.0/go.mod h1:+uW+93UVvGGq2qGaZxdDeJqSAqBqBdl+ZPMF/cC8nDY=
@@ -1564,6 +1568,11 @@ github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible h1:Av
 github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/aws-account-operator v0.0.0-20200914143350-bbda1c91242b h1:TS/IiLLrBjpqKeBZ4Yps6/UiAAIimyk5BGj29QaAGCI=
 github.com/openshift/aws-account-operator v0.0.0-20200914143350-bbda1c91242b/go.mod h1:3JOgGxqzrQEGoJhGIIwrfHG6c0OjUhPuxVi0/KV14zQ=
+github.com/openshift/aws-account-operator v0.0.0-20210603171020-10022be2ec32 h1:Z5aSzLO9LSG9mFtschaV8OXleYZnjed3EWDdjdMZEC0=
+github.com/openshift/aws-account-operator/pkg/apis v0.0.0-20210603171020-10022be2ec32 h1:4Cq43+4++7g4kTMcYbnGjPL9ouF8n0B9f13jGXSc+Bk=
+github.com/openshift/aws-account-operator/pkg/apis v0.0.0-20210603171020-10022be2ec32/go.mod h1:cLnYI1elYBw8yiSJMkJtYP7CWnG8N3yB26XM3SnDYtA=
+github.com/openshift/aws-account-operator/pkg/apis v0.0.0-20210611151019-01b1df7a3e9e h1:J/+IaMQmJ4l3ubBo7Gb2BfBnMyWlSuoYwaLnoNBUHGk=
+github.com/openshift/aws-account-operator/pkg/apis v0.0.0-20210611151019-01b1df7a3e9e/go.mod h1:cLnYI1elYBw8yiSJMkJtYP7CWnG8N3yB26XM3SnDYtA=
 github.com/openshift/baremetal-operator v0.0.0-20200206190020-71b826cc0f0a/go.mod h1:cXwn0hhgHpORjBasg0RnZwhKaJGy9+r6qgj0HCXrs/Y=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
@@ -2543,6 +2552,7 @@ k8s.io/api v0.0.0-20190918155943-95b840bb6a1f/go.mod h1:uWuOHnjmNrtQomJrvEBg0c0H
 k8s.io/api v0.0.0-20190918195907-bd6ac527cfd2/go.mod h1:AOxZTnaXR/xiarlQL0JUfwQPxjmKDvVYoRp58cA7lUo=
 k8s.io/api v0.0.0-20191003000013-35e20aa79eb8/go.mod h1:uWuOHnjmNrtQomJrvEBg0c0HRNyQ+8KTEERVsK0PW48=
 k8s.io/api v0.0.0-20191121015604-11707872ac1c/go.mod h1:R/s4gKT0V/cWEnbQa9taNRJNbWUK57/Dx6cPj6MD3A0=
+k8s.io/api v0.15.7/go.mod h1:a/tUxscL+UxvYyA7Tj5DRc8ivYqJIO1Y5KDdlI6wSvo=
 k8s.io/api v0.17.0/go.mod h1:npsyOePkeP0CPwyGfXDHxvypiYMJxBWAMpQxCaJ4ZxI=
 k8s.io/api v0.18.0-beta.2/go.mod h1:2oeNnWEqcSmaM/ibSh3t7xcIqbkGXhzZdn4ezV9T4m0=
 k8s.io/api v0.18.0-rc.1/go.mod h1:ZOh6SbHjOYyaMLlWmB2+UOQKEWDpCnVEVpEyt7S2J9s=
@@ -2565,6 +2575,7 @@ k8s.io/apimachinery v0.0.0-20190409092423-760d1845f48b/go.mod h1:FW86P8YXVLsbupl
 k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d/go.mod h1:3jediapYqJ2w1BFw7lAZPCx7scubsTfosqHkhXCWJKw=
 k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655/go.mod h1:nL6pwRT8NgfF8TT68DBI8uEePRt89cSvoXUVqbkWHq4=
 k8s.io/apimachinery v0.0.0-20191121015412-41065c7a8c2a/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
+k8s.io/apimachinery v0.15.7/go.mod h1:Xc10RHc1U+F/e9GCloJ8QAeCGevSVP5xhOhqlE+e1kM=
 k8s.io/apimachinery v0.17.0/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apimachinery v0.18.0-beta.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
 k8s.io/apimachinery v0.18.0-rc.1/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
@@ -2621,6 +2632,8 @@ k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+k8s.io/klog/v2 v2.9.0 h1:D7HV+n1V57XeZ0m6tdRkfknthUaM06VFbWldOFh8kzM=
+k8s.io/klog/v2 v2.9.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/kube-aggregator v0.0.0-20190404125450-f5e124c822d6/go.mod h1:8sbzT4QQKDEmSCIbfqjV0sd97GpUT7A4W626sBiYJmU=
 k8s.io/kube-aggregator v0.18.0-beta.2/go.mod h1:O3Td9mheraINbLHH4pzoFP2gRzG0Wk1COqzdSL4rBPk=
 k8s.io/kube-aggregator v0.18.0-rc.1/go.mod h1:35N7x/aAF8C5rEU78J+3pJ/k9v/8LypeWbzqBAEWA1I=
@@ -2628,6 +2641,7 @@ k8s.io/kube-aggregator v0.18.2/go.mod h1:ijq6FnNUoKinA6kKbkN6svdTacSoQVNtKqmQ1+X
 k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
+k8s.io/kube-openapi v0.0.0-20190918143330-0270cf2f1c1d/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 h1:Oh3Mzx5pJ+yIumsAD0MOECPVeXsVot0UkiaCGVyfGQY=


### PR DESCRIPTION
This adds `osdctl` support for generating console URLs and CLI credentials for STS-based clusters.

Fulfills [OSD-6757](https://issues.redhat.com/browse/OSD-6757)