### PR TITLE
fixed nil pointer dereference error when no accountclaim is available

### DIFF
--- a/pkg/k8s/clusterresourcefactory.go
+++ b/pkg/k8s/clusterresourcefactory.go
@@ -112,8 +112,8 @@ func (factory *ClusterResourceFactoryOptions) GetCloudProvider(verbose bool) (aw
 		if accountClaim.Spec.SupportRoleARN != "" {
 			supportRoleDefined = true
 		}
+		factory.Awscloudfactory.Region = accountClaim.Spec.Aws.Regions[0].Name
 	}
-	factory.Awscloudfactory.Region = accountClaim.Spec.Aws.Regions[0].Name
 
 	var err error
 	awsClient, err := factory.Awscloudfactory.NewAwsClient()
@@ -229,7 +229,7 @@ func (factory *ClusterResourceFactoryOptions) GetCloudProvider(verbose bool) (aw
 		AccessKeyID:     *factory.Awscloudfactory.Credentials.AccessKeyId,
 		SecretAccessKey: *factory.Awscloudfactory.Credentials.SecretAccessKey,
 		SessionToken:    *factory.Awscloudfactory.Credentials.SessionToken,
-		Region:          accountClaim.Spec.Aws.Regions[0].Name,
+		Region:          factory.Awscloudfactory.Region,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Command `./osdctl account cli -i 335462696174 -p osd-staging-2 ' returns 'panic: runtime error: invalid memory address or nil pointer dereference' because it tried to read an accountclaim when there doesn't exist any.