### PR TITLE
chore(docs): run `osdctl docs ./docs/command/`

### DIFF
--- a/docs/command/osdctl.md
+++ b/docs/command/osdctl.md
@@ -32,7 +32,9 @@ osdctl [flags]
 
 ### SEE ALSO
 
+* [osdctl aao](osdctl_aao.md)	 - AWS Account Operator Debugging Utilities
 * [osdctl account](osdctl_account.md)	 - AWS Account related utilities
+* [osdctl cluster](osdctl_cluster.md)	 - Provides vitals of an AWS cluster
 * [osdctl clusterdeployment](osdctl_clusterdeployment.md)	 - cluster deployment related utilities
 * [osdctl completion](osdctl_completion.md)	 - Output shell completion code for the specified shell (bash or zsh)
 * [osdctl cost](osdctl_cost.md)	 - Cost Management related utilities
@@ -41,4 +43,5 @@ osdctl [flags]
 * [osdctl network](osdctl_network.md)	 - network related utilities
 * [osdctl options](osdctl_options.md)	 - Print the list of flags inherited by all commands
 * [osdctl servicelog](osdctl_servicelog.md)	 - OCM/Hive Service log
+* [osdctl sts](osdctl_sts.md)	 - STS related utilities
 

--- a/docs/command/osdctl_aao.md
+++ b/docs/command/osdctl_aao.md
@@ -1,15 +1,15 @@
-## osdctl options
+## osdctl aao
 
-Print the list of flags inherited by all commands
+AWS Account Operator Debugging Utilities
 
 ```
-osdctl options
+osdctl aao [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for options
+  -h, --help   help for aao
 ```
 
 ### Options inherited from parent commands
@@ -34,4 +34,5 @@ osdctl options
 ### SEE ALSO
 
 * [osdctl](osdctl.md)	 - OSD CLI
+* [osdctl aao pool](osdctl_aao_pool.md)	 - Get the status of the AWS Account Operator AccountPool
 

--- a/docs/command/osdctl_aao_pool.md
+++ b/docs/command/osdctl_aao_pool.md
@@ -1,15 +1,15 @@
-## osdctl options
+## osdctl aao pool
 
-Print the list of flags inherited by all commands
+Get the status of the AWS Account Operator AccountPool
 
 ```
-osdctl options
+osdctl aao pool [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for options
+  -h, --help   help for pool
 ```
 
 ### Options inherited from parent commands
@@ -33,5 +33,5 @@ osdctl options
 
 ### SEE ALSO
 
-* [osdctl](osdctl.md)	 - OSD CLI
+* [osdctl aao](osdctl_aao.md)	 - AWS Account Operator Debugging Utilities
 

--- a/docs/command/osdctl_account.md
+++ b/docs/command/osdctl_account.md
@@ -2,10 +2,6 @@
 
 AWS Account related utilities
 
-### Synopsis
-
-AWS Account related utilities
-
 ```
 osdctl account [flags]
 ```
@@ -44,6 +40,7 @@ osdctl account [flags]
 * [osdctl account generate-secret](osdctl_account_generate-secret.md)	 - Generate IAM credentials secret
 * [osdctl account get](osdctl_account_get.md)	 - Get resources
 * [osdctl account list](osdctl_account_list.md)	 - List resources
+* [osdctl account mgmt](osdctl_account_mgmt.md)	 - AWS Account Management
 * [osdctl account reset](osdctl_account_reset.md)	 - Reset AWS Account CR
 * [osdctl account rotate-secret](osdctl_account_rotate-secret.md)	 - Rotate IAM credentials secret
 * [osdctl account servicequotas](osdctl_account_servicequotas.md)	 - Interact with AWS service-quotas

--- a/docs/command/osdctl_account_clean-velero-snapshots.md
+++ b/docs/command/osdctl_account_clean-velero-snapshots.md
@@ -2,10 +2,6 @@
 
 Cleans up S3 buckets whose name start with managed-velero
 
