### PR TITLE
Add unassign account cmd

### DIFF
--- a/cmd/account/account-unassign.go
+++ b/cmd/account/account-unassign.go
@@ -1,0 +1,325 @@
+package account
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/openshift/osdctl/pkg/k8s"
+	"github.com/openshift/osdctl/pkg/printer"
+	awsprovider "github.com/openshift/osdctl/pkg/provider/aws"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newCmdAccountUnassign(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	ops := newAccountUnassignOptions(streams, flags)
+	accountUnassignCmd := &cobra.Command{
+		Use:               "unassign",
+		Short:             "Unassign account to user",
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd, args))
+			cmdutil.CheckErr(ops.run())
+		},
+	}
+	ops.printFlags.AddFlags(accountUnassignCmd)
+	accountUnassignCmd.Flags().StringVarP(&ops.output, "output", "o", "", "Output format. One of: json|yaml|jsonpath=...|jsonpath-file=... see jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].")
+	accountUnassignCmd.Flags().StringVarP(&ops.payerAccount, "payer-account", "p", "", "Payer account type")
+	accountUnassignCmd.Flags().StringVarP(&ops.username, "username", "u", "", "LDAP username")
+	accountUnassignCmd.Flags().StringVarP(&ops.accountID, "account-id", "i", "", "Account ID")
+
+	return accountUnassignCmd
+}
+
+type accountUnassignOptions struct {
+	username     string
+	payerAccount string
+	output       string
+	accountID    string
+
+	flags      *genericclioptions.ConfigFlags
+	printFlags *printer.PrintFlags
+	genericclioptions.IOStreams
+	kubeCli client.Client
+}
+
+func newAccountUnassignOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *accountUnassignOptions {
+	return &accountUnassignOptions{
+		flags:      flags,
+		printFlags: printer.NewPrintFlags(),
+		IOStreams:  streams,
+	}
+}
+
+func (o *accountUnassignOptions) complete(cmd *cobra.Command, _ []string) error {
+	if o.payerAccount == "" {
+		return cmdutil.UsageErrorf(cmd, "Payer account was not provided")
+	}
+	if o.username == "" && o.accountID == "" {
+		return cmdutil.UsageErrorf(cmd, "Please provide either an username or account ID")
+	}
+	var err error
+	o.kubeCli, err = k8s.NewClient(o.flags)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func askForConfirmation(s string) bool {
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		fmt.Printf("%s [y/n]: ", s)
+
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		response = strings.ToLower(strings.TrimSpace(response))
+
+		if response == "y" {
+			return true
+		} else if response == "n" {
+			return false
+		}
+	}
+}
+
+func (o *accountUnassignOptions) run() error {
+
+	var (
+		accountUsername string
+		accountIdList   []string
+		hiveShardList   []string
+		destinationOU   string
+		rootID          string
+	)
+
+	hiveShardList = []string{"hivei01ue1", "hive-stage-1", "hives02ue1", "hive-stage-v3", "hive-integration-v3",
+		"hivep01ue1", "hivep02ue1", "hivep03uw1", "hivep04uw1", "hive-production-v3"}
+
+	// Instantiate Aws client
+	awsClient, err := awsprovider.NewAwsClient(o.payerAccount, "us-east-1", "")
+	if err != nil {
+		return err
+	}
+
+	if o.accountID != "" {
+		accountIdList = append(accountIdList, o.accountID)
+
+		// Go through tags to find the Username and verify it's not a non-ccs account
+		inputListTags := &organizations.ListTagsForResourceInput{
+			ResourceId: &o.accountID,
+		}
+		tagVal, err := awsClient.ListTagsForResource(inputListTags)
+		if err != nil {
+			return err
+		}
+
+		for _, t := range tagVal.Tags {
+			if t.Key == aws.String("owner") {
+				for _, i := range hiveShardList {
+					if *t.Value == i {
+						return fmt.Errorf("non-ccs account provided, only developers account accepted")
+					}
+				}
+			} else {
+				accountUsername = *t.Value
+			}
+		}
+	}
+
+	if o.username != "" {
+		// Check that username is not a hive
+		for _, j := range hiveShardList {
+			if o.username == j {
+				return fmt.Errorf("non-ccs account provided, only developers account accepted")
+			}
+		}
+
+		accountUsername = o.username
+
+		// Get all accounts from user
+		inputFilterTag := &resourcegroupstaggingapi.GetResourcesInput{
+			TagFilters: []*resourcegroupstaggingapi.TagFilter{
+				{
+					Key: aws.String("owner"),
+					Values: []*string{
+						aws.String(accountUsername),
+					},
+				},
+			},
+		}
+		accounts, err := awsClient.GetResources(inputFilterTag)
+		if err != nil {
+			return err
+		}
+		// Get last 9 digits of ResourceARN and append it to account list
+		for _, a := range accounts.ResourceTagMappingList {
+			accountIdList = append(accountIdList, (*a.ResourceARN)[len(*a.ResourceARN)-9:])
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	c := askForConfirmation("Are you sure you want to unassign the accounts? y/n")
+	if c {
+		// Delete login profile
+		inputDeleteLogin := &iam.DeleteLoginProfileInput{
+			UserName: &accountUsername,
+		}
+		_, err = awsClient.DeleteLoginProfile(inputDeleteLogin)
+		if err != nil {
+			return err
+		}
+		// Delete access keys
+		inputListAccessKeys := &iam.ListAccessKeysInput{
+			UserName: &accountUsername,
+		}
+		accessKeys, err := awsClient.ListAccessKeys(inputListAccessKeys)
+		if err != nil {
+			return err
+		}
+
+		for _, m := range accessKeys.AccessKeyMetadata {
+			inputDelKey := &iam.DeleteAccessKeyInput{
+				AccessKeyId: m.AccessKeyId,
+				UserName:    &accountUsername,
+			}
+			_, err = awsClient.DeleteAccessKey(inputDelKey)
+			if err != nil {
+				return err
+			}
+		}
+		// Delete signing certificates
+		inputListCert := &iam.ListSigningCertificatesInput{
+			UserName: &accountUsername,
+		}
+		cert, err := awsClient.ListSigningCertificates(inputListCert)
+		if err != nil {
+			return err
+		}
+
+		for _, c := range cert.Certificates {
+			inputDelCert := &iam.DeleteSigningCertificateInput{
+				CertificateId: c.CertificateId,
+				UserName:      &accountUsername,
+			}
+			_, err = awsClient.DeleteSigningCertificate(inputDelCert)
+			if err != nil {
+				return err
+			}
+		}
+		// Delete policies
+		inputListPolicies := &iam.ListUserPoliciesInput{
+			UserName: &accountUsername,
+		}
+		policies, err := awsClient.ListUserPolicies(inputListPolicies)
+		if err != nil {
+			return err
+		}
+
+		for _, p := range policies.PolicyNames {
+			inputDelPolicies := &iam.DeleteUserPolicyInput{
+				PolicyName: p,
+				UserName:   &accountUsername,
+			}
+			_, err = awsClient.DeleteUserPolicy(inputDelPolicies)
+			if err != nil {
+				return err
+			}
+		}
+		// Delete attached policies
+		inputListAttachedPol := &iam.ListAttachedUserPoliciesInput{
+			UserName: &accountUsername,
+		}
+		attachedPol, err := awsClient.ListAttachedUserPolicies(inputListAttachedPol)
+		if err != nil {
+			return err
+		}
+
+		for _, ap := range attachedPol.AttachedPolicies {
+			inputDetachPol := &iam.DetachUserPolicyInput{
+				PolicyArn: ap.PolicyArn,
+				UserName:  &accountUsername,
+			}
+			_, err = awsClient.DetachUserPolicy(inputDetachPol)
+			if err != nil {
+				return err
+			}
+		}
+		// Delete groups
+		inputListGroups := &iam.ListGroupsForUserInput{
+			UserName: &accountUsername,
+		}
+		groups, err := awsClient.ListGroupsForUser(inputListGroups)
+		if err != nil {
+			return err
+		}
+
+		for _, g := range groups.Groups {
+			inputRemoveFromGroup := &iam.RemoveUserFromGroupInput{
+				GroupName: g.GroupName,
+				UserName:  &accountUsername,
+			}
+			_, err = awsClient.RemoveUserFromGroup(inputRemoveFromGroup)
+			if err != nil {
+				return err
+			}
+		}
+		// Delete user
+		inputDelUser := &iam.DeleteUserInput{
+			UserName: &accountUsername,
+		}
+		_, err = awsClient.DeleteUser(inputDelUser)
+		if err != nil {
+			return err
+		}
+		// loop through accounts list and untag and move them back into root OU
+		for _, id := range accountIdList {
+
+			inputUntag := &organizations.UntagResourceInput{
+				ResourceId: &id,
+				TagKeys: []*string{
+					aws.String("owner"),
+					aws.String("claimed"),
+				},
+			}
+			_, err = awsClient.UntagResource(inputUntag)
+			if err != nil {
+				return err
+			}
+
+			destinationOU = "r-rs3h-ry0hn2l9"
+			rootID = "r-rs3h"
+			if o.payerAccount == "osd-staging-1" {
+				destinationOU = "ou-0wd6-z6tzkjek"
+				rootID = "ou-0wd6"
+			}
+
+			inputMove := &organizations.MoveAccountInput{
+				AccountId:           aws.String(id),
+				DestinationParentId: aws.String(rootID),
+				SourceParentId:      aws.String(destinationOU),
+			}
+
+			_, err = awsClient.MoveAccount(inputMove)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -18,6 +18,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/servicequotas"
@@ -62,6 +64,16 @@ type Client interface {
 	AttachRolePolicy(*iam.AttachRolePolicyInput) (*iam.AttachRolePolicyOutput, error)
 	DetachRolePolicy(*iam.DetachRolePolicyInput) (*iam.DetachRolePolicyOutput, error)
 	ListAttachedRolePolicies(*iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error)
+	DeleteLoginProfile(*iam.DeleteLoginProfileInput) (*iam.DeleteLoginProfileOutput, error)
+	ListSigningCertificates(*iam.ListSigningCertificatesInput) (*iam.ListSigningCertificatesOutput, error)
+	DeleteSigningCertificate(*iam.DeleteSigningCertificateInput) (*iam.DeleteSigningCertificateOutput, error)
+	ListUserPolicies(*iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error)
+	DeleteUserPolicy(*iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error)
+	ListAttachedUserPolicies(*iam.ListAttachedUserPoliciesInput) (*iam.ListAttachedUserPoliciesOutput, error)
+	DetachUserPolicy(*iam.DetachUserPolicyInput) (*iam.DetachUserPolicyOutput, error)
+	ListGroupsForUser(*iam.ListGroupsForUserInput) (*iam.ListGroupsForUserOutput, error)
+	RemoveUserFromGroup(*iam.RemoveUserFromGroupInput) (*iam.RemoveUserFromGroupOutput, error)
+	DeleteUser(*iam.DeleteUserInput) (*iam.DeleteUserOutput, error)
 
 	// Service Quotas
 	ListServiceQuotas(*servicequotas.ListServiceQuotasInput) (*servicequotas.ListServiceQuotasOutput, error)
@@ -71,6 +83,13 @@ type Client interface {
 	ListAccountsForParent(input *organizations.ListAccountsForParentInput) (*organizations.ListAccountsForParentOutput, error)
 	ListOrganizationalUnitsForParent(input *organizations.ListOrganizationalUnitsForParentInput) (*organizations.ListOrganizationalUnitsForParentOutput, error)
 	DescribeOrganizationalUnit(input *organizations.DescribeOrganizationalUnitInput) (*organizations.DescribeOrganizationalUnitOutput, error)
+	TagResource(input *organizations.TagResourceInput) (*organizations.TagResourceOutput, error)
+	UntagResource(input *organizations.UntagResourceInput) (*organizations.UntagResourceOutput, error)
+	ListTagsForResource(input *organizations.ListTagsForResourceInput) (*organizations.ListTagsForResourceOutput, error)
+	MoveAccount(input *organizations.MoveAccountInput) (*organizations.MoveAccountOutput, error)
+
+	// Resources
+	GetResources(input *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error)
 
 	// Cost Explorer
 	GetCostAndUsage(input *costexplorer.GetCostAndUsageInput) (*costexplorer.GetCostAndUsageOutput, error)
@@ -84,6 +103,7 @@ type AwsClient struct {
 	s3Client            s3iface.S3API
 	servicequotasClient servicequotasiface.ServiceQuotasAPI
 	orgClient           organizationsiface.OrganizationsAPI
+	resClient           resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
 	ceClient            costexploreriface.CostExplorerAPI
 }
 
@@ -125,6 +145,7 @@ func NewAwsClient(profile, region, configFile string) (Client, error) {
 		servicequotasClient: servicequotas.New(sess),
 		orgClient:           organizations.New(sess),
 		ceClient:            costexplorer.New(sess),
+		resClient:           resourcegroupstaggingapi.New(sess),
 	}, nil
 }
 
@@ -147,6 +168,7 @@ func NewAwsClientWithInput(input *AwsClientInput) (Client, error) {
 		servicequotasClient: servicequotas.New(s),
 		orgClient:           organizations.New(s),
 		ceClient:            costexplorer.New(s),
+		resClient:           resourcegroupstaggingapi.New(s),
 	}, nil
 }
 
@@ -226,6 +248,46 @@ func (c *AwsClient) ListAttachedRolePolicies(input *iam.ListAttachedRolePolicies
 	return c.iamClient.ListAttachedRolePolicies(input)
 }
 
+func (c *AwsClient) DeleteLoginProfile(input *iam.DeleteLoginProfileInput) (*iam.DeleteLoginProfileOutput, error) {
+	return c.iamClient.DeleteLoginProfile(input)
+}
+
+func (c *AwsClient) ListSigningCertificates(input *iam.ListSigningCertificatesInput) (*iam.ListSigningCertificatesOutput, error) {
+	return c.iamClient.ListSigningCertificates(input)
+}
+
+func (c *AwsClient) DeleteSigningCertificate(input *iam.DeleteSigningCertificateInput) (*iam.DeleteSigningCertificateOutput, error) {
+	return c.iamClient.DeleteSigningCertificate(input)
+}
+
+func (c *AwsClient) ListUserPolicies(input *iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error) {
+	return c.iamClient.ListUserPolicies(input)
+}
+
+func (c *AwsClient) DeleteUserPolicy(input *iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error) {
+	return c.iamClient.DeleteUserPolicy(input)
+}
+
+func (c *AwsClient) ListAttachedUserPolicies(input *iam.ListAttachedUserPoliciesInput) (*iam.ListAttachedUserPoliciesOutput, error) {
+	return c.iamClient.ListAttachedUserPolicies(input)
+}
+
+func (c *AwsClient) DetachUserPolicy(input *iam.DetachUserPolicyInput) (*iam.DetachUserPolicyOutput, error) {
+	return c.iamClient.DetachUserPolicy(input)
+}
+
+func (c *AwsClient) ListGroupsForUser(input *iam.ListGroupsForUserInput) (*iam.ListGroupsForUserOutput, error) {
+	return c.iamClient.ListGroupsForUser(input)
+}
+
+func (c *AwsClient) RemoveUserFromGroup(input *iam.RemoveUserFromGroupInput) (*iam.RemoveUserFromGroupOutput, error) {
+	return c.iamClient.RemoveUserFromGroup(input)
+}
+
+func (c *AwsClient) DeleteUser(input *iam.DeleteUserInput) (*iam.DeleteUserOutput, error) {
+	return c.iamClient.DeleteUser(input)
+}
+
 func (c *AwsClient) ListAccountsForParent(input *organizations.ListAccountsForParentInput) (*organizations.ListAccountsForParentOutput, error) {
 	return c.orgClient.ListAccountsForParent(input)
 }
@@ -244,6 +306,26 @@ func (c *AwsClient) ListOrganizationalUnitsForParent(input *organizations.ListOr
 
 func (c *AwsClient) DescribeOrganizationalUnit(input *organizations.DescribeOrganizationalUnitInput) (*organizations.DescribeOrganizationalUnitOutput, error) {
 	return c.orgClient.DescribeOrganizationalUnit(input)
+}
+
+func (c *AwsClient) TagResource(input *organizations.TagResourceInput) (*organizations.TagResourceOutput, error) {
+	return c.orgClient.TagResource(input)
+}
+
+func (c *AwsClient) UntagResource(input *organizations.UntagResourceInput) (*organizations.UntagResourceOutput, error) {
+	return c.orgClient.UntagResource(input)
+}
+
+func (c *AwsClient) ListTagsForResource(input *organizations.ListTagsForResourceInput) (*organizations.ListTagsForResourceOutput, error) {
+	return c.orgClient.ListTagsForResource(input)
+}
+
+func (c *AwsClient) MoveAccount(input *organizations.MoveAccountInput) (*organizations.MoveAccountOutput, error) {
+	return c.orgClient.MoveAccount(input)
+}
+
+func (c *AwsClient) GetResources(input *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	return c.resClient.GetResources(input)
 }
 
 func (c *AwsClient) GetCostAndUsage(input *costexplorer.GetCostAndUsageInput) (*costexplorer.GetCostAndUsageOutput, error) {

--- a/pkg/provider/aws/mock/client.go
+++ b/pkg/provider/aws/mock/client.go
@@ -8,6 +8,7 @@ import (
 	costexplorer "github.com/aws/aws-sdk-go/service/costexplorer"
 	iam "github.com/aws/aws-sdk-go/service/iam"
 	organizations "github.com/aws/aws-sdk-go/service/organizations"
+	resourcegroupstaggingapi "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	s3 "github.com/aws/aws-sdk-go/service/s3"
 	servicequotas "github.com/aws/aws-sdk-go/service/servicequotas"
 	sts "github.com/aws/aws-sdk-go/service/sts"
@@ -323,6 +324,156 @@ func (mr *MockClientMockRecorder) ListAttachedRolePolicies(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedRolePolicies", reflect.TypeOf((*MockClient)(nil).ListAttachedRolePolicies), arg0)
 }
 
+// DeleteLoginProfile mocks base method
+func (m *MockClient) DeleteLoginProfile(arg0 *iam.DeleteLoginProfileInput) (*iam.DeleteLoginProfileOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteLoginProfile", arg0)
+	ret0, _ := ret[0].(*iam.DeleteLoginProfileOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteLoginProfile indicates an expected call of DeleteLoginProfile
+func (mr *MockClientMockRecorder) DeleteLoginProfile(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoginProfile", reflect.TypeOf((*MockClient)(nil).DeleteLoginProfile), arg0)
+}
+
+// ListSigningCertificates mocks base method
+func (m *MockClient) ListSigningCertificates(arg0 *iam.ListSigningCertificatesInput) (*iam.ListSigningCertificatesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSigningCertificates", arg0)
+	ret0, _ := ret[0].(*iam.ListSigningCertificatesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSigningCertificates indicates an expected call of ListSigningCertificates
+func (mr *MockClientMockRecorder) ListSigningCertificates(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSigningCertificates", reflect.TypeOf((*MockClient)(nil).ListSigningCertificates), arg0)
+}
+
+// DeleteSigningCertificate mocks base method
+func (m *MockClient) DeleteSigningCertificate(arg0 *iam.DeleteSigningCertificateInput) (*iam.DeleteSigningCertificateOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteSigningCertificate", arg0)
+	ret0, _ := ret[0].(*iam.DeleteSigningCertificateOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteSigningCertificate indicates an expected call of DeleteSigningCertificate
+func (mr *MockClientMockRecorder) DeleteSigningCertificate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSigningCertificate", reflect.TypeOf((*MockClient)(nil).DeleteSigningCertificate), arg0)
+}
+
+// ListUserPolicies mocks base method
+func (m *MockClient) ListUserPolicies(arg0 *iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListUserPolicies", arg0)
+	ret0, _ := ret[0].(*iam.ListUserPoliciesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListUserPolicies indicates an expected call of ListUserPolicies
+func (mr *MockClientMockRecorder) ListUserPolicies(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserPolicies", reflect.TypeOf((*MockClient)(nil).ListUserPolicies), arg0)
+}
+
+// DeleteUserPolicy mocks base method
+func (m *MockClient) DeleteUserPolicy(arg0 *iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteUserPolicy", arg0)
+	ret0, _ := ret[0].(*iam.DeleteUserPolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteUserPolicy indicates an expected call of DeleteUserPolicy
+func (mr *MockClientMockRecorder) DeleteUserPolicy(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserPolicy", reflect.TypeOf((*MockClient)(nil).DeleteUserPolicy), arg0)
+}
+
+// ListAttachedUserPolicies mocks base method
+func (m *MockClient) ListAttachedUserPolicies(arg0 *iam.ListAttachedUserPoliciesInput) (*iam.ListAttachedUserPoliciesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAttachedUserPolicies", arg0)
+	ret0, _ := ret[0].(*iam.ListAttachedUserPoliciesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAttachedUserPolicies indicates an expected call of ListAttachedUserPolicies
+func (mr *MockClientMockRecorder) ListAttachedUserPolicies(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedUserPolicies", reflect.TypeOf((*MockClient)(nil).ListAttachedUserPolicies), arg0)
+}
+
+// DetachUserPolicy mocks base method
+func (m *MockClient) DetachUserPolicy(arg0 *iam.DetachUserPolicyInput) (*iam.DetachUserPolicyOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetachUserPolicy", arg0)
+	ret0, _ := ret[0].(*iam.DetachUserPolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DetachUserPolicy indicates an expected call of DetachUserPolicy
+func (mr *MockClientMockRecorder) DetachUserPolicy(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachUserPolicy", reflect.TypeOf((*MockClient)(nil).DetachUserPolicy), arg0)
+}
+
+// ListGroupsForUser mocks base method
+func (m *MockClient) ListGroupsForUser(arg0 *iam.ListGroupsForUserInput) (*iam.ListGroupsForUserOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListGroupsForUser", arg0)
+	ret0, _ := ret[0].(*iam.ListGroupsForUserOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListGroupsForUser indicates an expected call of ListGroupsForUser
+func (mr *MockClientMockRecorder) ListGroupsForUser(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupsForUser", reflect.TypeOf((*MockClient)(nil).ListGroupsForUser), arg0)
+}
+
+// RemoveUserFromGroup mocks base method
+func (m *MockClient) RemoveUserFromGroup(arg0 *iam.RemoveUserFromGroupInput) (*iam.RemoveUserFromGroupOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveUserFromGroup", arg0)
+	ret0, _ := ret[0].(*iam.RemoveUserFromGroupOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveUserFromGroup indicates an expected call of RemoveUserFromGroup
+func (mr *MockClientMockRecorder) RemoveUserFromGroup(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUserFromGroup", reflect.TypeOf((*MockClient)(nil).RemoveUserFromGroup), arg0)
+}
+
+// DeleteUser mocks base method
+func (m *MockClient) DeleteUser(arg0 *iam.DeleteUserInput) (*iam.DeleteUserOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteUser", arg0)
+	ret0, _ := ret[0].(*iam.DeleteUserOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteUser indicates an expected call of DeleteUser
+func (mr *MockClientMockRecorder) DeleteUser(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockClient)(nil).DeleteUser), arg0)
+}
+
 // ListServiceQuotas mocks base method
 func (m *MockClient) ListServiceQuotas(arg0 *servicequotas.ListServiceQuotasInput) (*servicequotas.ListServiceQuotasOutput, error) {
 	m.ctrl.T.Helper()
@@ -396,6 +547,81 @@ func (m *MockClient) DescribeOrganizationalUnit(input *organizations.DescribeOrg
 func (mr *MockClientMockRecorder) DescribeOrganizationalUnit(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeOrganizationalUnit", reflect.TypeOf((*MockClient)(nil).DescribeOrganizationalUnit), input)
+}
+
+// TagResource mocks base method
+func (m *MockClient) TagResource(input *organizations.TagResourceInput) (*organizations.TagResourceOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TagResource", input)
+	ret0, _ := ret[0].(*organizations.TagResourceOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TagResource indicates an expected call of TagResource
+func (mr *MockClientMockRecorder) TagResource(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResource", reflect.TypeOf((*MockClient)(nil).TagResource), input)
+}
+
+// UntagResource mocks base method
+func (m *MockClient) UntagResource(input *organizations.UntagResourceInput) (*organizations.UntagResourceOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UntagResource", input)
+	ret0, _ := ret[0].(*organizations.UntagResourceOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UntagResource indicates an expected call of UntagResource
+func (mr *MockClientMockRecorder) UntagResource(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResource", reflect.TypeOf((*MockClient)(nil).UntagResource), input)
+}
+
+// ListTagsForResource mocks base method
+func (m *MockClient) ListTagsForResource(input *organizations.ListTagsForResourceInput) (*organizations.ListTagsForResourceOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTagsForResource", input)
+	ret0, _ := ret[0].(*organizations.ListTagsForResourceOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTagsForResource indicates an expected call of ListTagsForResource
+func (mr *MockClientMockRecorder) ListTagsForResource(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResource", reflect.TypeOf((*MockClient)(nil).ListTagsForResource), input)
+}
+
+// MoveAccount mocks base method
+func (m *MockClient) MoveAccount(input *organizations.MoveAccountInput) (*organizations.MoveAccountOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MoveAccount", input)
+	ret0, _ := ret[0].(*organizations.MoveAccountOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MoveAccount indicates an expected call of MoveAccount
+func (mr *MockClientMockRecorder) MoveAccount(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveAccount", reflect.TypeOf((*MockClient)(nil).MoveAccount), input)
+}
+
+// GetResources mocks base method
+func (m *MockClient) GetResources(input *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetResources", input)
+	ret0, _ := ret[0].(*resourcegroupstaggingapi.GetResourcesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetResources indicates an expected call of GetResources
+func (mr *MockClientMockRecorder) GetResources(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResources", reflect.TypeOf((*MockClient)(nil).GetResources), input)
 }
 
 // GetCostAndUsage mocks base method


### PR DESCRIPTION
This cmd takes either an developer account ID or Username and deletes its IAM users, Access Keys, Roles, and Policies. It then untags it and moves it to the Root