### PR TITLE
fixed piping through jq functionality

### DIFF
--- a/cmd/account/cli.go
+++ b/cmd/account/cli.go
@@ -76,6 +76,7 @@ func (o *cliOptions) complete(cmd *cobra.Command) error {
 func (o *cliOptions) run() error {
 	awsClient, err := o.k8sclusterresourcefactory.GetCloudProvider(o.verbose)
 	if err != nil {
+
 		return err
 	}
 
@@ -98,7 +99,12 @@ func (o *cliOptions) run() error {
 	}
 
 	if o.output == "json" {
-		fmt.Fprintf(o.IOStreams.Out, "%s\n", creds)
+		fmt.Fprintf(o.IOStreams.Out, "{\n\"AccessKeyId\": %q, \n\"Expiration\": %q, \n\"SecretAccessKey\": %q, \n\"SessionToken\": %q\n}",
+			*creds.AccessKeyId,
+			*creds.Expiration,
+			*creds.SecretAccessKey,
+			*creds.SessionToken,
+		)
 	}
 
 	if o.output == "env" {


### PR DESCRIPTION
Reconfigure the output of osdctl account cli -C 1jv3v7h0entnarjo6j06ceahlukr0eqj -p rhcontrol -o json because previously it didn't print out json format, therefore can't be piped through jq. 