-### Synopsis
-
-Cleans up S3 buckets whose name start with managed-velero
-
 ```
 osdctl account clean-velero-snapshots [flags]
 ```

--- a/docs/command/osdctl_account_cli.md
+++ b/docs/command/osdctl_account_cli.md
@@ -2,10 +2,6 @@
 
 Generate temporary AWS CLI credentials on demand
 
-### Synopsis
-
-Generate temporary AWS CLI credentials on demand
-
 ```
 osdctl account cli [flags]
 ```

--- a/docs/command/osdctl_account_console.md
+++ b/docs/command/osdctl_account_console.md
@@ -2,10 +2,6 @@
 
 Generate an AWS console URL on the fly
 
-### Synopsis
-
-Generate an AWS console URL on the fly
-
 ```
 osdctl account console [flags]
 ```
@@ -22,6 +18,7 @@ osdctl account console [flags]
   -C, --cluster-id string          The Internal Cluster ID from Hive to create AWS console URL for
   -d, --duration int               The duration of the console session. Default value is 3600 seconds(1 hour) (default 3600)
   -h, --help                       help for console
+      --launch                     Launch web browser directly
       --verbose                    Verbose output
 ```
 

--- a/docs/command/osdctl_account_generate-secret.md
+++ b/docs/command/osdctl_account_generate-secret.md
@@ -2,10 +2,6 @@
 
 Generate IAM credentials secret
 
-### Synopsis
-
-Generate IAM credentials secret
-
 ```
 osdctl account generate-secret <IAM User name> [flags]
 ```

--- a/docs/command/osdctl_account_get.md
+++ b/docs/command/osdctl_account_get.md
@@ -2,10 +2,6 @@
 
 Get resources
 
-### Synopsis
-
-Get resources
-
 ```
 osdctl account get [flags]
 ```

--- a/docs/command/osdctl_account_get_account-claim.md
+++ b/docs/command/osdctl_account_get_account-claim.md
@@ -2,10 +2,6 @@
 
 Get AWS Account Claim CR
 
-### Synopsis
-
-Get AWS Account Claim CR
-
 ```
 osdctl account get account-claim [flags]
 ```

--- a/docs/command/osdctl_account_get_account.md
+++ b/docs/command/osdctl_account_get_account.md
@@ -2,10 +2,6 @@
 
 Get AWS Account CR
 
-### Synopsis
-
-Get AWS Account CR
-
 ```
 osdctl account get account [flags]
 ```

--- a/docs/command/osdctl_account_get_aws-account.md
+++ b/docs/command/osdctl_account_get_aws-account.md
@@ -2,10 +2,6 @@
 
 Get AWS Account ID
 
-### Synopsis
-
-Get AWS Account ID
-
 ```
 osdctl account get aws-account [flags]
 ```

--- a/docs/command/osdctl_account_get_legal-entity.md
+++ b/docs/command/osdctl_account_get_legal-entity.md
@@ -2,10 +2,6 @@
 
 Get AWS Account Legal Entity
 
-### Synopsis
-
-Get AWS Account Legal Entity
-
 ```
 osdctl account get legal-entity [flags]
 ```

--- a/docs/command/osdctl_account_get_secrets.md
+++ b/docs/command/osdctl_account_get_secrets.md
@@ -2,10 +2,6 @@
 
 Get AWS Account CR related secrets
 
-### Synopsis
-
-Get AWS Account CR related secrets
-
 ```
 osdctl account get secrets [flags]
 ```

--- a/docs/command/osdctl_account_list.md
+++ b/docs/command/osdctl_account_list.md
@@ -2,10 +2,6 @@
 
 List resources
 
-### Synopsis
-
-List resources
-
 ```
 osdctl account list [flags]
 ```

--- a/docs/command/osdctl_account_list_account-claim.md
+++ b/docs/command/osdctl_account_list_account-claim.md
@@ -2,10 +2,6 @@
 
 List AWS Account Claim CR
 
-### Synopsis
-
-List AWS Account Claim CR
-
 ```
 osdctl account list account-claim [flags]
 ```

--- a/docs/command/osdctl_account_list_account.md
+++ b/docs/command/osdctl_account_list_account.md
@@ -2,10 +2,6 @@
 
 List AWS Account CR
 
-### Synopsis
-
-List AWS Account CR
-
 ```
 osdctl account list account [flags]
 ```

--- a/docs/command/osdctl_account_mgmt.md
+++ b/docs/command/osdctl_account_mgmt.md
@@ -1,15 +1,15 @@
-## osdctl options
+## osdctl account mgmt
 
-Print the list of flags inherited by all commands
+AWS Account Management
 
 ```
