### PR TITLE
[OSD-3574] Removing references to osdManagedAdminSRE

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ For the detailed usage of each command, please refer to [here](./docs/command).
 osdctl account reset test-cr
 Reset account test-cr? (Y/N) y
 
-Deleting secret test-cr-osdmanagedadminsre-secret
 Deleting secret test-cr-secret
 Deleting secret test-cr-sre-cli-credentials
 Deleting secret test-cr-sre-console-url
@@ -162,7 +161,6 @@ osdctl account get legal-entity -i <Account ID>
 # Get Secrets information by AWS Account ID
 osdctl account get secrets -i <Account ID>
 
-test-cr-osdmanagedadminsre-secret
 test-cr-secret
 ```
 

--- a/cmd/account/get/secrets.go
+++ b/cmd/account/get/secrets.go
@@ -19,8 +19,7 @@ import (
 )
 
 const (
-	osdAdminSecret = "-osdmanagedadminsre-secret"
-	secret         = "-secret"
+	secret = "-secret"
 )
 
 // newCmdGetSecrets implements the get secrets command which get
@@ -102,7 +101,7 @@ func (o *getSecretsOptions) run() error {
 		return fmt.Errorf("Account matches for AWS Account ID %s not found\n", o.accountID)
 	}
 
-	secretSuffixes := []string{osdAdminSecret, secret}
+	secretSuffixes := []string{secret}
 	var secret v1.Secret
 	for _, suffix := range secretSuffixes {
 		if err := o.kubeCli.Get(ctx, types.NamespacedName{

--- a/cmd/account/rotate-secret.go
+++ b/cmd/account/rotate-secret.go
@@ -207,31 +207,6 @@ func (o *rotateSecretOptions) run() error {
 
 	fmt.Printf("Succesfully rotated secrets for %s\n", osdManagedAdminUsername)
 
-	// Update osdManagedAdminSRE secret
-	// Username is osdManagedAdminSRE-aaabbb
-	osdManagedAdminSREUsername := common.OSDManagedAdminIAM + "SRE" + "-" + accountIDSuffixLabel
-	createAccessKeyOutputSRE, err := awsClient.CreateAccessKey(&iam.CreateAccessKeyInput{
-		UserName: aws.String(osdManagedAdminSREUsername),
-	})
-	if err != nil {
-		return err
-	}
-
-	// Place new credentials into body for secret
-	newOsdManagedAdminSRESecretData := map[string][]byte{
-		"aws_user_name":         []byte(*createAccessKeyOutputSRE.AccessKey.UserName),
-		"aws_access_key_id":     []byte(*createAccessKeyOutputSRE.AccessKey.AccessKeyId),
-		"aws_secret_access_key": []byte(*createAccessKeyOutputSRE.AccessKey.SecretAccessKey),
-	}
-
-	// Update existing osdManagedAdmin secret
-	err = common.UpdateSecret(o.kubeCli, o.accountCRName+"-osdmanagedadminsre-secret", common.AWSAccountNamespace, newOsdManagedAdminSRESecretData)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("Succesfully rotated secrets for %s\n", osdManagedAdminSREUsername)
-
 	// Only update osdCcsAdmin credential if specified
 	if o.updateCcsCreds {
 		// Ony update if the Account CR is actually CCS


### PR DESCRIPTION
Ref [OSD-3574](https://issues.redhat.com/browse/OSD-3574)
- removed all references to osdManagedAdminSRE as it's phased out of AAO and eventually deleted from all AWS accounts
- [AAO PR](https://github.com/openshift/aws-account-operator/pull/607)