### PR TITLE
Add assign account cmd

### DIFF
--- a/cmd/account/mgmt/account-assign.go
+++ b/cmd/account/mgmt/account-assign.go
@@ -1,0 +1,199 @@
+package mgmt
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/openshift/osdctl/pkg/printer"
+	awsprovider "github.com/openshift/osdctl/pkg/provider/aws"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+// Global variables
+var (
+	OSDStaging2RootID = "r-rs3h"
+	OSDStaging2OuID   = "ou-rs3h-ry0hn2l9"
+	OSDStaging1RootID = "r-0wd6"
+	OSDStaging1OuID   = "ou-0wd6-z6tzkjek"
+)
+
+type accountAssignOptions struct {
+	awsClient    awsprovider.Client
+	username     string
+	payerAccount string
+
+	flags      *genericclioptions.ConfigFlags
+	printFlags *printer.PrintFlags
+	genericclioptions.IOStreams
+}
+
+func newAccountAssignOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *accountAssignOptions {
+	return &accountAssignOptions{
+		flags:      flags,
+		printFlags: printer.NewPrintFlags(),
+		IOStreams:  streams,
+	}
+}
+
+// assignCmd assigns an aws account to user under osd-staging-2 by default unless osd-staging-1 is specified
+func newCmdAccountAssign(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	ops := newAccountAssignOptions(streams, flags)
+	accountAssignCmd := &cobra.Command{
+		Use:               "assign",
+		Short:             "Assign account to user",
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd, args))
+			cmdutil.CheckErr(ops.run())
+		},
+	}
+	ops.printFlags.AddFlags(accountAssignCmd)
+	accountAssignCmd.Flags().StringVarP(&ops.payerAccount, "payer-account", "p", "", "Payer account type")
+	accountAssignCmd.Flags().StringVarP(&ops.username, "username", "u", "", "LDAP username")
+
+	return accountAssignCmd
+}
+
+func (o *accountAssignOptions) complete(cmd *cobra.Command, _ []string) error {
+	if o.username == "" {
+		return cmdutil.UsageErrorf(cmd, "LDAP username was not provided")
+	}
+	if o.payerAccount == "" {
+		return cmdutil.UsageErrorf(cmd, "Payer account was not provided")
+	}
+
+	return nil
+}
+
+func (o *accountAssignOptions) run() error {
+
+	var (
+		accountAssignID string
+		destinationOU   string
+		rootID          string
+	)
+
+	if o.payerAccount == "osd-staging-1" {
+		rootID = OSDStaging1RootID
+		destinationOU = OSDStaging1OuID
+	} else if o.payerAccount == "osd-staging-2" {
+		rootID = OSDStaging2RootID
+		destinationOU = OSDStaging2OuID
+	} else {
+		return fmt.Errorf("Invalid payer account provided")
+	}
+	//Instantiate aws client
+	awsClient, err := awsprovider.NewAwsClient(o.payerAccount, "us-east-1", "")
+	if err != nil {
+		return err
+	}
+
+	o.awsClient = awsClient
+	accountAssignID, err = o.findUntaggedAccount(rootID)
+	if err != nil {
+		return err
+	}
+
+	err = o.tagAccount(accountAssignID)
+	if err != nil {
+		return err
+	}
+
+	err = o.moveAccount(accountAssignID, destinationOU, rootID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(o.IOStreams.Out, accountAssignID)
+
+	return nil
+}
+
+var ErrNoUntaggedAccounts = fmt.Errorf("no untagged accounts available")
+var ErrNoAccountsInRoot = fmt.Errorf("no accounts available")
+
+func (o *accountAssignOptions) findUntaggedAccount(rootOu string) (string, error) {
+	//List accounts that are not in any OU
+	input := &organizations.ListAccountsForParentInput{
+		ParentId: &rootOu,
+	}
+	accounts, err := o.awsClient.ListAccountsForParent(input)
+	if err != nil {
+		return "", err
+	}
+	if len(accounts.Accounts) == 0 {
+		return "", ErrNoAccountsInRoot
+	}
+
+	// Loop through accounts and check that it's untagged and assign ID to user
+	var accountAssignID string
+	for _, a := range accounts.Accounts {
+
+		inputListTags := &organizations.ListTagsForResourceInput{
+			ResourceId: a.Id,
+		}
+		tags, err := o.awsClient.ListTagsForResource(inputListTags)
+		if err != nil {
+			return "", err
+		}
+
+		hasNoOwnerClaimedTag := true
+
+		for _, t := range tags.Tags {
+			if *t.Key == "owner" || *t.Key == "claimed" {
+				hasNoOwnerClaimedTag = false
+				break
+			}
+		}
+
+		if hasNoOwnerClaimedTag {
+			accountAssignID = *a.Id
+			break
+		}
+	}
+
+	if accountAssignID == "" {
+		return "", ErrNoUntaggedAccounts
+	}
+	return accountAssignID, nil
+}
+
+func (o *accountAssignOptions) tagAccount(accountIdInput string) error {
+
+	inputTag := &organizations.TagResourceInput{
+		ResourceId: aws.String(accountIdInput),
+		Tags: []*organizations.Tag{
+			{
+				Key:   aws.String("owner"),
+				Value: aws.String(o.username),
+			},
+			{
+				Key:   aws.String("claimed"),
+				Value: aws.String("true"),
+			},
+		},
+	}
+	_, err := o.awsClient.TagResource(inputTag)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *accountAssignOptions) moveAccount(accountIdInput string, destOuInput string, rootIdInput string) error {
+
+	inputMove := &organizations.MoveAccountInput{
+		AccountId:           aws.String(accountIdInput),
+		DestinationParentId: aws.String(destOuInput),
+		SourceParentId:      aws.String(rootIdInput),
+	}
+
+	_, err := o.awsClient.MoveAccount(inputMove)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/account/mgmt/account-assign_test.go
+++ b/cmd/account/mgmt/account-assign_test.go
@@ -1,0 +1,178 @@
+package mgmt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/golang/mock/gomock"
+	"github.com/openshift/osdctl/pkg/provider/aws/mock"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestFindUntaggedAccount(t *testing.T) {
+	var genericAWSError error = fmt.Errorf("Generic AWS error")
+
+	testData := []struct {
+		name              string
+		accountsList      []string
+		tags              map[string]string
+		expectedAccountId string
+		expectErr         error
+		expectedAWSError  error
+	}{
+		{
+			name:              "test for untagged account present",
+			accountsList:      []string{"111111111111"},
+			expectedAccountId: "111111111111",
+			tags:              map[string]string{},
+			expectErr:         nil,
+			expectedAWSError:  nil,
+		},
+		{
+			name:              "test for only partially tagged accounts present",
+			accountsList:      []string{"111111111111"},
+			expectedAccountId: "",
+			tags: map[string]string{
+				"claimed": "true",
+			},
+			expectErr:        ErrNoUntaggedAccounts,
+			expectedAWSError: nil,
+		},
+		{
+			name:              "test for only tagged accounts present",
+			accountsList:      []string{"111111111111"},
+			expectedAccountId: "",
+			tags: map[string]string{
+				"owner":   "randuser",
+				"claimed": "true",
+			},
+			expectErr:        ErrNoUntaggedAccounts,
+			expectedAWSError: nil,
+		},
+		{
+			name:              "test for no accounts available in root",
+			accountsList:      []string{},
+			expectedAccountId: "",
+			tags:              nil,
+			expectErr:         ErrNoAccountsInRoot,
+			expectedAWSError:  nil,
+		},
+		{
+			name:              "test for AWS list accounts error",
+			accountsList:      []string{},
+			expectedAccountId: "",
+			tags:              nil,
+			expectErr:         genericAWSError,
+			expectedAWSError:  genericAWSError,
+		},
+	}
+
+	for _, test := range testData {
+		t.Run(test.name, func(t *testing.T) {
+
+			mocks := setupDefaultMocks(t, []runtime.Object{})
+
+			mockAWSClient := mock.NewMockClient(mocks.mockCtrl)
+			rootOuId := "abc"
+
+			awsOutputAccounts := &organizations.ListAccountsForParentOutput{}
+
+			if test.accountsList != nil {
+				accountsList := []*organizations.Account{}
+				for _, a := range test.accountsList {
+					account := &organizations.Account{
+						Id: aws.String(a),
+					}
+					accountsList = append(accountsList, account)
+				}
+				awsOutputAccounts.Accounts = accountsList
+			}
+
+			if test.tags != nil {
+				awsOutputTags := &organizations.ListTagsForResourceOutput{}
+				tags := []*organizations.Tag{}
+				for key, value := range test.tags {
+					tag := &organizations.Tag{
+						Key:   aws.String(key),
+						Value: aws.String(value),
+					}
+					tags = append(tags, tag)
+				}
+				awsOutputTags.Tags = tags
+
+				mockAWSClient.EXPECT().ListTagsForResource(
+					&organizations.ListTagsForResourceInput{
+						ResourceId: &test.accountsList[0],
+					}).Return(
+					awsOutputTags,
+					test.expectedAWSError,
+				)
+			}
+
+			mockAWSClient.EXPECT().ListAccountsForParent(gomock.Any()).Return(
+				awsOutputAccounts,
+				test.expectedAWSError,
+			)
+
+			o := &accountAssignOptions{}
+			o.awsClient = mockAWSClient
+			returnValue, err := o.findUntaggedAccount(rootOuId)
+			if test.expectErr != err {
+				t.Errorf("expected error %s and got %s", test.expectErr, err)
+			}
+			if returnValue != test.expectedAccountId {
+				t.Errorf("expected %s is %s", test.expectedAccountId, returnValue)
+			}
+		})
+	}
+}
+
+func TestTagAccount(t *testing.T) {
+
+	mocks := setupDefaultMocks(t, []runtime.Object{})
+
+	mockAWSClient := mock.NewMockClient(mocks.mockCtrl)
+	accountID := "111111111111"
+
+	awsOutputTag := &organizations.TagResourceOutput{}
+
+	mockAWSClient.EXPECT().TagResource(gomock.Any()).Return(
+		awsOutputTag,
+		nil,
+	)
+
+	o := &accountAssignOptions{}
+	o.awsClient = mockAWSClient
+	err := o.tagAccount(accountID)
+	if err != nil {
+		t.Errorf("failed to tag account")
+	}
+}
+
+func TestMoveAccount(t *testing.T) {
+
+	mocks := setupDefaultMocks(t, []runtime.Object{})
+
+	mockAWSClient := mock.NewMockClient(mocks.mockCtrl)
+
+	accountId := "111111111111"
+	destOu := "abc-vnjfdshs"
+	rootOu := "abc"
+
+	awsOutputMove := &organizations.MoveAccountOutput{}
+
+	mockAWSClient.EXPECT().MoveAccount(gomock.Any()).Return(
+		awsOutputMove,
+		nil,
+	)
+
+	o := &accountAssignOptions{}
+	o.awsClient = mockAWSClient
+	err := o.moveAccount(accountId, destOu, rootOu)
+	if err != nil {
+		t.Errorf("failed to move account")
+	}
+}

--- a/cmd/account/mgmt/cmd.go
+++ b/cmd/account/mgmt/cmd.go
@@ -16,6 +16,7 @@ func NewCmdMgmt(streams genericclioptions.IOStreams, flags *genericclioptions.Co
 	}
 
 	mgmtCmd.AddCommand(newCmdAccountList(streams, flags))
+	mgmtCmd.AddCommand(newCmdAccountAssign(streams, flags))
 
 	return mgmtCmd
 }

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -75,12 +75,14 @@ type Client interface {
 	RequestServiceQuotaIncrease(*servicequotas.RequestServiceQuotaIncreaseInput) (*servicequotas.RequestServiceQuotaIncreaseOutput, error)
 
 	// Organizations
-	ListAccountsForParentPages(input *organizations.ListAccountsForParentInput, fn func(*organizations.ListAccountsForParentOutput, bool) bool) error
+	ListAccounts(input *organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error)
 	ListAccountsForParent(input *organizations.ListAccountsForParentInput) (*organizations.ListAccountsForParentOutput, error)
 	ListOrganizationalUnitsForParent(input *organizations.ListOrganizationalUnitsForParentInput) (*organizations.ListOrganizationalUnitsForParentOutput, error)
 	DescribeOrganizationalUnit(input *organizations.DescribeOrganizationalUnitInput) (*organizations.DescribeOrganizationalUnitOutput, error)
 	TagResource(input *organizations.TagResourceInput) (*organizations.TagResourceOutput, error)
+	UntagResource(input *organizations.UntagResourceInput) (*organizations.UntagResourceOutput, error)
 	ListTagsForResource(input *organizations.ListTagsForResourceInput) (*organizations.ListTagsForResourceOutput, error)
+	MoveAccount(input *organizations.MoveAccountInput) (*organizations.MoveAccountOutput, error)
 
 	// Resources
 	GetResources(input *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error)
@@ -245,8 +247,8 @@ func (c *AwsClient) ListAttachedRolePolicies(input *iam.ListAttachedRolePolicies
 	return c.iamClient.ListAttachedRolePolicies(input)
 }
 
-func (c *AwsClient) ListAccountsForParentPages(input *organizations.ListAccountsForParentInput, fn func(*organizations.ListAccountsForParentOutput, bool) bool) error {
-	return c.orgClient.ListAccountsForParentPages(input, fn)
+func (c *AwsClient) ListAccounts(input *organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error) {
+	return c.orgClient.ListAccounts(input)
 }
 
 func (c *AwsClient) ListAccountsForParent(input *organizations.ListAccountsForParentInput) (*organizations.ListAccountsForParentOutput, error) {
@@ -278,6 +280,14 @@ func (c *AwsClient) ListTagsForResource(input *organizations.ListTagsForResource
 
 func (c *AwsClient) GetResources(input *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
 	return c.resClient.GetResources(input)
+}
+
+func (c *AwsClient) UntagResource(input *organizations.UntagResourceInput) (*organizations.UntagResourceOutput, error) {
+	return c.orgClient.UntagResource(input)
+}
+
+func (c *AwsClient) MoveAccount(input *organizations.MoveAccountInput) (*organizations.MoveAccountOutput, error) {
+	return c.orgClient.MoveAccount(input)
 }
 
 func (c *AwsClient) GetCostAndUsage(input *costexplorer.GetCostAndUsageInput) (*costexplorer.GetCostAndUsageOutput, error) {

--- a/pkg/provider/aws/mock/client.go
+++ b/pkg/provider/aws/mock/client.go
@@ -370,18 +370,19 @@ func (mr *MockClientMockRecorder) RequestServiceQuotaIncrease(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestServiceQuotaIncrease", reflect.TypeOf((*MockClient)(nil).RequestServiceQuotaIncrease), arg0)
 }
 
-// ListAccountsForParentPages mocks base method
-func (m *MockClient) ListAccountsForParentPages(input *organizations.ListAccountsForParentInput, fn func(*organizations.ListAccountsForParentOutput, bool) bool) error {
+// ListAccounts mocks base method
+func (m *MockClient) ListAccounts(input *organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAccountsForParentPages", input, fn)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "ListAccounts", input)
+	ret0, _ := ret[0].(*organizations.ListAccountsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// ListAccountsForParentPages indicates an expected call of ListAccountsForParentPages
-func (mr *MockClientMockRecorder) ListAccountsForParentPages(input, fn interface{}) *gomock.Call {
+// ListAccounts indicates an expected call of ListAccounts
+func (mr *MockClientMockRecorder) ListAccounts(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccountsForParentPages", reflect.TypeOf((*MockClient)(nil).ListAccountsForParentPages), input, fn)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccounts", reflect.TypeOf((*MockClient)(nil).ListAccounts), input)
 }
 
 // ListAccountsForParent mocks base method
@@ -444,6 +445,21 @@ func (mr *MockClientMockRecorder) TagResource(input interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResource", reflect.TypeOf((*MockClient)(nil).TagResource), input)
 }
 
+// UntagResource mocks base method
+func (m *MockClient) UntagResource(input *organizations.UntagResourceInput) (*organizations.UntagResourceOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UntagResource", input)
+	ret0, _ := ret[0].(*organizations.UntagResourceOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UntagResource indicates an expected call of UntagResource
+func (mr *MockClientMockRecorder) UntagResource(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResource", reflect.TypeOf((*MockClient)(nil).UntagResource), input)
+}
+
 // ListTagsForResource mocks base method
 func (m *MockClient) ListTagsForResource(input *organizations.ListTagsForResourceInput) (*organizations.ListTagsForResourceOutput, error) {
 	m.ctrl.T.Helper()
@@ -457,6 +473,21 @@ func (m *MockClient) ListTagsForResource(input *organizations.ListTagsForResourc
 func (mr *MockClientMockRecorder) ListTagsForResource(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResource", reflect.TypeOf((*MockClient)(nil).ListTagsForResource), input)
+}
+
+// MoveAccount mocks base method
+func (m *MockClient) MoveAccount(input *organizations.MoveAccountInput) (*organizations.MoveAccountOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MoveAccount", input)
+	ret0, _ := ret[0].(*organizations.MoveAccountOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MoveAccount indicates an expected call of MoveAccount
+func (mr *MockClientMockRecorder) MoveAccount(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveAccount", reflect.TypeOf((*MockClient)(nil).MoveAccount), input)
 }
 
 // GetResources mocks base method


### PR DESCRIPTION
The assign cmd takes an LDAP username, finds an available account in the root, tags it as claimed with the username and moves it to the developers OU. [OSD-7350](https://issues.redhat.com/browse/OSD-7350)