-osdctl options
+osdctl account mgmt [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for options
+  -h, --help   help for mgmt
 ```
 
 ### Options inherited from parent commands
@@ -33,5 +33,8 @@ osdctl options
 
 ### SEE ALSO
 
-* [osdctl](osdctl.md)	 - OSD CLI
+* [osdctl account](osdctl_account.md)	 - AWS Account related utilities
+* [osdctl account mgmt assign](osdctl_account_mgmt_assign.md)	 - Assign account to user
+* [osdctl account mgmt list](osdctl_account_mgmt_list.md)	 - List out accounts for username
+* [osdctl account mgmt unassign](osdctl_account_mgmt_unassign.md)	 - Unassign account to user
 

--- a/docs/command/osdctl_account_mgmt_assign.md
+++ b/docs/command/osdctl_account_mgmt_assign.md
@@ -1,15 +1,18 @@
-## osdctl options
+## osdctl account mgmt assign
 
-Print the list of flags inherited by all commands
+Assign account to user
 
 ```
-osdctl options
+osdctl account mgmt assign [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for options
+  -h, --help                   help for assign
+  -p, --payer-account string   Payer account type
+      --template string        Template string or path to template file to use when --output=jsonpath, --output=jsonpath-file.
+  -u, --username string        LDAP username
 ```
 
 ### Options inherited from parent commands
@@ -33,5 +36,5 @@ osdctl options
 
 ### SEE ALSO
 
-* [osdctl](osdctl.md)	 - OSD CLI
+* [osdctl account mgmt](osdctl_account_mgmt.md)	 - AWS Account Management
 

--- a/docs/command/osdctl_account_mgmt_list.md
+++ b/docs/command/osdctl_account_mgmt_list.md
@@ -1,15 +1,19 @@
-## osdctl options
+## osdctl account mgmt list
 
-Print the list of flags inherited by all commands
+List out accounts for username
 
 ```
-osdctl options
+osdctl account mgmt list [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for options
+  -i, --account-id string      Account ID
+  -h, --help                   help for list
+  -p, --payer-account string   Payer account type
+      --template string        Template string or path to template file to use when --output=jsonpath, --output=jsonpath-file.
+  -u, --user string            LDAP username
 ```
 
 ### Options inherited from parent commands
@@ -33,5 +37,5 @@ osdctl options
 
 ### SEE ALSO
 
-* [osdctl](osdctl.md)	 - OSD CLI
+* [osdctl account mgmt](osdctl_account_mgmt.md)	 - AWS Account Management
 

--- a/docs/command/osdctl_account_mgmt_unassign.md
+++ b/docs/command/osdctl_account_mgmt_unassign.md
@@ -1,15 +1,19 @@
-## osdctl options
+## osdctl account mgmt unassign
 
-Print the list of flags inherited by all commands
+Unassign account to user
 
 ```
-osdctl options
+osdctl account mgmt unassign [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for options
+  -i, --account-id string      Account ID
+  -h, --help                   help for unassign
+  -p, --payer-account string   Payer account type
+      --template string        Template string or path to template file to use when --output=jsonpath, --output=jsonpath-file.
+  -u, --username string        LDAP username
 ```
 
 ### Options inherited from parent commands
@@ -33,5 +37,5 @@ osdctl options
 
 ### SEE ALSO
 
-* [osdctl](osdctl.md)	 - OSD CLI
+* [osdctl account mgmt](osdctl_account_mgmt.md)	 - AWS Account Management
 

--- a/docs/command/osdctl_account_reset.md
+++ b/docs/command/osdctl_account_reset.md
@@ -2,10 +2,6 @@
 
 Reset AWS Account CR
 
-### Synopsis
-
-Reset AWS Account CR
-
 ```
 osdctl account reset <account name> [flags]
 ```

--- a/docs/command/osdctl_account_rotate-secret.md
+++ b/docs/command/osdctl_account_rotate-secret.md
@@ -2,10 +2,6 @@
 
 Rotate IAM credentials secret
 
-### Synopsis
-
-Rotate IAM credentials secret
-
 ```
 osdctl account rotate-secret <IAM User name> [flags]
 ```

--- a/docs/command/osdctl_account_servicequotas.md
+++ b/docs/command/osdctl_account_servicequotas.md
@@ -2,10 +2,6 @@
 
 Interact with AWS service-quotas
 
-### Synopsis
-
-Interact with AWS service-quotas
-
 ```
 osdctl account servicequotas [flags]
 ```

--- a/docs/command/osdctl_account_servicequotas_describe.md
+++ b/docs/command/osdctl_account_servicequotas_describe.md
@@ -2,10 +2,6 @@
 
 Describe AWS service-quotas
 
-### Synopsis
-
-Describe AWS service-quotas
-
 ```
 osdctl account servicequotas describe [flags]
 ```

--- a/docs/command/osdctl_account_set.md
+++ b/docs/command/osdctl_account_set.md
@@ -2,10 +2,6 @@
 
 Set AWS Account CR status
 
-### Synopsis
-
-Set AWS Account CR status
-
 ```
 osdctl account set <account name> [flags]
 ```

--- a/docs/command/osdctl_account_verify-secrets.md
+++ b/docs/command/osdctl_account_verify-secrets.md
@@ -2,10 +2,6 @@
 
 Verify AWS Account CR IAM User credentials
 
-### Synopsis
-
-Verify AWS Account CR IAM User credentials
-
 ```
 osdctl account verify-secrets [<account name>] [flags]
 ```

--- a/docs/command/osdctl_cluster.md
+++ b/docs/command/osdctl_cluster.md
@@ -1,15 +1,15 @@
-## osdctl options
+## osdctl cluster
 
-Print the list of flags inherited by all commands
+Provides vitals of an AWS cluster
 
 ```
-osdctl options
+osdctl cluster [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for options
+  -h, --help   help for cluster
 ```
 
 ### Options inherited from parent commands
@@ -34,4 +34,5 @@ osdctl options
 ### SEE ALSO
 
 * [osdctl](osdctl.md)	 - OSD CLI
+* [osdctl cluster health](osdctl_cluster_health.md)	 - Describes health of cluster nodes and provides other cluster vitals.
 

--- a/docs/command/osdctl_cluster_health.md
+++ b/docs/command/osdctl_cluster_health.md
@@ -1,15 +1,25 @@
-## osdctl options
+## osdctl cluster health
 
-Print the list of flags inherited by all commands
+Describes health of cluster nodes and provides other cluster vitals.
 
 ```
-osdctl options
+osdctl cluster health [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for options
+  -i, --account-id string          The AWS account ID we need to create AWS credentials for -- This argument will not work for CCS accounts
+  -a, --account-name string        The AWS account CR we need to create a temporary AWS console URL for
+      --account-namespace string   The namespace to keep AWS accounts. The default value is aws-account-operator. (default "aws-account-operator")
+  -c, --aws-config string          specify AWS config file path
+  -p, --aws-profile string         specify AWS profile
+  -r, --aws-region string          specify AWS region (default "us-east-1")
+  -C, --cluster-id string          The Internal Cluster ID from Hive to create AWS console URL for
+  -d, --duration int               The duration of the console session. Default value is 3600 seconds(1 hour) (default 3600)
+  -h, --help                       help for health
+  -o, --out string                 Output format [default | json | env] (default "default")
+      --verbose                    Verbose output
 ```
 
 ### Options inherited from parent commands
@@ -33,5 +43,5 @@ osdctl options
 
 ### SEE ALSO
 
-* [osdctl](osdctl.md)	 - OSD CLI
+* [osdctl cluster](osdctl_cluster.md)	 - Provides vitals of an AWS cluster
 

--- a/docs/command/osdctl_clusterdeployment.md
+++ b/docs/command/osdctl_clusterdeployment.md
@@ -2,10 +2,6 @@
 
 cluster deployment related utilities
 
-### Synopsis
-
-cluster deployment related utilities
-
 ```
 osdctl clusterdeployment [flags]
 ```
@@ -39,4 +35,5 @@ osdctl clusterdeployment [flags]
 
 * [osdctl](osdctl.md)	 - OSD CLI
 * [osdctl clusterdeployment list](osdctl_clusterdeployment_list.md)	 - List cluster deployment crs
+* [osdctl clusterdeployment listresources](osdctl_clusterdeployment_listresources.md)	 - List all resources on a hive cluster related to a given cluster
 

--- a/docs/command/osdctl_clusterdeployment_list.md
+++ b/docs/command/osdctl_clusterdeployment_list.md
@@ -2,10 +2,6 @@
 
 List cluster deployment crs
 
-### Synopsis
-
-List cluster deployment crs
-
 ```
 osdctl clusterdeployment list [flags]
 ```

--- a/docs/command/osdctl_clusterdeployment_listresources.md
+++ b/docs/command/osdctl_clusterdeployment_listresources.md
@@ -1,15 +1,17 @@
-## osdctl options
+## osdctl clusterdeployment listresources
 
-Print the list of flags inherited by all commands
+List all resources on a hive cluster related to a given cluster
 
 ```
-osdctl options
+osdctl clusterdeployment listresources [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for options
+  -C, --cluster-id string   Cluster ID
+  -e, --external            only list external resources (i.e. exclude resources in cluster namespace)
+  -h, --help                help for listresources
 ```
 
 ### Options inherited from parent commands
@@ -33,5 +35,5 @@ osdctl options
 
 ### SEE ALSO
 
-* [osdctl](osdctl.md)	 - OSD CLI
+* [osdctl clusterdeployment](osdctl_clusterdeployment.md)	 - cluster deployment related utilities
 

--- a/docs/command/osdctl_completion.md
+++ b/docs/command/osdctl_completion.md
@@ -2,10 +2,6 @@
 
 Output shell completion code for the specified shell (bash or zsh)
 
-### Synopsis
-
-Output shell completion code for the specified shell (bash or zsh)
-
 ```
 osdctl completion SHELL
 ```

--- a/docs/command/osdctl_cost_create.md
+++ b/docs/command/osdctl_cost_create.md
@@ -2,10 +2,6 @@
 
 Create a cost category for the given OU
 
-### Synopsis
-
-Create a cost category for the given OU
-
 ```
 osdctl cost create [flags]
 ```

--- a/docs/command/osdctl_cost_get.md
+++ b/docs/command/osdctl_cost_get.md
@@ -2,10 +2,6 @@
 
 Get total cost of a given OU
 
-### Synopsis
-
-Get total cost of a given OU
-
 ```
 osdctl cost get [flags]
 ```
@@ -13,11 +9,13 @@ osdctl cost get [flags]
 ### Options
 
 ```
-      --csv           output result as csv
-  -h, --help          help for get
-      --ou string     get OU ID
-  -r, --recursive     recurse through OUs
-  -t, --time string   set time. One of 'LM', 'MTD', 'TYD', '3M', '6M', '1Y'
+      --csv            output result as csv
+      --end string     set end date range
+  -h, --help           help for get
+      --ou string      get OU ID
+  -r, --recursive      recurse through OUs
+      --start string   set start date range
+  -t, --time string    set time. One of 'LM', 'MTD', 'TYD', '3M', '6M', '1Y'
 ```
 
 ### Options inherited from parent commands

--- a/docs/command/osdctl_cost_list.md
+++ b/docs/command/osdctl_cost_list.md
@@ -2,10 +2,6 @@
 
 List the cost of each OU under given OU
 
-### Synopsis
-
-List the cost of each OU under given OU
-
 ```
 osdctl cost list [flags]
 ```
@@ -13,10 +9,12 @@ osdctl cost list [flags]
 ### Options
 
 ```
-      --csv           output result as csv
-  -h, --help          help for list
-      --ou string     get OU ID
-  -t, --time string   set time. One of 'LM', 'MTD', 'TYD', '3M', '6M', '1Y'
+      --csv            output result as csv
+      --end string     set end date range
+  -h, --help           help for list
+      --ou string      get OU ID
+      --start string   set start date range
+  -t, --time string    set time. One of 'LM', 'MTD', 'TYD', '3M', '6M', '1Y'
 ```
 
 ### Options inherited from parent commands

--- a/docs/command/osdctl_cost_reconcile.md
+++ b/docs/command/osdctl_cost_reconcile.md
@@ -2,10 +2,6 @@
 
 Checks if there's a cost category for every OU. If an OU is missing a cost category, creates the cost category
 
-### Synopsis
-
-Checks if there's a cost category for every OU. If an OU is missing a cost category, creates the cost category
-
 ```
 osdctl cost reconcile [flags]
 ```

--- a/docs/command/osdctl_federatedrole.md
+++ b/docs/command/osdctl_federatedrole.md
@@ -2,10 +2,6 @@
 
 federated role related commands
 
-### Synopsis
-
-federated role related commands
-
 ```
 osdctl federatedrole [flags]
 ```

--- a/docs/command/osdctl_federatedrole_apply.md
+++ b/docs/command/osdctl_federatedrole_apply.md
@@ -2,10 +2,6 @@
 
 Apply federated role CR
 
-### Synopsis
-
-Apply federated role CR
-
 ```
 osdctl federatedrole apply [flags]
 ```

--- a/docs/command/osdctl_metrics.md
+++ b/docs/command/osdctl_metrics.md
@@ -2,10 +2,6 @@
 
 Display metrics of aws-account-operator
 
-### Synopsis
-
-Display metrics of aws-account-operator
-
 ```
 osdctl metrics [flags]
 ```

--- a/docs/command/osdctl_network.md
+++ b/docs/command/osdctl_network.md
@@ -2,10 +2,6 @@
 
 network related utilities
 
-### Synopsis
-
-network related utilities
-
 ```
 osdctl network [flags]
 ```

--- a/docs/command/osdctl_network_packet-capture.md
+++ b/docs/command/osdctl_network_packet-capture.md
@@ -2,10 +2,6 @@
 
 Start packet capture
 
-### Synopsis
-
-Start packet capture
-
 ```
 osdctl network packet-capture [flags]
 ```
@@ -19,6 +15,7 @@ osdctl network packet-capture [flags]
   -n, --namespace string          Namespace to deploy Daemonset (default "default")
       --node-label-key string     Node label key (default "node-role.kubernetes.io/worker")
       --node-label-value string   Node label value
+      --single-pod                toogle deployment as single pod (default: deploy a daemonset)
 ```
 
 ### Options inherited from parent commands

--- a/docs/command/osdctl_servicelog.md
+++ b/docs/command/osdctl_servicelog.md
@@ -2,10 +2,6 @@
 
 OCM/Hive Service log
 
-### Synopsis
-
-OCM/Hive Service log
-
 ```
 osdctl servicelog [flags]
 ```

--- a/docs/command/osdctl_servicelog_list.md
+++ b/docs/command/osdctl_servicelog_list.md
@@ -2,12 +2,8 @@
 
 gets all servicelog messages for a given cluster
 
-### Synopsis
-
-gets all servicelog messages for a given cluster
-
 ```
-osdctl servicelog list [flags]
+osdctl servicelog list [flags] [options] cluster-identifier
 ```
 
 ### Options

--- a/docs/command/osdctl_servicelog_post.md
+++ b/docs/command/osdctl_servicelog_post.md
@@ -2,10 +2,6 @@
 
 Send a servicelog message to a given cluster
 
-### Synopsis
-
-Send a servicelog message to a given cluster
-
 ```
 osdctl servicelog post [flags]
 ```
@@ -13,10 +9,14 @@ osdctl servicelog post [flags]
 ### Options
 
 ```
-  -d, --dry-run             Dry-run - print the service log about to be sent but don't send it.
-  -h, --help                help for post
-  -p, --param stringArray   Specify a key-value pair (eg. -p FOO=BAR) to set/override a parameter value in the template.
-  -t, --template string     Message template file or URL
+  -c, --clusters-file string     Read a list of clusters to post the servicelog to
+  -d, --dry-run                  Dry-run - print the service log about to be sent but don't send it.
+  -h, --help                     help for post
+  -p, --param stringArray        Specify a key-value pair (eg. -p FOO=BAR) to set/override a parameter value in the template.
+  -q, --query stringArray        Specify a search query (eg. -q "name like foo") for a bulk-post to matching clusters.
+  -f, --query-file stringArray   File containing search queries to apply. All lines in the file will be concatenated into a single query. If this flag is called multiple times, every file's search query will be combined with logical AND.
+  -t, --template string          Message template file or URL
+  -y, --yes                      Skips all prompts.
 ```
 
 ### Options inherited from parent commands

--- a/docs/command/osdctl_sts.md
+++ b/docs/command/osdctl_sts.md
@@ -1,15 +1,15 @@
-## osdctl options
+## osdctl sts
 
-Print the list of flags inherited by all commands
+STS related utilities
 
 ```
-osdctl options
+osdctl sts [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for options
+  -h, --help   help for sts
 ```
 
 ### Options inherited from parent commands
@@ -34,4 +34,6 @@ osdctl options
 ### SEE ALSO
 
 * [osdctl](osdctl.md)	 - OSD CLI
+* [osdctl sts policy](osdctl_sts_policy.md)	 - Get OCP STS policy
+* [osdctl sts policy-diff](osdctl_sts_policy-diff.md)	 - Get diff between two versions of OCP STS policy
 

--- a/docs/command/osdctl_sts_policy-diff.md
+++ b/docs/command/osdctl_sts_policy-diff.md
@@ -1,15 +1,17 @@
-## osdctl options
+## osdctl sts policy-diff
 
-Print the list of flags inherited by all commands
+Get diff between two versions of OCP STS policy
 
 ```
-osdctl options
+osdctl sts policy-diff [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for options
+  -h, --help                 help for policy-diff
+  -n, --new-version string   
+  -o, --old-version string   
 ```
 
 ### Options inherited from parent commands
@@ -33,5 +35,5 @@ osdctl options
 
 ### SEE ALSO
 
-* [osdctl](osdctl.md)	 - OSD CLI
+* [osdctl sts](osdctl_sts.md)	 - STS related utilities
 

--- a/docs/command/osdctl_sts_policy.md
+++ b/docs/command/osdctl_sts_policy.md
@@ -1,15 +1,16 @@
-## osdctl options
+## osdctl sts policy
 
-Print the list of flags inherited by all commands
+Get OCP STS policy
 
 ```
-osdctl options
+osdctl sts policy [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for options
+  -h, --help                     help for policy
+  -r, --release-version string   
 ```
 
 ### Options inherited from parent commands
@@ -33,5 +34,5 @@ osdctl options
 
 ### SEE ALSO
 
-* [osdctl](osdctl.md)	 - OSD CLI
+* [osdctl sts](osdctl_sts.md)	 - STS related utilities
 


### PR DESCRIPTION
this is not run per-commit, and as such has a large drift to our current
setup.

should we use these docs? or remove them altogether
