### PR TITLE
OSD-7691 - Apply service log command to multiple clusters

### DIFF
--- a/cmd/cluster/health.go
+++ b/cmd/cluster/health.go
@@ -15,8 +15,10 @@ import (
 	awsprovider "github.com/openshift/osdctl/pkg/provider/aws"
 	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog"
+
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
@@ -80,12 +82,26 @@ func (o *healthOptions) complete(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
+type ClusterHealthCondensedObject struct {
+	ID       string   `yaml:"ID"`
+	Name     string   `yaml:"Name"`
+	Provider string   `yaml:"Provider"`
+	AZs      []string `yaml:"AZs"`
+	Nodes    struct {
+		Expected int `yaml:"Expected"`
+		Running  int `yaml:"Running"`
+	} `yaml:"Nodes"`
+}
+
+var healthObject = ClusterHealthCondensedObject{}
+
 func (o *healthOptions) run() error {
 
 	// This call gets the availability zone of the cluster, as well as the expected number of nodes.
 	az, clusterName, nodesExpected, err := ocmDescribe(o.k8sclusterresourcefactory.ClusterID)
 	if az != nil {
-		fmt.Fprintf(o.IOStreams.Out, "\nThe expected number of nodes in availability zone(s) %s is : %v \n", az, nodesExpected)
+		healthObject.AZs = az
+		healthObject.Nodes.Expected = nodesExpected
 	}
 	if err != nil {
 		return err
@@ -132,10 +148,7 @@ func (o *healthOptions) run() error {
 		return err
 	}
 
-	log.Println("Getting instances info:")
-
 	instances, err := awsJumpClient.DescribeInstances(&ec2.DescribeInstancesInput{})
-
 	totalRunning := 0
 
 	//Here we count the number of customer's running instances in the cluster in the given region. To decide if the instance belongs to the cluster we are checking the Name Tag on the instance.
@@ -153,12 +166,19 @@ func (o *healthOptions) run() error {
 		}
 
 	}
-	fmt.Fprintf(o.IOStreams.Out, "\nThe number of running instances that belong to this cluster in region %s is : %v \n", reg, totalRunning)
+	healthObject.Nodes.Running = totalRunning
 
 	if err != nil {
 		log.Fatalf("Error getting instances %v", err)
 		return err
 	}
+
+	d, err := yaml.Marshal(&healthObject)
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+	fmt.Printf(string(d))
+
 	return nil
 }
 
@@ -202,8 +222,9 @@ func ocmDescribe(clusterID string) ([]string, string, int, error) {
 	cloudProvider := cluster.CloudProvider().ID()
 	cloudProviderMessage := strings.ToUpper(cloudProvider)
 
-	fmt.Printf("\nCluster %s - %s\n", cluster.Name(), cluster.ID())
-	fmt.Printf("\nCloud provider: %s\n", cloudProviderMessage)
+	healthObject.ID = cluster.ID()
+	healthObject.Name = cluster.Name()
+	healthObject.Provider = cloudProviderMessage
 
 	if cloudProvider != "aws" {
 		return nil, "", 0, fmt.Errorf("This command is only supported for AWS clusters. The command is not supported for %s clusters.", cloudProviderMessage)

--- a/cmd/servicelog/common.go
+++ b/cmd/servicelog/common.go
@@ -2,16 +2,19 @@ package servicelog
 
 import (
 	"strings"
+	"fmt"
+	"encoding/json"
 
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/openshift/osdctl/internal/servicelog"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	log "github.com/sirupsen/logrus"
+	v1  "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 var (
-	templateParams, userParameterNames, userParameterValues []string
-	isURL                                                   bool
-	HTMLBody                                                []byte
+	templateParams, userParameterNames, userParameterValues, filterParams []string
+	HTMLBody                                                              []byte
 )
 
 const (
@@ -31,6 +34,41 @@ func createConnection() *sdk.Connection {
 	return connection
 }
 
+// generateClusterQuery returns an OCM search query to identify a cluster
+func generateQuery(clusterIdentifier string) string {
+        return "id is '" + clusterIdentifier + "' or external_id is '" + clusterIdentifier + "' or display_name i  s '" + clusterIdentifier + "'"
+}
+
+// getFilteredClusters retrieves clusters in OCM which match the filters given
+func applyFilters(ocmClient *sdk.Connection, filters []string) ([]*v1.Cluster, error) {
+        if len(filters) < 1 {
+                return nil, nil
+        }
+
+        for k, v := range filters {
+                filters[k] = fmt.Sprintf("(%s)", v)
+        }
+
+	requestSize := 50
+        request := ocmClient.ClustersMgmt().V1().Clusters().List().Search(strings.Join(filters, " and ")).Size(requestSize)
+        response, err := request.Send()
+        if err != nil {
+                return nil, err
+        }
+
+	items := response.Items().Slice()
+	for response.Size() >= requestSize {
+		request.Page(response.Page() + 1)
+		response, err = request.Send()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, response.Items().Slice()...)
+	}
+
+	return items, err
+}
+
 func sendRequest(request *sdk.Request) *sdk.Response {
 	response, err := request.Send()
 	if err != nil {
@@ -39,19 +77,54 @@ func sendRequest(request *sdk.Request) *sdk.Response {
 	return response
 }
 
-func check(response *sdk.Response, dir string) {
-	status := response.Status()
-
+func check(response *sdk.Response, clusterMessage servicelog.Message) {
 	body := response.Bytes()
-
-	if status < 400 {
-		validateGoodResponse(body)
-		log.Info("Message has been successfully sent")
-
+	if response.Status() < 400 {
+		validateGoodResponse(body, clusterMessage)
+		log.Infof("Message has been successfully sent to %s\n", clusterMessage.ClusterUUID)
 	} else {
-		validateBadResponse(body)
-		cleanup(dir)
-		log.Fatalf("Failed to post message because of %q", BadReply.Reason)
-
+		badReply := validateBadResponse(body)
+		log.Fatalf("Failed to post message because of %q", badReply.Reason)
 	}
+}
+
+func validateGoodResponse(body []byte, clusterMessage servicelog.Message) servicelog.GoodReply {
+        var goodReply servicelog.GoodReply
+        if err := json.Unmarshal(body, &goodReply); err != nil {
+                log.Fatalf("Cannot not parse the JSON template.\nError: %q\n", err)
+        }
+
+        if goodReply.Severity != clusterMessage.Severity {
+                log.Fatalf("Message sent, but wrong severity information was passed (wanted %q, got %q)", clusterMessage.Severity, goodReply.Severity)
+        }
+        if goodReply.ServiceName != clusterMessage.ServiceName {
+                log.Fatalf("Message sent, but wrong service_name information was passed (wanted %q, got %q)", clusterMessage.ServiceName, goodReply.ServiceName)
+        }
+        if goodReply.ClusterUUID != clusterMessage.ClusterUUID {
+                log.Fatalf("Message sent, but to different cluster (wanted %q, got %q)", clusterMessage.ClusterUUID, goodReply.ClusterUUID)
+        }
+        if goodReply.Summary != clusterMessage.Summary {
+                log.Fatalf("Message sent, but wrong summary information was passed (wanted %q, got %q)", clusterMessage.Summary, goodReply.Summary)
+        }
+        if goodReply.Description != clusterMessage.Description {
+                log.Fatalf("Message sent, but wrong description information was passed (wanted %q, got %q)", clusterMessage.Description, goodReply.Description)
+        }
+        if !json.Valid(body) {
+                log.Fatalf("Server returned invalid JSON")
+        }
+
+        return goodReply
+}
+
+func validateBadResponse(body []byte) servicelog.BadReply {
+        if ok := json.Valid(body); !ok {
+                log.Errorf("Server returned invalid JSON")
+        }
+
+        var badReply servicelog.BadReply
+        if err := json.Unmarshal(body, &badReply); err != nil {
+                log.Fatalf("Cannot parse the error JSON message %q", err)
+        }
+
+        return badReply
 }

--- a/cmd/servicelog/list.go
+++ b/cmd/servicelog/list.go
@@ -1,7 +1,6 @@
 package servicelog
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -9,7 +8,7 @@ import (
 	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	"github.com/openshift-online/ocm-cli/pkg/dump"
 	sdk "github.com/openshift-online/ocm-sdk-go"
-	"github.com/openshift/osdctl/internal/servicelog"
+	v1  "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -19,13 +18,14 @@ var listCmd = &cobra.Command{
 	Use:           "list [flags] [options] cluster-identifier",
 	Short:         "gets all servicelog messages for a given cluster",
 	Args:          cobra.ArbitraryArgs,
+	// validate only clusterid is provided
+	//Args: cobra.MinimumNArgs(1),
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
 			cmd.Help()
 			return fmt.Errorf("cluster-identifier was not provided. please provide a cluster id, UUID, or name")
 		}
-		clusterId := args[0]
 
 		// Create an OCM client to talk to the cluster API
 		// the user has to be logged in (e.g. 'ocm login')
@@ -36,25 +36,19 @@ var listCmd = &cobra.Command{
 			}
 		}()
 
-		// Use the OCM client to create the POST request
-		request := createClusterRequest(ocmClient, clusterId)
-		response := sendRequest(request)
-		clusterExternalId, err := extractExternalIdFromResponse(response)
-		if err != nil {
-			cmd.Help()
-			return err
-		}
+		// Use the OCM client to retrieve clusters
+		clusters := getClusters(ocmClient, args)
 
 		// send it as logservice and validate the response
-		request = createListRequest(ocmClient, clusterExternalId, serviceLogListAllMessagesFlag)
-		response = sendRequest(request)
+		for _, cluster := range clusters {
+			response := sendRequest(createListRequest(ocmClient, cluster.ExternalID(), serviceLogListAllMessagesFlag))
 
-		err = dump.Pretty(os.Stdout, response.Bytes())
-		if err != nil {
-			cmd.Help()
-			return err
+			err := dump.Pretty(os.Stdout, response.Bytes())
+			if err != nil {
+				cmd.Help()
+				return err
+			}
 		}
-
 		return nil
 	},
 }
@@ -68,44 +62,18 @@ func init() {
 	listCmd.Flags().BoolVarP(&serviceLogListAllMessagesFlag, "all-messages", "A", serviceLogListAllMessagesFlag, "Toggle if we should see all of the messages or only SRE-P specific ones")
 }
 
-func extractExternalIdFromResponse(response *sdk.Response) (string, error) {
-	status := response.Status()
-	body := response.Bytes()
-
-	if status >= 400 {
-		validateBadResponse(body)
-		log.Fatalf("Failed to list message because of %q", BadReply.Reason)
-		return "", nil
+func getClusters(ocmClient *sdk.Connection, clusterIds []string) ([]*v1.Cluster){
+	for i, id := range clusterIds {
+		clusterIds[i] = fmt.Sprintf(`display_name like '%[1]s' or name like '%[1]s' or id like '%[1]s' or external_id like '%[1]s'`, id)
+		clusterIds[i] = strings.TrimSpace(clusterIds[i])
 	}
 
-	validateGoodResponse(body)
-	clusterListGoodReply := servicelog.ClusterListGoodReply{}
-	err := json.Unmarshal(body, &clusterListGoodReply)
+	clusters, err := applyFilters(ocmClient, []string{strings.Join(clusterIds, " or ")})
 	if err != nil {
-		err = fmt.Errorf("cannot parse good clusterlist response: %w", err)
-		return "", err
+		log.Fatalf("Error while retrieving cluster(s) from ocm: %[1]s", err)
 	}
 
-	if clusterListGoodReply.Total != 1 || len(clusterListGoodReply.Items) != 1 {
-		return "", fmt.Errorf("could not find an exact match for the clustername")
-	}
-
-	return clusterListGoodReply.Items[0].ExternalID, nil
-}
-
-func createClusterRequest(ocmClient *sdk.Connection, clusterId string) *sdk.Request {
-
-	searchString := fmt.Sprintf(`search=display_name like '%[1]s' or name like '%[1]s' or id like '%[1]s' or external_id like '%[1]s'`, clusterId)
-	searchString = strings.TrimSpace(searchString)
-	request := ocmClient.Get()
-	err := arguments.ApplyPathArg(request, "/api/clusters_mgmt/v1/clusters/")
-	if err != nil {
-		log.Fatalf("Can't parse API path '%s': %v\n", targetAPIPath, err)
-	}
-
-	arguments.ApplyParameterFlag(request, []string{searchString})
-
-	return request
+	return clusters
 }
 
 func createListRequest(ocmClient *sdk.Connection, clusterId string, allMessages bool) *sdk.Request {

--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -1,34 +1,37 @@
 package servicelog
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/url"
 	"os"
-	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	"github.com/openshift-online/ocm-cli/pkg/dump"
 	sdk "github.com/openshift-online/ocm-sdk-go"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/osdctl/internal/servicelog"
 	"github.com/openshift/osdctl/internal/utils"
+	"github.com/openshift/osdctl/pkg/printer"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var (
-	GoodReply servicelog.GoodReply
-	BadReply  servicelog.BadReply
 	Message   servicelog.Message
 	template  string
+	filterFiles []string	// Path to filter file
+	filtersFromFile string	// Contents of filterFiles
 	isDryRun  bool
+	skipPrompts bool
 )
 
 const (
 	defaultTemplate = ""
-	modifiedJSON    = "modified-template.json"
 )
 
 // postCmd represents the post command
@@ -38,21 +41,17 @@ var postCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		parseUserParameters() // parse all the '-p' user flags
+		readFilterFile()  // parse the ocm filters in file provided via '-f' flag
+		readTemplate()     // parse the given JSON template provided via '-t' flag
 
-		readTemplate() // parse the given JSON template provided via '-t' flag
-
-		// For every '-p' flag, replace its related placeholder in the template
-		for k, v := range templateParams {
-			replaceFlags(userParameterValues[k], "", userParameterNames[k], userParameterNames[k], "p", v)
+		// For every '-p' flag, replace its related placeholder in the template & filterFiles
+		for k := range userParameterNames {
+			replaceFlags(userParameterNames[k], userParameterValues[k])
 		}
 
-		// Check if there are any remaining placeholders in the template that are not replaced by a parameter
-		checkLeftovers()
-
-		dir := tempDir()
-		defer cleanup(dir)
-
-		newData := modifyTemplate(dir)
+		// Check if there are any remaining placeholders in the template that are not replaced by a parameter, 
+		// excluding '${CLUSTER_UUID}' which will be replaced for each cluster later
+		checkLeftovers([]string{"${CLUSTER_UUID}"})
 
 		// Create an OCM client to talk to the cluster API
 		// the user has to be logged in (e.g. 'ocm login')
@@ -63,25 +62,48 @@ var postCmd = &cobra.Command{
 			}
 		}()
 
-		// Use the OCM client to create the POST request
-		// send it as logservice and validate the response
-		request := createPostRequest(ocmClient, newData)
-
-		// If this is a dry-run, print the populated template
-		// but don't proceed further.
-		if isDryRun {
-			if err := printTemplate(newData); err != nil {
-				log.Errorf("Cannot read generated template: %q", err)
+		// Retrieve matching clusters
+		if filtersFromFile != "" {
+			if len(filterParams) != 0 {
+				log.Warnf("Search queries were passed using both the '-q' and '-f' flags. This will apply logical AND between the queries, potentially resulting in no matches")
 			}
+			filters := strings.Join(strings.Split(strings.TrimSpace(filtersFromFile), "\n"), " ")
+			filterParams = append(filterParams, filters)
+		}
+
+		clusters, err := applyFilters(ocmClient, filterParams)
+
+		if err != nil {
+			log.Fatalf("Cannot retrieve clusters: %q", err)
+		} else if len(clusters) < 1 {
+			log.Fatalf("No clusters match the given parameters.")
+		}
+
+		log.Infoln("The following clusters match the given parameters:")
+		if err := printClusters(clusters); err != nil {
+			log.Fatalf("Could not print matching clusters: %q", err)
+		}
+
+		log.Infoln("The following template will be sent:")
+		if err := printTemplate(); err != nil {
+				log.Errorf("Cannot read generated template: %q", err)
+		}
+
+		// If this is a dry-run, don't proceed further.
+		if isDryRun {
 			return
 		}
 
-		response := sendRequest(request)
-		check(response, dir)
+		if !skipPrompts {
+			if err = confirmSend(); err != nil {
+				log.Errorf("Error confirming message: %q", err)
+			}
+		}
 
-		err := dump.Pretty(os.Stdout, response.Bytes())
-		if err != nil {
-			log.Errorf("cannot print post command: %q", err)
+		for _, cluster := range clusters {
+			request, clusterMessage := createPostRequest(ocmClient, cluster.ExternalID())
+			response := sendRequest(request)
+			check(response, clusterMessage)
 		}
 	},
 }
@@ -91,54 +113,79 @@ func init() {
 	postCmd.Flags().StringVarP(&template, "template", "t", defaultTemplate, "Message template file or URL")
 	postCmd.Flags().StringArrayVarP(&templateParams, "param", "p", templateParams, "Specify a key-value pair (eg. -p FOO=BAR) to set/override a parameter value in the template.")
 	postCmd.Flags().BoolVarP(&isDryRun, "dry-run", "d", false, "Dry-run - print the service log about to be sent but don't send it.")
+	postCmd.Flags().StringArrayVarP(&filterParams, "query", "q", filterParams, "Specify a search query (eg. -q \"name like foo\") for a bulk-post to matching clusters.")
+	postCmd.Flags().BoolVarP(&skipPrompts, "yes", "y", false, "Skips all prompts.")
+	postCmd.Flags().StringArrayVarP(&filterFiles, "query-file", "f", filterFiles, "File containing search queries to apply. All lines in the file will be concatenated into a single query. If this flag is called multiple times, all every file's search query will be combined with logical AND.")
 }
 
 // parseUserParameters parse all the '-p FOO=BAR' parameters and checks for syntax errors
 func parseUserParameters() {
-	for k, v := range templateParams {
+	var queries []string // interpret all '-p CLUSTER_UUID' parameters as queries to be made to the ocmClient
+	for _, v := range templateParams {
 		if !strings.Contains(v, "=") {
 			log.Fatalf("Wrong syntax of '-p' flag. Please use it like this: '-p FOO=BAR'")
 		}
 
-		userParameterNames = append(userParameterNames, fmt.Sprintf("${%v}", strings.Split(v, "=")[0]))
-		userParameterValues = append(userParameterValues, strings.Split(v, "=")[1])
-
-		if userParameterValues[k] == "" {
+		param := strings.Split(v, "=")
+		if param[0] == "" || param[1] == "" {
 			log.Fatalf("Wrong syntax of '-p' flag. Please use it like this: '-p FOO=BAR'")
 		}
+
+		if param[0] != "CLUSTER_UUID" {
+			userParameterNames = append(userParameterNames, fmt.Sprintf("${%v}", param[0]))
+			userParameterValues = append(userParameterValues, param[1])
+		} else {
+			queries = append(queries, generateQuery(param[1]))
+		}
+	}
+
+	if len(queries) != 0 {
+		if len(filterParams) != 0 {
+			log.Warnf("At least one $CLUSTER_UUID parameter was passed with the '-q' flag. This will apply logical AND between the search query and the cluster(s) given, potentially resulting in no matches")
+		}
+		filterParams = append(filterParams, strings.Join(queries, " or "))
 	}
 }
 
-// accessTemplate checks if the provided template is currently accessible and returns an error
-func accessTemplate(template string) (err error) {
-
-	if template == "" {
-		log.Errorf("Template file is not provided. Use '-t' to fix this.")
+func confirmSend() error {
+	fmt.Print("Continue? (y/N): ")
+	reader := bufio.NewReader(os.Stdin)
+	responseBytes, _, err := reader.ReadLine()
+	if err != nil {
 		return err
 	}
+	response := strings.ToUpper(string(responseBytes))
 
-	if utils.FileExists(template) {
-		return err
+	if response != "Y" && response != "YES" {
+		if response != "N" && response != "NO" && response != "" {
+			log.Fatal("Invalid response, expected 'YES' or 'Y' (case-insensitive). ")
+		}
+		log.Fatalf("Exiting...")
 	}
+	return nil
+}
 
-	if utils.FolderExists(template) {
-		log.Errorf("the provided template %q is a directory, not a file!", template)
+// accessTemplate returns the contents of a local file or url, and any errors encountered
+func accessFile(filePath string) ([]byte, error) {
+	if utils.FileExists(filePath) {
+		file, err := ioutil.ReadFile(filePath) // template is file on the disk
+		if err != nil {
+			return file, fmt.Errorf("Cannot read the file.\nError: %q\n", err)
+		}
+		return file, nil
 	}
-
-	if utils.IsValidUrl(template) {
-		urlPage, _ := url.Parse(template)
+	if utils.FolderExists(filePath) {
+		return nil, fmt.Errorf("the provided path %q is a directory, not a file!", filePath)
+	}
+	if utils.IsValidUrl(filePath) {
+		urlPage, _ := url.Parse(filePath)
 		if err := utils.IsOnline(*urlPage); err != nil {
-			log.Errorf("host %q is not accessible", template)
+			return nil, fmt.Errorf("host %q is not accessible", filePath)
 		} else {
-			HTMLBody, err = utils.CurlThis(urlPage.String())
-			if err == nil {
-				isURL = true
-			}
-			return err
+			return utils.CurlThis(urlPage.String())
 		}
 	}
-	return fmt.Errorf("cannot read the template %q", template)
-
+	return nil, fmt.Errorf("cannot read the file %q", filePath)
 }
 
 // parseTemplate reads the template file into a JSON struct
@@ -146,166 +193,132 @@ func parseTemplate(jsonFile []byte) error {
 	return json.Unmarshal(jsonFile, &Message)
 }
 
-func parseGoodReply(jsonFile []byte) error {
-	return json.Unmarshal(jsonFile, &GoodReply)
-}
-
-func parseBadReply(jsonFile []byte) error {
-	return json.Unmarshal(jsonFile, &BadReply)
-}
-
+// readTemplate loads the template into the Message variable
 func readTemplate() {
-	if err := accessTemplate(template); err == nil { // check if this URL or file and if we can access it
-		var file []byte
-		if isURL {
-			// template is URL on the web
-			file = HTMLBody
-		} else {
-			// template is file on the disk
-			file, err = ioutil.ReadFile(template) // this works only for files
-			if err != nil {
-				log.Fatalf("Cannot not read the file.\nError: %q\n", err)
-			}
-		}
-
-		if err = parseTemplate(file); err != nil {
-			log.Fatalf("Cannot not parse the JSON template.\nError: %q\n", err)
-		}
-	} else {
-		log.Fatal(err)
+	if template == defaultTemplate {
+		log.Fatalf("Template file is not provided. Use '-t' to fix this.")
 	}
+
+	file, err := accessFile(template)
+        if err != nil { // check if this URL or file and if we can access it
+                log.Fatal(err)
+	}
+
+        if err = parseTemplate(file); err != nil {
+                log.Fatalf("Cannot not parse the JSON template.\nError: %q\n", err)
+        }
 }
 
-func checkLeftovers() {
-	unusedParameters, found := Message.FindLeftovers()
-	if found {
-		for _, v := range unusedParameters {
-			regex := strings.NewReplacer("${", "", "}", "")
-			log.Errorf("The selected template is using '%s' parameter, but '--%s' flag is not set for this one. Use '-%s %v=\"FOOBAR\"' to fix this.", v, "param", "p", regex.Replace(v))
-		}
-		if numberOfMissingParameters := len(unusedParameters); numberOfMissingParameters == 1 {
-			log.Fatal("Please define this missing parameter properly.")
-		} else {
-			log.Fatalf("Please define all %v missing parameters properly.", numberOfMissingParameters)
-		}
+func readFilterFile() {
+	if len(filterFiles) < 1 {
+		// No filterFiles specified in args
+		return
 	}
-}
 
-func replaceFlags(flagName, flagDefaultValue, flagParameter, flagLongName, flagShorthand, parameter string) {
-	if err := strings.Compare(flagName, flagDefaultValue); err == 0 {
-		// The user didn't set the flag. Check if the template is using the flag.
-		if found := Message.SearchFlag(flagParameter); found == true {
-			log.Fatalf("The selected template is using '%s' parameter, but '%s' flag was not set. Use '-%s' to fix this.", flagParameter, flagLongName, flagShorthand)
-		}
-	} else {
-		// The user set the flag. Check if the template is using the flag.
-		if found := Message.SearchFlag(flagParameter); found == false {
-			log.Fatalf("The selected template is not using '%s' parameter, but '--%s' flag was set. Do not use '-%s %s' to fix this.", flagParameter, "param", flagShorthand, parameter)
-		}
-		Message.ReplaceWithFlag(flagParameter, flagName)
-	}
-}
-
-func tempDir() (dir string) {
-	if dirPath, err := os.Getwd(); err != nil {
-		log.Error(err)
-	} else {
-		dir, err = ioutil.TempDir(dirPath, "servicelog-")
+	for _, filterFile := range filterFiles {
+		fileContents, err := accessFile(filterFile)
 		if err != nil {
 			log.Fatal(err)
 		}
+
+		if filtersFromFile == "" {
+			filtersFromFile = "(" + strings.TrimSpace(string(fileContents)) + ")"
+		} else {
+			filtersFromFile = filtersFromFile + " and (" + strings.TrimSpace(string(fileContents)) + ")"
+		}
 	}
-	return dir
 }
 
-func modifyTemplate(dir string) (newData string) {
-	// Write the modified file
-	newData = filepath.Join(dir, modifiedJSON)
-	if err := utils.CreateFile(newData); err == nil {
-		file, err := os.Create(newData)
-		if err != nil {
-			log.Fatalf("Cannot overwrite file %q", err)
-		}
-		defer file.Close()
-
-		// Create the corrected JSON
-		s, _ := json.MarshalIndent(Message, "", "\t")
-		if _, err := file.WriteString(string(s)); err != nil {
-			log.Fatalf("Cannot write the new modified template %q", err)
-		}
-	} else {
-		log.Fatalf("Cannot create file %q", err)
+// Simple helper to determine if a string is present in a slice
+func contains(a []string, s string) bool {
+	for _, v := range a {
+		if v == s { return true }
 	}
-	return newData
+	return false
 }
 
-func printTemplate(filePath string) error {
-	contents, err := ioutil.ReadFile(filePath)
+func FindLeftovers(s string) (matches []string) {
+        r := regexp.MustCompile(`\${[^{}]*}`)
+        matches = r.FindAllString(s, -1)
+        return matches
+}
+
+
+func checkLeftovers(excludes []string) {
+	unusedParameters, _ := Message.FindLeftovers()
+	unusedParameters = append(unusedParameters, FindLeftovers(filtersFromFile)...)
+	
+	var numberOfMissingParameters int
+	for _, v := range unusedParameters {
+		// Ignore parameters in the exclude list, ie ${CLUSTER_UUID}, which will be replaced later for each cluster a servicelog is sent to
+		if !contains(excludes, v){
+			numberOfMissingParameters++
+			regex := strings.NewReplacer("${", "", "}", "")
+			log.Errorf("The one of the template files is using '%s' parameter, but '--param' flag is not set for this one. Use '-p %v=\"FOOBAR\"' to fix this.", v, regex.Replace(v))
+		}
+	}
+	if numberOfMissingParameters == 1 {
+		log.Fatal("Please define this missing parameter properly.")
+	} else if numberOfMissingParameters > 1 {
+		log.Fatalf("Please define all %v missing parameters properly.", numberOfMissingParameters)
+	}
+}
+
+func replaceFlags(flagName string, flagValue string) {
+	if flagValue == "" {
+		log.Fatalf("The selected template is using '%s' parameter, but '%s' flag was not set. Use '-p %s=\"FOOBAR\"' to fix this.", flagName)
+	}
+
+	found := false
+	if Message.SearchFlag(flagName) {
+		found = true
+		Message.ReplaceWithFlag(flagName, flagValue)
+	}
+	if strings.Contains(filtersFromFile, flagName) {
+		found = true
+		filtersFromFile = strings.ReplaceAll(filtersFromFile, flagName, flagValue)
+	} 
+
+	if !found {
+		log.Fatalf("The selected template is not using '%[1]s' parameter, but '--param' flag was set. Do not use '-p %[1]s=%[2]s' to fix this.", flagName, flagValue)
+	}
+}
+
+func printClusters(clusters []*v1.Cluster) (err error){
+	table := printer.NewTablePrinter(os.Stdout, 20, 1, 3, ' ')
+	table.AddRow([]string{"Name", "ID", "State", "Version", "Cloud Provider", "Region"})
+	for _, cluster := range clusters {
+		table.AddRow([]string{cluster.DisplayName(), cluster.ID(), string(cluster.State()), cluster.OpenshiftVersion(), cluster.CloudProvider().ID(), cluster.Region().ID()})
+	}
+
+	// Add empty row for readability
+	table.AddRow([]string{})
+	return table.Flush()
+}
+
+func printTemplate() (err error) {
+	exampleMessage, err := json.Marshal(Message)
 	if err != nil {
 		return err
 	}
-	return dump.Pretty(os.Stdout, contents)
+	return dump.Pretty(os.Stdout, exampleMessage)
 }
 
-func createPostRequest(ocmClient *sdk.Connection, newData string) *sdk.Request {
+func createPostRequest(ocmClient *sdk.Connection, clusterId string) (request *sdk.Request, clusterMessage servicelog.Message) {
 	// Create and populate the request:
-	request := ocmClient.Post()
+	request = ocmClient.Post()
 	err := arguments.ApplyPathArg(request, targetAPIPath)
 	if err != nil {
 		log.Fatalf("Can't parse API path '%s': %v\n", targetAPIPath, err)
 	}
-	var empty []string
-	arguments.ApplyParameterFlag(request, empty)
-	arguments.ApplyHeaderFlag(request, empty)
-	err = arguments.ApplyBodyFlag(request, newData)
+
+	clusterMessage = Message
+	clusterMessage.ReplaceWithFlag("${CLUSTER_UUID}", clusterId)
+	messageBytes, err := json.Marshal(clusterMessage)
 	if err != nil {
-		log.Fatalf("Can't read body: %v", err)
-	}
-	return request
-}
-
-func validateGoodResponse(body []byte) {
-	if err := parseGoodReply(body); err != nil {
-		log.Fatalf("Cannot not parse the JSON template.\nError: %q\n", err)
+		log.Fatalf("Cannot marshal template to json: %s", err)
 	}
 
-	severity := GoodReply.Severity
-	if severity != Message.Severity {
-		log.Fatalf("Message sent, but wrong severity information was passed (wanted %q, got %q)", Message.Severity, severity)
-	}
-	serviceName := GoodReply.ServiceName
-	if serviceName != Message.ServiceName {
-		log.Fatalf("Message sent, but wrong service_name information was passed (wanted %q, got %q)", Message.ServiceName, serviceName)
-	}
-	clusteruuid := GoodReply.ClusterUUID
-	if clusteruuid != Message.ClusterUUID {
-		log.Fatalf("Message sent, but to different cluster (wanted %q, got %q)", Message.ClusterUUID, clusteruuid)
-	}
-	summary := GoodReply.Summary
-	if summary != Message.Summary {
-		log.Fatalf("Message sent, but wrong summary information was passed (wanted %q, got %q)", Message.Summary, summary)
-	}
-	description := GoodReply.Description
-	if description != Message.Description {
-		log.Fatalf("Message sent, but wrong description information was passed (wanted %q, got %q)", Message.Description, description)
-	}
-	if ok := json.Valid(body); !ok {
-		log.Fatalf("Server returned invalid JSON")
-	}
-}
-
-func validateBadResponse(body []byte) {
-	if ok := json.Valid(body); !ok {
-		log.Errorf("Server returned invalid JSON")
-	}
-
-	if err := parseBadReply(body); err != nil {
-		log.Fatalf("Cannot parse the error JSON message %q", err)
-	}
-}
-
-func cleanup(dir string) {
-	if err := os.RemoveAll(dir); err != nil {
-		log.Errorf("Cannot clean up %q", err)
-	}
+	request.Bytes(messageBytes)
+	return request, clusterMessage
 }

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/api v0.18.5
 	k8s.io/apimachinery v0.18.5


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-7691

These changes introduce the ability to apply servicelog commands to multiple clusters at once using ocm's search capability.

---

For the `servicelog post` subcommand, there are two ways to filter clusters. Using the `-q` flag allows you to query OCM directly for ad hoc filtering:
```
$ osdctl servicelog post -q "name like 'foo%'" -t ...
```

Using the `-f` flag allows you to specify predefined filters located on disk or from a URL:
```
$ osdctl servicelog post -f "~/workspace/managed-notifications/cluster/clusterIsCCS.txt" ...

$ osdctl servicelog post -f "https://raw.githubusercontent.com/tnierman/managed-notifications/OSD-7691/cluster/clusterIsCCS.txt" ... 
```
These filter files also act as templates:
```
$ osdctl servicelog post -f "https://github.com/tnierman/managed-notifications/blob/OSD-7691/cluster/clusterVersionLessThanEqualTo.txt" -p CLUSTER_VERSION=4.6.0 ...
```

Invoking `-f` more than once joins the queries with logical AND, meaning these filters can be combined to create extremely granular queries: 
```
$ osdctl servicelog post -f https://raw.githubusercontent.com/tnierman/managed-notifications/OSD-7691/cluster/clusterIsErrored.txt -f https://raw.githubusercontent.com/tnierman/managed-notifications/OSD-7691/cluster/clusterIsPrivateLink.txt -t ...
```

---

Listing also applies to multiple clusters:
```
$ osdctl servicelog list foo%
```
Will return all clusters who's names, internal IDs, or external IDs begin with `foo`. 

```
$ osdctl servicelog list foo
```
Will return all clusters who's names, internal IDs, or external IDs match `foo`. 

```
$ osdctl servicelog list foo bar
```
Will return all clusters who's names, internal IDs, or external IDs match `foo` or `bar`.