### PR TITLE
Use the new `SupportRoleArn` field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,15 @@ fmt:
 	@gofmt -w -s .
 	@git diff --exit-code .
 
-OS := $(shell go env GOOS | sed 's/[a-z]/\U&/')
+OS := $(shell go env GOOS)
 .PHONY: download-goreleaser
 download-goreleaser:
-	mkdir -p ./bin && curl -sSLf https://github.com/goreleaser/goreleaser/releases/latest/download/goreleaser_${OS}_x86_64.tar.gz -o - | tar --extract --gunzip --directory ./bin goreleaser
+	@if [ "${OS}" = "darwin" ]; then\
+		mkdir -p ./bin && curl -sSLf https://github.com/goreleaser/goreleaser/releases/latest/download/goreleaser_Darwin_all.tar.gz -o - | tar --extract --gunzip --directory ./bin goreleaser;\
+	fi
+	@if [ "${OS}" = "linux" ]; then\
+    		mkdir -p ./bin && curl -sSLf https://github.com/goreleaser/goreleaser/releases/latest/download/goreleaser_Linux_x86_64.tar.gz -o - | tar --extract --gunzip --directory ./bin goreleaser;\
+    fi
 
 # CI build containers don't include goreleaser by default,
 # so they need to get it first, and then run the build

--- a/cmd/account/cli.go
+++ b/cmd/account/cli.go
@@ -89,7 +89,7 @@ func (o *cliOptions) run() error {
 				o.k8sclusterresourcefactory.AccountID,
 				o.k8sclusterresourcefactory.Awscloudfactory.RoleName)))
 		if err != nil {
-			klog.Error("Failed to assume BYOC role. Customer either deleted role or denied SREP access")
+			klog.Error("Failed to assume ManagedOpenShiftSupport role. Customer either deleted role or denied SREP access")
 			return err
 		}
 	}

--- a/cmd/account/console.go
+++ b/cmd/account/console.go
@@ -83,7 +83,7 @@ func (o *consoleOptions) run() error {
 		aws.String(o.k8sclusterresourcefactory.Awscloudfactory.SessionName), aws.String(fmt.Sprintf("arn:aws:iam::%s:role/%s",
 			o.k8sclusterresourcefactory.AccountID, o.k8sclusterresourcefactory.Awscloudfactory.RoleName)))
 	if err != nil {
-		fmt.Fprintf(o.IOStreams.Out, "Generating console failed. If CCS cluster, customer removed or denied access to the BYOC role.")
+		fmt.Fprintf(o.IOStreams.Out, "Generating console failed. If CCS cluster, customer removed or denied access to the ManagedOpenShiftSupport role.")
 		return err
 	}
 	fmt.Fprintf(o.IOStreams.Out, "The AWS Console URL is:\n%s\n", consoleURL)

--- a/cmd/account/generate-secret.go
+++ b/cmd/account/generate-secret.go
@@ -275,8 +275,8 @@ func (o *generateSecretOptions) generateCcsSecret() error {
 		return err
 	}
 
