### PR TITLE
Add assign account cmd

### DIFF
--- a/cmd/account/account-assign.go
+++ b/cmd/account/account-assign.go
@@ -1,0 +1,154 @@
+package account
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/openshift/osdctl/pkg/k8s"
+	"github.com/openshift/osdctl/pkg/printer"
+	awsprovider "github.com/openshift/osdctl/pkg/provider/aws"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Global variables
+var (
+	OSDStaging2RootID = "r-rs3h"
+	OSDStaging2OuID   = "ou-rs3h-i0v69q47"
+	OSDStaging1RootID = "r-0wd6"
+	OSDStaging1OuID   = "ou-0wd6-z6tzkjek"
+)
+
+type accountAssignOptions struct {
+	username     string
+	payerAccount string
+	output       string
+
+	flags      *genericclioptions.ConfigFlags
+	printFlags *printer.PrintFlags
+	genericclioptions.IOStreams
+	kubeCli client.Client
+}
+
+func newAccountAssignOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *accountAssignOptions {
+	return &accountAssignOptions{
+		flags:      flags,
+		printFlags: printer.NewPrintFlags(),
+		IOStreams:  streams,
+	}
+}
+
+// assignCmd assigns an aws account to user under osd-staging-2 by default unless osd-staging-1 is specified
+func newCmdAccountAssign(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	ops := newAccountAssignOptions(streams, flags)
+	accountAssignCmd := &cobra.Command{
+		Use:               "assign",
+		Short:             "Assign account to user",
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd, args))
+			cmdutil.CheckErr(ops.run())
+		},
+	}
+	ops.printFlags.AddFlags(accountAssignCmd)
+	accountAssignCmd.Flags().StringVarP(&ops.output, "output", "o", "", "Output format. One of: json|yaml|jsonpath=...|jsonpath-file=... see jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].")
+	accountAssignCmd.Flags().StringVarP(&ops.payerAccount, "payer-account", "p", "", "Payer account type")
+	accountAssignCmd.Flags().StringVarP(&ops.username, "username", "u", "", "LDAP username")
+
+	return accountAssignCmd
+}
+
+func (o *accountAssignOptions) complete(cmd *cobra.Command, _ []string) error {
+	if o.username == "" {
+		return cmdutil.UsageErrorf(cmd, "LDAP username was not provided")
+	}
+	if o.payerAccount == "" {
+		return cmdutil.UsageErrorf(cmd, "Payer account was not provided")
+	}
+
+	var err error
+	o.kubeCli, err = k8s.NewClient(o.flags)
+	if err != nil {
+		fmt.Println(err.Error())
+		return err
+	}
+
+	return nil
+}
+
+func (o *accountAssignOptions) run() error {
+
+	var (
+		accountAssignID string
+		destinationOU   string
+		rootID          string
+	)
+
+	rootID = OSDStaging2RootID
+	destinationOU = OSDStaging2OuID
+	if o.username != "" && o.payerAccount == "osd-staging-1" {
+		rootID = OSDStaging1RootID
+		destinationOU = OSDStaging1OuID
+	}
+	//Instantiate aws client
+	awsClient, err := awsprovider.NewAwsClient(o.payerAccount, "us-east-1", "")
+	if err != nil {
+		fmt.Println(err.Error())
+		return err
+	}
+	//List accounts that are not in any OU
+	input := &organizations.ListAccountsInput{}
+	accounts, err := awsClient.ListAccounts(input)
+	if err != nil {
+		fmt.Println(err.Error())
+		return err
+	}
+	if len(accounts.Accounts) == 0 {
+		return fmt.Errorf("no accounts available to assign")
+	}
+
+	//Get one account and tag it
+	a := accounts.Accounts[0]
+	accountAssignID = *a.Id
+	//Create input for tagging
+	inputTag := &organizations.TagResourceInput{
+		ResourceId: aws.String(accountAssignID),
+		Tags: []*organizations.Tag{
+			{
+				Key:   aws.String("owner"),
+				Value: aws.String(o.username),
+			},
+			{
+				Key:   aws.String("claimed"),
+				Value: aws.String("true"),
+			},
+		},
+	}
+
+	_, err = awsClient.TagResource(inputTag)
+	if err != nil {
+		fmt.Println(err.Error())
+		return err
+	}
+	// Move account to developers OU
+	inputMove := &organizations.MoveAccountInput{
+		AccountId:           aws.String(accountAssignID),
+		DestinationParentId: aws.String(destinationOU),
+		SourceParentId:      aws.String(rootID),
+	}
+
+	_, err = awsClient.MoveAccount(inputMove)
+	if err != nil {
+		fmt.Println(err.Error())
+		return err
+	}
+
+	if o.output == "" {
+		fmt.Fprintln(o.IOStreams.Out, accountAssignID)
+	}
+
+	return nil
+}

