### PR TITLE
OSD-8714 - Automate STS diff in osdctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,15 @@ aws_account_operator_total_accounts_crs_claimed{name="aws-account-operator"} => 
 ......
 ```
 
+### Get cluster policy and policy-diff
+
+`policy` command saves the crs files in /tmp/crs- directory for given `x.y.z` release version. `policy-diff` command, in addition, compares the files of directories and outputs the diff.
+
+```bash
+osdctl sts policy <OCP version>
+osdctl sts policy-diff <old version> <new version>
+```
+
 ### Hive ClusterDeployment CR list
 
 ```bash

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/osdctl/cmd/federatedrole"
 	"github.com/openshift/osdctl/cmd/network"
 	"github.com/openshift/osdctl/cmd/servicelog"
+	"github.com/openshift/osdctl/cmd/sts"
 )
 
 // GitCommit is the short git commit hash from the environment
@@ -75,6 +76,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	rootCmd.AddCommand(network.NewCmdNetwork(streams, kubeFlags))
 	rootCmd.AddCommand(newCmdMetrics(streams, kubeFlags))
 	rootCmd.AddCommand(servicelog.NewCmdServiceLog())
+	rootCmd.AddCommand(sts.NewCmdSts(streams, kubeFlags))
 
 	// add docs command
 	rootCmd.AddCommand(newCmdDocs(streams))

--- a/cmd/sts/cmd.go
+++ b/cmd/sts/cmd.go
@@ -1,0 +1,25 @@
+package sts
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+// NewCmdClusterHealth implements the base cluster health command
+func NewCmdSts(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	clusterCmd := &cobra.Command{
+		Use:               "sts",
+		Short:             "STS related utilities",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		Run:               help,
+	}
+
+	clusterCmd.AddCommand(newCmdPolicyDiff(streams, flags))
+	clusterCmd.AddCommand(newCmdPolicy(streams, flags))
+	return clusterCmd
+}
+
+func help(cmd *cobra.Command, _ []string) {
+	cmd.Help()
+}

--- a/cmd/sts/policy.go
+++ b/cmd/sts/policy.go
@@ -1,0 +1,85 @@
+package sts
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/osdctl/pkg/k8s"
+)
+
+type policyOptions struct {
+	ReleaseVersion string
+
+	flags *genericclioptions.ConfigFlags
+	genericclioptions.IOStreams
+	kubeCli client.Client
+}
+
+func newPolicyOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *policyOptions {
+	return &policyOptions{
+		flags:     flags,
+		IOStreams: streams,
+	}
+}
+
+func newCmdPolicy(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	ops := newPolicyOptions(streams, flags)
+	policyCmd := &cobra.Command{
+		Use:               "policy",
+		Short:             "Get OCP STS policy",
+		Args:              cobra.ExactArgs(1),
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd, args))
+			cmdutil.CheckErr(ops.run(args))
+		},
+	}
+
+	policyCmd.Flags().StringVarP(&ops.ReleaseVersion, "release-version", "r", "", "")
+
+	return policyCmd
+}
+
+func (o *policyOptions) complete(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return cmdutil.UsageErrorf(cmd, "Release version is required for policy command")
+	}
+
+	re := regexp.MustCompile(`^[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}$`)
+	if !re.MatchString(args[0]) {
+		return cmdutil.UsageErrorf(cmd, "Release version have to be in the x.y.z format ")
+	}
+
+	// only initialize kubernetes client when versions are set
+	if o.ReleaseVersion != "" {
+		var err error
+		o.kubeCli, err = k8s.NewClient(o.flags)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o *policyOptions) run(args []string) error {
+	// save crs files in /tmp/crs- dir for given release version
+	crs := "oc adm release extract quay.io/openshift-release-dev/ocp-release:" + args[0] + "-x86_64 --credentials-requests --cloud=aws --to=/tmp/crs-" + args[0]
+	_, err := exec.Command("bash", "-c", crs).Output()
+	if err != nil {
+		fmt.Print(err)
+		return err
+	}
+
+	output := "OCP STS policy files have been saved in /tmp/crs-" + args[0] + " directory"
+	fmt.Println(output)
+
+	return nil
+}

--- a/cmd/sts/policydiff.go
+++ b/cmd/sts/policydiff.go
@@ -1,0 +1,92 @@
+package sts
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+
+	"github.com/spf13/cobra"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/osdctl/pkg/k8s"
+)
+
+type policyDiffOptions struct {
+	oldReleaseVersion string
+	newReleaseVersion string
+
+	flags *genericclioptions.ConfigFlags
+	genericclioptions.IOStreams
+	kubeCli client.Client
+}
+
+func newPolicyDiffOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *policyDiffOptions {
+	return &policyDiffOptions{
+		flags:     flags,
+		IOStreams: streams,
+	}
+}
+
+func newCmdPolicyDiff(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	ops := newPolicyDiffOptions(streams, flags)
+	policyDiffCmd := &cobra.Command{
+		Use:               "policy-diff",
+		Short:             "Get diff between two versions of OCP STS policy",
+		Args:              cobra.ExactArgs(2),
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd, args))
+			cmdutil.CheckErr(ops.run(args))
+		},
+	}
+
+	policyDiffCmd.Flags().StringVarP(&ops.oldReleaseVersion, "old-version", "o", "", "")
+	policyDiffCmd.Flags().StringVarP(&ops.newReleaseVersion, "new-version", "n", "", "")
+
+	return policyDiffCmd
+}
+
+func (o *policyDiffOptions) complete(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return cmdutil.UsageErrorf(cmd, "Old and new release version is required for policy-diff command")
+	}
+
+	for _, s := range args {
+		re := regexp.MustCompile(`^[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}$`)
+		if !re.MatchString(s) {
+			return cmdutil.UsageErrorf(cmd, "Release version have to be in the x.y.z format ")
+		}
+	}
+
+	// only initialize kubernetes client when versions are set
+	if o.oldReleaseVersion != "" && o.newReleaseVersion != "" {
+		var err error
+		o.kubeCli, err = k8s.NewClient(o.flags)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o *policyDiffOptions) run(args []string) error {
+	// save crs files in /tmp/crs- dirs for each release version
+	for _, s := range args {
+		crs := "oc adm release extract quay.io/openshift-release-dev/ocp-release:" + s + "-x86_64 --credentials-requests --cloud=aws --to=/tmp/crs-" + s
+		_, err := exec.Command("bash", "-c", crs).Output()
+		if err != nil {
+			fmt.Print(err)
+			return err
+		}
+	}
+
+	diff := "diff /tmp/crs-" + string(args[0]) + " /tmp/crs-" + string(args[1])
+	output, _ := exec.Command("bash", "-c", diff).Output()
+	fmt.Println(string(output))
+
+	return nil
+}


### PR DESCRIPTION
OSDCTL can output diff between two versions of OCP STS policy or the current permission set of a version of OCP.
Resolves: https://issues.redhat.com/browse/OSD-8714