-	// Role chain to assume BYOCAdminAccessRole-{uid}
-	roleArn := aws.String(fmt.Sprintf("arn:aws:iam::%s:role/%s", account.Spec.AwsAccountID, "BYOCAdminAccess-"+accountIDSuffixLabel))
+	// Role chain to assume ManagedOpenShift-Support-{uid}
+	roleArn := aws.String(fmt.Sprintf("arn:aws:iam::%s:role/%s", account.Spec.AwsAccountID, "ManagedOpenShift-Support-"+accountIDSuffixLabel))
 	credentials, err := awsprovider.GetAssumeRoleCredentials(srepRoleClient, aws.Int64(900),
 		callerIdentityOutput.UserId, roleArn)
 	if err != nil {

--- a/cmd/account/rotate-secret.go
+++ b/cmd/account/rotate-secret.go
@@ -146,8 +146,8 @@ func (o *rotateSecretOptions) run() error {
 			return err
 		}
 
-		// Role chain to assume BYOCAdminAccessRole-{uid}
-		roleArn := aws.String(fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, "BYOCAdminAccess-"+accountIDSuffixLabel))
+		// Role chain to assume ManagedOpenShift-Support-{uid}
+		roleArn := aws.String(fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, "ManagedOpenShift-Support-"+accountIDSuffixLabel))
 		credentials, err = awsprovider.GetAssumeRoleCredentials(srepRoleClient, aws.Int64(900),
 			callerIdentityOutput.UserId, roleArn)
 		if err != nil {

--- a/cmd/cluster/health.go
+++ b/cmd/cluster/health.go
@@ -122,7 +122,7 @@ func (o *healthOptions) run() error {
 				o.k8sclusterresourcefactory.AccountID,
 				o.k8sclusterresourcefactory.Awscloudfactory.RoleName)))
 		if err != nil {
-			klog.Error("Failed to assume BYOC role. Customer either deleted role or denied SREP access.")
+			klog.Error("Failed to assume ManagedOpenShiftSupport role. Customer either deleted role or denied SREP access.")
 			return err
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openshift-online/ocm-sdk-go v0.1.152
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/aws-account-operator/pkg/apis v0.0.0-20210611151019-01b1df7a3e9e
-	github.com/openshift/gcp-project-operator v0.0.0-20210818135501-58ea50451037
+	github.com/openshift/gcp-project-operator v0.0.0-20210906153132-ce9b2425f1a7
 	github.com/openshift/hive v1.0.5
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1802,8 +1802,8 @@ github.com/openshift/cluster-api-provider-openstack v0.0.0-20200526112135-319a35
 github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20200504092944-27473ea1ae43/go.mod h1:Vl/bvZulLw6PdUADIFWGfoTWH1O4L1B80eN7BtLYEuo=
 github.com/openshift/cluster-autoscaler-operator v0.0.0-20190521201101-62768a6ba480/go.mod h1:/XmV44Fh28Vo3Ye93qFrxAbcFJ/Uy+7LPD+jGjmfJYc=
 github.com/openshift/cluster-version-operator v3.11.1-0.20190629164025-08cac1c02538+incompatible/go.mod h1:0BbpR1mrN0F2ZRae5N1XHcytmkvVPaeKgSQwRRBWugc=
-github.com/openshift/gcp-project-operator v0.0.0-20210818135501-58ea50451037 h1:CJAy9YlhmToXZSJfQAK7VwBi8ueNEhZ4XvaH/oMAQ7E=
-github.com/openshift/gcp-project-operator v0.0.0-20210818135501-58ea50451037/go.mod h1:uRHPXMMwiVBYQuU6LhPPxIPuviT2UCs5H+huZecOXfs=
+github.com/openshift/gcp-project-operator v0.0.0-20210906153132-ce9b2425f1a7 h1:WMmBsiQxBGTKA2Lck4/aWzyNzoUqZrweBls3ugfNjI4=
+github.com/openshift/gcp-project-operator v0.0.0-20210906153132-ce9b2425f1a7/go.mod h1:uRHPXMMwiVBYQuU6LhPPxIPuviT2UCs5H+huZecOXfs=
 github.com/openshift/generic-admission-server v1.14.0/go.mod h1:GD9KN/W4KxqRQGVMbqQHpHzb2XcQVvLCaBaSciqXvfM=
 github.com/openshift/hive v1.0.5 h1:QWqdPR2H+Hb4FqgBBeX7EkQrpf04SPm+re1BW5uki00=
 github.com/openshift/hive v1.0.5/go.mod h1:X2NIeZ7/2yXEXYPIgsKkLDmu3bFm+fnTn331uAR1QVE=

--- a/pkg/k8s/clusterresourcefactory.go
+++ b/pkg/k8s/clusterresourcefactory.go
@@ -173,7 +173,7 @@ func (factory *ClusterResourceFactoryOptions) GetCloudProvider(verbose bool) (aw
 			klog.Error("Unexpected error parsing the account CR suffix")
 			return nil, fmt.Errorf("Unexpected error parsing the account CR suffix")
 		}
-		factory.Awscloudfactory.RoleName = fmt.Sprintf("BYOCAdminAccess-%s", acctSuffix)
+		factory.Awscloudfactory.RoleName = fmt.Sprintf("ManagedOpenShift-Support-%s", acctSuffix)
 
 		// Get STS Credentials
 		if verbose {


### PR DESCRIPTION
Update osdctl to use the new `SupportRoleArn` field for all account access requests that are via a cluster (basically any osdctl account [cli|console] call that doesn't use the -i [aws account id] flag.

https://issues.redhat.com/browse/OSD-8367