--- a/cmd/account/cmd.go
+++ b/cmd/account/cmd.go
@@ -30,6 +30,7 @@ func NewCmdAccount(streams genericclioptions.IOStreams, flags *genericclioptions
 	accountCmd.AddCommand(newCmdVerifySecrets(streams, flags))
 	accountCmd.AddCommand(newCmdRotateSecret(streams, flags))
 	accountCmd.AddCommand(newCmdGenerateSecret(streams, flags))
+	accountCmd.AddCommand(newCmdAccountAssign(streams, flags))
 
 	return accountCmd
 }

--- a/go.mod
+++ b/go.mod
@@ -5,21 +5,27 @@ go 1.14
 require (
 	github.com/aws/aws-sdk-go v1.31.10
 	github.com/deckarep/golang-set v1.7.1
+	github.com/emicklei/go-restful v2.11.2+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
-	github.com/golang/mock v1.5.0
+	github.com/golang/mock v1.4.4
 	github.com/onsi/gomega v1.10.1
 	github.com/openshift-online/ocm-cli v0.1.47
 	github.com/openshift-online/ocm-sdk-go v0.1.152
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/aws-account-operator/pkg/apis v0.0.0-20210611151019-01b1df7a3e9e
-	github.com/openshift/gcp-project-operator v0.0.0-20210616141757-9e53b15c72e4
 	github.com/openshift/hive v1.0.5
+	github.com/operator-framework/operator-sdk v0.17.1 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/common v0.11.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.6.1 // indirect
+	golang.org/x/tools v0.1.0 // indirect
+	google.golang.org/api v0.25.0 // indirect
+	google.golang.org/genproto v0.0.0-20200527145253-8367513e4ece // indirect
+	google.golang.org/grpc v1.29.1 // indirect
 	k8s.io/api v0.18.5
 	k8s.io/apimachinery v0.18.5
 	k8s.io/cli-runtime v0.18.3

--- a/go.sum
+++ b/go.sum
@@ -1048,6 +1048,8 @@ github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
+github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -5,11 +5,12 @@ package aws
 
 import (
 	"fmt"
+	"path/filepath"
+
 	"github.com/aws/aws-sdk-go/service/costexplorer"
 	"github.com/aws/aws-sdk-go/service/costexplorer/costexploreriface"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/aws/aws-sdk-go/service/organizations/organizationsiface"
-	"path/filepath"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -67,9 +68,12 @@ type Client interface {
 	RequestServiceQuotaIncrease(*servicequotas.RequestServiceQuotaIncreaseInput) (*servicequotas.RequestServiceQuotaIncreaseOutput, error)
 
 	// Organizations
+	ListAccounts(input *organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error)
 	ListAccountsForParent(input *organizations.ListAccountsForParentInput) (*organizations.ListAccountsForParentOutput, error)
 	ListOrganizationalUnitsForParent(input *organizations.ListOrganizationalUnitsForParentInput) (*organizations.ListOrganizationalUnitsForParentOutput, error)
+	MoveAccount(input *organizations.MoveAccountInput) (*organizations.MoveAccountOutput, error)
 	DescribeOrganizationalUnit(input *organizations.DescribeOrganizationalUnitInput) (*organizations.DescribeOrganizationalUnitOutput, error)
+	TagResource(input *organizations.TagResourceInput) (*organizations.TagResourceOutput, error)
 
 	// Cost Explorer
 	GetCostAndUsage(input *costexplorer.GetCostAndUsageInput) (*costexplorer.GetCostAndUsageOutput, error)
@@ -225,8 +229,16 @@ func (c *AwsClient) ListAttachedRolePolicies(input *iam.ListAttachedRolePolicies
 	return c.iamClient.ListAttachedRolePolicies(input)
 }
 
+func (c *AwsClient) ListAccounts(input *organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error) {
+	return c.orgClient.ListAccounts(input)
+}
+
 func (c *AwsClient) ListAccountsForParent(input *organizations.ListAccountsForParentInput) (*organizations.ListAccountsForParentOutput, error) {
 	return c.orgClient.ListAccountsForParent(input)
+}
+
+func (c *AwsClient) MoveAccount(input *organizations.MoveAccountInput) (*organizations.MoveAccountOutput, error) {
+	return c.orgClient.MoveAccount(input)
 }
 
 func (c *AwsClient) ListServiceQuotas(input *servicequotas.ListServiceQuotasInput) (*servicequotas.ListServiceQuotasOutput, error) {
@@ -243,6 +255,10 @@ func (c *AwsClient) ListOrganizationalUnitsForParent(input *organizations.ListOr
 
 func (c *AwsClient) DescribeOrganizationalUnit(input *organizations.DescribeOrganizationalUnitInput) (*organizations.DescribeOrganizationalUnitOutput, error) {
 	return c.orgClient.DescribeOrganizationalUnit(input)
+}
+
+func (c *AwsClient) TagResource(input *organizations.TagResourceInput) (*organizations.TagResourceOutput, error) {
+	return c.orgClient.TagResource(input)
 }
 
 func (c *AwsClient) GetCostAndUsage(input *costexplorer.GetCostAndUsageInput) (*costexplorer.GetCostAndUsageOutput, error) {

--- a/pkg/provider/aws/mock/client.go
+++ b/pkg/provider/aws/mock/client.go
@@ -353,6 +353,21 @@ func (mr *MockClientMockRecorder) RequestServiceQuotaIncrease(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestServiceQuotaIncrease", reflect.TypeOf((*MockClient)(nil).RequestServiceQuotaIncrease), arg0)
 }
 
+// ListAccounts mocks base method
+func (m *MockClient) ListAccounts(input *organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAccounts", input)
+	ret0, _ := ret[0].(*organizations.ListAccountsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAccounts indicates an expected call of ListAccounts
+func (mr *MockClientMockRecorder) ListAccounts(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccounts", reflect.TypeOf((*MockClient)(nil).ListAccounts), input)
+}
+
 // ListAccountsForParent mocks base method
 func (m *MockClient) ListAccountsForParent(input *organizations.ListAccountsForParentInput) (*organizations.ListAccountsForParentOutput, error) {
 	m.ctrl.T.Helper()
@@ -383,6 +398,21 @@ func (mr *MockClientMockRecorder) ListOrganizationalUnitsForParent(input interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOrganizationalUnitsForParent", reflect.TypeOf((*MockClient)(nil).ListOrganizationalUnitsForParent), input)
 }
 
+// MoveAccount mocks base method
+func (m *MockClient) MoveAccount(input *organizations.MoveAccountInput) (*organizations.MoveAccountOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MoveAccount", input)
+	ret0, _ := ret[0].(*organizations.MoveAccountOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MoveAccount indicates an expected call of MoveAccount
+func (mr *MockClientMockRecorder) MoveAccount(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveAccount", reflect.TypeOf((*MockClient)(nil).MoveAccount), input)
+}
+
 // DescribeOrganizationalUnit mocks base method
 func (m *MockClient) DescribeOrganizationalUnit(input *organizations.DescribeOrganizationalUnitInput) (*organizations.DescribeOrganizationalUnitOutput, error) {
 	m.ctrl.T.Helper()
@@ -396,6 +426,21 @@ func (m *MockClient) DescribeOrganizationalUnit(input *organizations.DescribeOrg
 func (mr *MockClientMockRecorder) DescribeOrganizationalUnit(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeOrganizationalUnit", reflect.TypeOf((*MockClient)(nil).DescribeOrganizationalUnit), input)
+}
+
+// TagResource mocks base method
+func (m *MockClient) TagResource(input *organizations.TagResourceInput) (*organizations.TagResourceOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TagResource", input)
+	ret0, _ := ret[0].(*organizations.TagResourceOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TagResource indicates an expected call of TagResource
+func (mr *MockClientMockRecorder) TagResource(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResource", reflect.TypeOf((*MockClient)(nil).TagResource), input)
 }
 
 // GetCostAndUsage mocks base method


### PR DESCRIPTION
This Cmd takes a LDAP username and a payer account type as input. It then goes through the list of accounts in the root and finds an unassigned one, it adds a tag with the username and claimed, and moves it into the developers OU