### PR TITLE
fixed the region problem for : osdctl account cli -i  -o env

### DIFF
--- a/pkg/k8s/clusterresourcefactory.go
+++ b/pkg/k8s/clusterresourcefactory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -91,12 +92,6 @@ func (factory *ClusterResourceFactoryOptions) GetCloudProvider(verbose bool) (aw
 		}
 	}
 
-	var err error
-	awsClient, err := factory.Awscloudfactory.NewAwsClient()
-	if err != nil {
-		return nil, err
-	}
-
 	supportRoleDefined := false
 
 	ctx := context.TODO()
@@ -118,6 +113,14 @@ func (factory *ClusterResourceFactoryOptions) GetCloudProvider(verbose bool) (aw
 			supportRoleDefined = true
 		}
 	}
+	factory.Awscloudfactory.Region = accountClaim.Spec.Aws.Regions[0].Name
+
+	var err error
+	awsClient, err := factory.Awscloudfactory.NewAwsClient()
+	if err != nil {
+		return nil, err
+	}
+
 	var isBYOC bool
 	var acctSuffix string
 	if factory.AccountName != "" {
@@ -222,12 +225,11 @@ func (factory *ClusterResourceFactoryOptions) GetCloudProvider(verbose bool) (aw
 			return nil, err
 		}
 	}
-
 	awsClient, err = awsprovider.NewAwsClientWithInput(&awsprovider.AwsClientInput{
 		AccessKeyID:     *factory.Awscloudfactory.Credentials.AccessKeyId,
 		SecretAccessKey: *factory.Awscloudfactory.Credentials.SecretAccessKey,
 		SessionToken:    *factory.Awscloudfactory.Credentials.SessionToken,
-		Region:          factory.Awscloudfactory.Region,
+		Region:          accountClaim.Spec.Aws.Regions[0].Name,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -5,11 +5,12 @@ package aws
 
 import (
 	"fmt"
+	"path/filepath"
+
 	"github.com/aws/aws-sdk-go/service/costexplorer"
 	"github.com/aws/aws-sdk-go/service/costexplorer/costexploreriface"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/aws/aws-sdk-go/service/organizations/organizationsiface"
-	"path/filepath"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"


### PR DESCRIPTION
Changes made:
1. in osdctl/pkg/k8s/clusterresourcefactory.go , line 230 changed `Region:          factory.Awscloudfactory.Region,` to ` Region:          accountClaim.Spec.Aws.Regions[0].Name,` because Region is already available in the accountClaim 
2. changed the order so that it would go in and try to get account claim from cluster id first(if there's any) and then try to create a new AWS client profile if there's not accountClaim.