### PR TITLE
Add list accounts cmd

### DIFF
--- a/cmd/account/account-list.go
+++ b/cmd/account/account-list.go
@@ -160,6 +160,7 @@ func (o *accountListOptions) run() error {
 		if err != nil {
 			return err
 		}
+		
 		for _, t := range val.Tags {
 			if t.Key == aws.String("owner") {
 				fmt.Fprintln(o.IOStreams.Out, *t.Value)

--- a/cmd/account/account-list.go
+++ b/cmd/account/account-list.go
@@ -1,0 +1,177 @@
+package account
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/openshift/osdctl/pkg/k8s"
+	"github.com/openshift/osdctl/pkg/printer"
+	awsprovider "github.com/openshift/osdctl/pkg/provider/aws"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type accountListOptions struct {
+	username     string
+	payerAccount string
+	accountID    string
+	output       string
+
+	flags      *genericclioptions.ConfigFlags
+	printFlags *printer.PrintFlags
+	genericclioptions.IOStreams
+	kubeCli client.Client
+}
+
+func newAccountListOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *accountListOptions {
+	return &accountListOptions{
+		flags:      flags,
+		printFlags: printer.NewPrintFlags(),
+		IOStreams:  streams,
+	}
+}
+
+func newCmdAccountList(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	ops := newAccountListOptions(streams, flags)
+	accountListCmd := &cobra.Command{
+		Use:               "list",
+		Short:             "List out accounts for username",
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd, args))
+			cmdutil.CheckErr(ops.run())
+		},
+	}
+	ops.printFlags.AddFlags(accountListCmd)
+	accountListCmd.Flags().StringVarP(&ops.output, "output", "o", "", "Output format. One of: json|yaml|jsonpath=...|jsonpath-file=... see jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].")
+	accountListCmd.Flags().StringVarP(&ops.username, "user", "u", "", "LDAP username")
+	accountListCmd.Flags().StringVarP(&ops.payerAccount, "payer-account", "p", "", "Payer account type")
+	accountListCmd.Flags().StringVarP(&ops.accountID, "account-id", "i", "", "Account ID")
+
+	return accountListCmd
+}
+
+func (o *accountListOptions) complete(cmd *cobra.Command, _ []string) error {
+	if o.payerAccount == "" {
+		return cmdutil.UsageErrorf(cmd, "Payer account was not provided")
+	}
+	if o.username != "" && o.accountID != "" {
+		return cmdutil.UsageErrorf(cmd, "Cannot provide both username and account ID")
+	}
+	var err error
+	o.kubeCli, err = k8s.NewClient(o.flags)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *accountListOptions) run() error {
+
+	var (
+		tempAccountIDs []string
+		user           string
+		OuID           string
+	)
+	// Instantiate Aws client
+	awsClient, err := awsprovider.NewAwsClient(o.payerAccount, "us-east-1", "")
+	if err != nil {
+		return err
+	}
+
+	if o.payerAccount == "osd-staging-2" {
+		OuID = "ou-rs3h-i0v69q47"
+	} else if o.payerAccount == "osd-staging-1" {
+		OuID = "ou-0wd6-z6tzkjek"
+	}
+
+	input := &organizations.ListAccountsForParentInput{
+		ParentId: &OuID,
+	}
+	accounts, err := awsClient.ListAccountsForParent(input)
+	if err != nil {
+		return err
+	}
+	// Initialize hashmap
+	m := make(map[string][]string)
+
+	if o.username == "" {
+		// Loop through list of accounts and build hashmap of users and accounts
+		for _, a := range accounts.Accounts {
+			inputListTags := &organizations.ListTagsForResourceInput{
+				ResourceId: a.Id,
+			}
+			tagVal, err := awsClient.ListTagsForResource(inputListTags)
+			if err != nil {
+				return err
+			}
+			for _, t := range tagVal.Tags {
+				if t.Key == aws.String("owner") {
+					user = *t.Value
+				}
+			}
+			// Check if user is already in the hashmap
+			// If yes append to list of accounts
+			// If no create list of accounts and add it as value to key
+			_, ok := m[user]
+			if ok {
+				_ = append(m[user], *a.Id)
+			} else {
+				tempAccountIDs = append(tempAccountIDs, *a.Id)
+				m[user] = tempAccountIDs
+			}
+		}
+	} else if o.username != "" {
+		user = o.username
+		// Create input to list the accounts from a specific user
+		inputFilterTag := &resourcegroupstaggingapi.GetResourcesInput{
+			TagFilters: []*resourcegroupstaggingapi.TagFilter{
+				{
+					Key: aws.String("owner"),
+					Values: []*string{
+						aws.String(user),
+					},
+				},
+			},
+		}
+		accounts, err := awsClient.GetResources(inputFilterTag)
+		if err != nil {
+			return err
+		}
+		// Get last 9 digits of ResourceARN and append it to account list
+		for _, a := range accounts.ResourceTagMappingList {
+			tempAccountIDs = append(tempAccountIDs, (*a.ResourceARN)[len(*a.ResourceARN)-9:])
+		}
+		if err != nil {
+			return err
+		}
+		m[user] = tempAccountIDs
+	}
+
+	if o.accountID != "" {
+		input := &organizations.ListTagsForResourceInput{
+			ResourceId: &o.accountID,
+		}
+		val, err := awsClient.ListTagsForResource(input)
+		if err != nil {
+			return err
+		}
+		for _, t := range val.Tags {
+			if t.Key == aws.String("owner") {
+				fmt.Fprintln(o.IOStreams.Out, *t.Value)
+			}
+		}
+	}
+
+	if o.output == "" {
+		for key, value := range m {
+			fmt.Fprintln(o.IOStreams.Out, key, value)
+		}
+	}
+
+	return nil
+}

