### PR TITLE
Adds initial `aao pool` command structure

### DIFF
--- a/cmd/aao/cmd.go
+++ b/cmd/aao/cmd.go
@@ -1,0 +1,25 @@
+package aao
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+// NewCmdAao implements the base aao command
+func NewCmdAao(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	aaoCmd := &cobra.Command{
+		Use:               "aao",
+		Short:             "AWS Account Operator Debugging Utilities",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		Run:               help,
+	}
+
+	aaoCmd.AddCommand(newCmdPool(streams, flags))
+
+	return aaoCmd
+}
+
+func help(cmd *cobra.Command, _ []string) {
+	cmd.Help()
+}

--- a/cmd/aao/pool.go
+++ b/cmd/aao/pool.go
@@ -2,6 +2,7 @@ package aao
 
 import (
 	"fmt"
+	"os/exec"
 
 	"github.com/spf13/cobra"
 
@@ -43,6 +44,13 @@ func (o *poolOptions) complete(cmd *cobra.Command) error {
 }
 
 func (o *poolOptions) run() error {
-	fmt.Println("test")
+	cmd := "oc get accounts -o json -n aws-account-operator | jq '.items | map(select(.status.claimed==\"false\" or .status.claimed==null)) | map(select(.status.state!=\"Failed\")) | map(select(.spec.legalEntity==null or .spec.legalEntity.id==\"\" or .spec.legalEntity.id==null)) | length'"
+	output, err := exec.Command("bash", "-c", cmd).Output()
+	if err != nil {
+		fmt.Println(string(output))
+		fmt.Print(err)
+		return err
+	}
+	fmt.Printf("Available Accounts: %s", string(output))
 	return nil
 }

--- a/cmd/aao/pool.go
+++ b/cmd/aao/pool.go
@@ -1,0 +1,48 @@
+package aao
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	//"k8s.io/klog"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+// newCmdPool gets the current status of the AWS Account Operator AccountPool
+func newCmdPool(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	ops := newPoolOptions(streams, flags)
+	poolCmd := &cobra.Command{
+		Use:               "pool",
+		Short:             "Get the status of the AWS Account Operator AccountPool",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd))
+			cmdutil.CheckErr(ops.run())
+		},
+	}
+
+	return poolCmd
+}
+
+// poolOptions defines the struct for running the pool command
+type poolOptions struct {
+	genericclioptions.IOStreams
+}
+
+func newPoolOptions(streams genericclioptions.IOStreams, _ *genericclioptions.ConfigFlags) *poolOptions {
+	return &poolOptions{
+		IOStreams: streams,
+	}
+}
+
+func (o *poolOptions) complete(cmd *cobra.Command) error {
+	return nil
+}
+
+func (o *poolOptions) run() error {
+	fmt.Println("test")
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 	"k8s.io/utils/pointer"
 
+	"github.com/openshift/osdctl/cmd/aao"
 	"github.com/openshift/osdctl/cmd/account"
 	"github.com/openshift/osdctl/cmd/clusterdeployment"
 	"github.com/openshift/osdctl/cmd/cost"
@@ -65,6 +66,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	kubeFlags.AddFlags(rootCmd.PersistentFlags())
 
 	// add sub commands
+	rootCmd.AddCommand(aao.NewCmdAao(streams, kubeFlags))
 	rootCmd.AddCommand(account.NewCmdAccount(streams, kubeFlags))
 	rootCmd.AddCommand(clusterdeployment.NewCmdClusterDeployment(streams, kubeFlags))
 	rootCmd.AddCommand(federatedrole.NewCmdFederatedRole(streams, kubeFlags))


### PR DESCRIPTION
Adds the aao subcommand and `aao pool` commands to osdctl to get the account pool size.