### PR TITLE
OSD-7691 - Apply service log command to multiple clusters

### DIFF
--- a/cmd/servicelog/common.go
+++ b/cmd/servicelog/common.go
@@ -34,9 +34,9 @@ func createConnection() *sdk.Connection {
 	return connection
 }
 
-// generateClusterQuery returns an OCM search query to identify a cluster
+// generateQuery returns an OCM search query to retrieve all clusters matching an expression (ie- "foo%")
 func generateQuery(clusterIdentifier string) string {
-	return "id is '" + clusterIdentifier + "' or external_id is '" + clusterIdentifier + "' or display_name i  s '" + clusterIdentifier + "'"
+	return strings.TrimSpace(fmt.Sprintf("id like '%[1]s' or external_id like '%[1]s' or display_name like '%[1]s'", clusterIdentifier))
 }
 
 // getFilteredClusters retrieves clusters in OCM which match the filters given

--- a/cmd/servicelog/common.go
+++ b/cmd/servicelog/common.go
@@ -1,17 +1,20 @@
 package servicelog
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	sdk "github.com/openshift-online/ocm-sdk-go"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/osdctl/internal/servicelog"
 	log "github.com/sirupsen/logrus"
 )
 
 var (
-	templateParams, userParameterNames, userParameterValues []string
-	isURL                                                   bool
-	HTMLBody                                                []byte
+	templateParams, userParameterNames, userParameterValues, filterParams []string
+	HTMLBody                                                              []byte
 )
 
 const (
@@ -31,6 +34,41 @@ func createConnection() *sdk.Connection {
 	return connection
 }
 
+// generateClusterQuery returns an OCM search query to identify a cluster
+func generateQuery(clusterIdentifier string) string {
+	return "id is '" + clusterIdentifier + "' or external_id is '" + clusterIdentifier + "' or display_name i  s '" + clusterIdentifier + "'"
+}
+
+// getFilteredClusters retrieves clusters in OCM which match the filters given
+func applyFilters(ocmClient *sdk.Connection, filters []string) ([]*v1.Cluster, error) {
+	if len(filters) < 1 {
+		return nil, nil
+	}
+
+	for k, v := range filters {
+		filters[k] = fmt.Sprintf("(%s)", v)
+	}
+
+	requestSize := 50
+	request := ocmClient.ClustersMgmt().V1().Clusters().List().Search(strings.Join(filters, " and ")).Size(requestSize)
+	response, err := request.Send()
+	if err != nil {
+		return nil, err
+	}
+
+	items := response.Items().Slice()
+	for response.Size() >= requestSize {
+		request.Page(response.Page() + 1)
+		response, err = request.Send()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, response.Items().Slice()...)
+	}
+
+	return items, err
+}
+
 func sendRequest(request *sdk.Request) *sdk.Response {
 	response, err := request.Send()
 	if err != nil {
@@ -39,19 +77,54 @@ func sendRequest(request *sdk.Request) *sdk.Response {
 	return response
 }
 
-func check(response *sdk.Response, dir string) {
-	status := response.Status()
-
+func check(response *sdk.Response, clusterMessage servicelog.Message) {
 	body := response.Bytes()
-
-	if status < 400 {
-		validateGoodResponse(body)
-		log.Info("Message has been successfully sent")
-
+	if response.Status() < 400 {
+		validateGoodResponse(body, clusterMessage)
+		log.Infof("Message has been successfully sent to %s\n", clusterMessage.ClusterUUID)
 	} else {
-		validateBadResponse(body)
-		cleanup(dir)
-		log.Fatalf("Failed to post message because of %q", BadReply.Reason)
-
+		badReply := validateBadResponse(body)
+		log.Fatalf("Failed to post message because of %q", badReply.Reason)
 	}
+}
+
+func validateGoodResponse(body []byte, clusterMessage servicelog.Message) servicelog.GoodReply {
+	var goodReply servicelog.GoodReply
+	if err := json.Unmarshal(body, &goodReply); err != nil {
+		log.Fatalf("Cannot not parse the JSON template.\nError: %q\n", err)
+	}
+
+	if goodReply.Severity != clusterMessage.Severity {
+		log.Fatalf("Message sent, but wrong severity information was passed (wanted %q, got %q)", clusterMessage.Severity, goodReply.Severity)
+	}
+	if goodReply.ServiceName != clusterMessage.ServiceName {
+		log.Fatalf("Message sent, but wrong service_name information was passed (wanted %q, got %q)", clusterMessage.ServiceName, goodReply.ServiceName)
+	}
+	if goodReply.ClusterUUID != clusterMessage.ClusterUUID {
+		log.Fatalf("Message sent, but to different cluster (wanted %q, got %q)", clusterMessage.ClusterUUID, goodReply.ClusterUUID)
+	}
+	if goodReply.Summary != clusterMessage.Summary {
+		log.Fatalf("Message sent, but wrong summary information was passed (wanted %q, got %q)", clusterMessage.Summary, goodReply.Summary)
+	}
+	if goodReply.Description != clusterMessage.Description {
+		log.Fatalf("Message sent, but wrong description information was passed (wanted %q, got %q)", clusterMessage.Description, goodReply.Description)
+	}
+	if !json.Valid(body) {
+		log.Fatalf("Server returned invalid JSON")
+	}
+
+	return goodReply
+}
+
+func validateBadResponse(body []byte) servicelog.BadReply {
+	if ok := json.Valid(body); !ok {
+		log.Errorf("Server returned invalid JSON")
+	}
+
+	var badReply servicelog.BadReply
+	if err := json.Unmarshal(body, &badReply); err != nil {
+		log.Fatalf("Cannot parse the error JSON message %q", err)
+	}
+
+	return badReply
 }

--- a/cmd/servicelog/list.go
+++ b/cmd/servicelog/list.go
@@ -62,8 +62,7 @@ func init() {
 
 func getClusters(ocmClient *sdk.Connection, clusterIds []string) []*v1.Cluster {
 	for i, id := range clusterIds {
-		clusterIds[i] = fmt.Sprintf(`display_name like '%[1]s' or name like '%[1]s' or id like '%[1]s' or external_id like '%[1]s'`, id)
-		clusterIds[i] = strings.TrimSpace(clusterIds[i])
+		clusterIds[i] = generateQuery(id)
 	}
 
 	clusters, err := applyFilters(ocmClient, []string{strings.Join(clusterIds, " or ")})

--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -115,7 +115,7 @@ func init() {
 	postCmd.Flags().BoolVarP(&isDryRun, "dry-run", "d", false, "Dry-run - print the service log about to be sent but don't send it.")
 	postCmd.Flags().StringArrayVarP(&filterParams, "query", "q", filterParams, "Specify a search query (eg. -q \"name like foo\") for a bulk-post to matching clusters.")
 	postCmd.Flags().BoolVarP(&skipPrompts, "yes", "y", false, "Skips all prompts.")
-	postCmd.Flags().StringArrayVarP(&filterFiles, "query-file", "f", filterFiles, "File containing search queries to apply. All lines in the file will be concatenated into a single query. If this flag is called multiple times, all every file's search query will be combined with logical AND.")
+	postCmd.Flags().StringArrayVarP(&filterFiles, "query-file", "f", filterFiles, "File containing search queries to apply. All lines in the file will be concatenated into a single query. If this flag is called multiple times, every file's search query will be combined with logical AND.")
 }
 
 // parseUserParameters parse all the '-p FOO=BAR' parameters and checks for syntax errors


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/OSD-7691
Relates to: https://github.com/openshift/managed-notifications/pull/72
Obsoletes: https://github.com/openshift/managed-notifications/pull/62

These changes introduce the ability to apply servicelog commands to multiple clusters at once using ocm's search capability.

---

For the `servicelog post` subcommand, there are several ways to filter clusters. 

Using the `-q` flag allows you to query OCM directly for ad hoc filtering:
```
$ osdctl servicelog post -q "name like 'foo%'" -t ...
```

Using the `-f` flag allows you to specify predefined filters located on disk or from a URL:
```
$ osdctl servicelog post -f "~/workspace/managed-notifications/cluster/clusterIsCCS.txt" ...

$ osdctl servicelog post -f "https://raw.githubusercontent.com/tnierman/managed-notifications/OSD-7691/cluster/clusterIsCCS.txt" ... 
```
These filter files also act as templates:
```
$ osdctl servicelog post -f "https://github.com/tnierman/managed-notifications/blob/OSD-7691/cluster/clusterVersionLessThanEqualTo.txt" -p CLUSTER_VERSION=4.6.0 ...
```

Invoking `-f` more than once joins the queries with logical AND, meaning these filters can be combined to create extremely granular queries: 
```
$ osdctl servicelog post -f https://raw.githubusercontent.com/tnierman/managed-notifications/OSD-7691/cluster/clusterIsErrored.txt -f https://raw.githubusercontent.com/tnierman/managed-notifications/OSD-7691/cluster/clusterIsPrivateLink.txt -t ...
```

Finally, similarly named clusters can be selected simultaneously using wildcards with the `-p` flag: 
```
$ osdctl servicelog post -p "CLUSTER_UUID=foo%" -t ...
```

---

Listing also applies to multiple clusters:
```
$ osdctl servicelog list foo%
```
Will return all clusters who's names, internal IDs, or external IDs begin with `foo`. 

```
$ osdctl servicelog list foo
```
Will return all clusters who's names, internal IDs, or external IDs match `foo`. 

```
$ osdctl servicelog list foo bar
```
Will return all clusters who's names, internal IDs, or external IDs match `foo` or `bar`.