--- a/cmd/account/account-list.go
+++ b/cmd/account/account-list.go
@@ -142,6 +142,7 @@ func (o *accountListOptions) run() error {
 		if err != nil {
 			return err
 		}
+		
 		// Get last 9 digits of ResourceARN and append it to account list
 		for _, a := range accounts.ResourceTagMappingList {
 			tempAccountIDs = append(tempAccountIDs, (*a.ResourceARN)[len(*a.ResourceARN)-9:])

--- a/cmd/account/cmd.go
+++ b/cmd/account/cmd.go
@@ -30,6 +30,7 @@ func NewCmdAccount(streams genericclioptions.IOStreams, flags *genericclioptions
 	accountCmd.AddCommand(newCmdVerifySecrets(streams, flags))
 	accountCmd.AddCommand(newCmdRotateSecret(streams, flags))
 	accountCmd.AddCommand(newCmdGenerateSecret(streams, flags))
+	accountCmd.AddCommand(newCmdAccountList(streams, flags))
 
 	return accountCmd
 }

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -17,6 +17,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/servicequotas"
@@ -70,6 +72,11 @@ type Client interface {
 	ListAccountsForParent(input *organizations.ListAccountsForParentInput) (*organizations.ListAccountsForParentOutput, error)
 	ListOrganizationalUnitsForParent(input *organizations.ListOrganizationalUnitsForParentInput) (*organizations.ListOrganizationalUnitsForParentOutput, error)
 	DescribeOrganizationalUnit(input *organizations.DescribeOrganizationalUnitInput) (*organizations.DescribeOrganizationalUnitOutput, error)
+	TagResource(input *organizations.TagResourceInput) (*organizations.TagResourceOutput, error)
+	ListTagsForResource(input *organizations.ListTagsForResourceInput) (*organizations.ListTagsForResourceOutput, error)
+
+	// Resources
+	GetResources(input *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error)
 
 	// Cost Explorer
 	GetCostAndUsage(input *costexplorer.GetCostAndUsageInput) (*costexplorer.GetCostAndUsageOutput, error)
@@ -83,6 +90,7 @@ type AwsClient struct {
 	s3Client            s3iface.S3API
 	servicequotasClient servicequotasiface.ServiceQuotasAPI
 	orgClient           organizationsiface.OrganizationsAPI
+	resClient           resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
 	ceClient            costexploreriface.CostExplorerAPI
 }
 
@@ -124,6 +132,7 @@ func NewAwsClient(profile, region, configFile string) (Client, error) {
 		servicequotasClient: servicequotas.New(sess),
 		orgClient:           organizations.New(sess),
 		ceClient:            costexplorer.New(sess),
+		resClient:           resourcegroupstaggingapi.New(sess),
 	}, nil
 }
 
@@ -146,6 +155,7 @@ func NewAwsClientWithInput(input *AwsClientInput) (Client, error) {
 		servicequotasClient: servicequotas.New(s),
 		orgClient:           organizations.New(s),
 		ceClient:            costexplorer.New(s),
+		resClient:           resourcegroupstaggingapi.New(s),
 	}, nil
 }
 
@@ -243,6 +253,17 @@ func (c *AwsClient) ListOrganizationalUnitsForParent(input *organizations.ListOr
 
 func (c *AwsClient) DescribeOrganizationalUnit(input *organizations.DescribeOrganizationalUnitInput) (*organizations.DescribeOrganizationalUnitOutput, error) {
 	return c.orgClient.DescribeOrganizationalUnit(input)
+}
+
+func (c *AwsClient) TagResource(input *organizations.TagResourceInput) (*organizations.TagResourceOutput, error) {
+	return c.orgClient.TagResource(input)
+}
+func (c *AwsClient) ListTagsForResource(input *organizations.ListTagsForResourceInput) (*organizations.ListTagsForResourceOutput, error) {
+	return c.orgClient.ListTagsForResource(input)
+}
+
+func (c *AwsClient) GetResources(input *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	return c.resClient.GetResources(input)
 }
 
 func (c *AwsClient) GetCostAndUsage(input *costexplorer.GetCostAndUsageInput) (*costexplorer.GetCostAndUsageOutput, error) {

--- a/pkg/provider/aws/mock/client.go
+++ b/pkg/provider/aws/mock/client.go
@@ -8,6 +8,7 @@ import (
 	costexplorer "github.com/aws/aws-sdk-go/service/costexplorer"
 	iam "github.com/aws/aws-sdk-go/service/iam"
 	organizations "github.com/aws/aws-sdk-go/service/organizations"
+	resourcegroupstaggingapi "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	s3 "github.com/aws/aws-sdk-go/service/s3"
 	servicequotas "github.com/aws/aws-sdk-go/service/servicequotas"
 	sts "github.com/aws/aws-sdk-go/service/sts"
@@ -396,6 +397,51 @@ func (m *MockClient) DescribeOrganizationalUnit(input *organizations.DescribeOrg
 func (mr *MockClientMockRecorder) DescribeOrganizationalUnit(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeOrganizationalUnit", reflect.TypeOf((*MockClient)(nil).DescribeOrganizationalUnit), input)
+}
+
+// TagResource mocks base method
+func (m *MockClient) TagResource(input *organizations.TagResourceInput) (*organizations.TagResourceOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TagResource", input)
+	ret0, _ := ret[0].(*organizations.TagResourceOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TagResource indicates an expected call of TagResource
+func (mr *MockClientMockRecorder) TagResource(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResource", reflect.TypeOf((*MockClient)(nil).TagResource), input)
+}
+
+// ListTagsForResource mocks base method
+func (m *MockClient) ListTagsForResource(input *organizations.ListTagsForResourceInput) (*organizations.ListTagsForResourceOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTagsForResource", input)
+	ret0, _ := ret[0].(*organizations.ListTagsForResourceOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTagsForResource indicates an expected call of ListTagsForResource
+func (mr *MockClientMockRecorder) ListTagsForResource(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResource", reflect.TypeOf((*MockClient)(nil).ListTagsForResource), input)
+}
+
+// GetResources mocks base method
+func (m *MockClient) GetResources(input *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetResources", input)
+	ret0, _ := ret[0].(*resourcegroupstaggingapi.GetResourcesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetResources indicates an expected call of GetResources
+func (mr *MockClientMockRecorder) GetResources(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResources", reflect.TypeOf((*MockClient)(nil).GetResources), input)
 }
 
 // GetCostAndUsage mocks base method


### PR DESCRIPTION
This cmd takes an LDAP username and payer profile and lists the accounts assigned to that user. If no username is provided, it lists all the account from the developers OU