### PR TITLE
fix output

### DIFF
--- a/cmd/account/cli.go
+++ b/cmd/account/cli.go
@@ -6,12 +6,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/spf13/cobra"
 
+	outputflag "github.com/openshift/osdctl/cmd/getoutput"
+	k8spkg "github.com/openshift/osdctl/pkg/k8s"
+	awsprovider "github.com/openshift/osdctl/pkg/provider/aws"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-
-	k8spkg "github.com/openshift/osdctl/pkg/k8s"
-	awsprovider "github.com/openshift/osdctl/pkg/provider/aws"
 )
 
 // newCmdCli implements the Cli command which generates temporary STS cli credentials for the specified account cr
@@ -30,7 +30,6 @@ func newCmdCli(streams genericclioptions.IOStreams, flags *genericclioptions.Con
 
 	ops.k8sclusterresourcefactory.AttachCobraCliFlags(cliCmd)
 
-	cliCmd.Flags().StringVarP(&ops.output, "out", "o", "default", "Output format [default | json | env]")
 	cliCmd.Flags().BoolVarP(&ops.verbose, "verbose", "", false, "Verbose output")
 
 	return cliCmd
@@ -70,6 +69,12 @@ func (o *cliOptions) complete(cmd *cobra.Command) error {
 		}
 	}
 
+	output, err := outputflag.GetOutput(cmd)
+	if err != nil {
+		return err
+	}
+	o.output = output
+
 	return nil
 }
 
@@ -94,7 +99,7 @@ func (o *cliOptions) run() error {
 		}
 	}
 
-	if o.output == "default" {
+	if o.output == "" {
 		fmt.Fprintf(o.IOStreams.Out, "Temporary AWS Credentials:\n%s\n", creds)
 	}
 

--- a/cmd/account/cmd.go
+++ b/cmd/account/cmd.go
@@ -8,10 +8,11 @@ import (
 	"github.com/openshift/osdctl/cmd/account/list"
 	"github.com/openshift/osdctl/cmd/account/mgmt"
 	"github.com/openshift/osdctl/cmd/account/servicequotas"
+	"github.com/openshift/osdctl/internal/utils/globalflags"
 )
 
 // NewCmdAccount implements the base account command
-func NewCmdAccount(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+func NewCmdAccount(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	accountCmd := &cobra.Command{
 		Use:               "account",
 		Short:             "AWS Account related utilities",
@@ -20,7 +21,7 @@ func NewCmdAccount(streams genericclioptions.IOStreams, flags *genericclioptions
 		Run:               help,
 	}
 
-	accountCmd.AddCommand(get.NewCmdGet(streams, flags))
+	accountCmd.AddCommand(get.NewCmdGet(streams, flags, globalOpts))
 	accountCmd.AddCommand(list.NewCmdList(streams, flags))
 	accountCmd.AddCommand(servicequotas.NewCmdServiceQuotas(streams, flags))
 	accountCmd.AddCommand(mgmt.NewCmdMgmt(streams, flags))

--- a/cmd/account/cmd.go
+++ b/cmd/account/cmd.go
@@ -22,7 +22,7 @@ func NewCmdAccount(streams genericclioptions.IOStreams, flags *genericclioptions
 	}
 
 	accountCmd.AddCommand(get.NewCmdGet(streams, flags, globalOpts))
-	accountCmd.AddCommand(list.NewCmdList(streams, flags))
+	accountCmd.AddCommand(list.NewCmdList(streams, flags, globalOpts))
 	accountCmd.AddCommand(servicequotas.NewCmdServiceQuotas(streams, flags))
 	accountCmd.AddCommand(mgmt.NewCmdMgmt(streams, flags))
 	accountCmd.AddCommand(newCmdReset(streams, flags))

--- a/cmd/account/get/account-claim.go
+++ b/cmd/account/get/account-claim.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/osdctl/cmd/common"
-	outputflag "github.com/openshift/osdctl/cmd/getoutput"
+	"github.com/openshift/osdctl/internal/utils/globalflags"
 	"github.com/openshift/osdctl/pkg/k8s"
 	"github.com/openshift/osdctl/pkg/printer"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -18,8 +18,8 @@ import (
 
 // newCmdGetAccountClaim implements the get account-claim command which get
 // the Account Claim CR related to the specified AWS Account ID
-func newCmdGetAccountClaim(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
-	ops := newGetAccountClaimOptions(streams, flags)
+func newCmdGetAccountClaim(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newGetAccountClaimOptions(streams, flags, globalOpts)
 	getAccountClaimCmd := &cobra.Command{
 		Use:               "account-claim",
 		Short:             "Get AWS Account Claim CR",
@@ -51,14 +51,16 @@ type getAccountClaimOptions struct {
 	flags      *genericclioptions.ConfigFlags
 	printFlags *printer.PrintFlags
 	genericclioptions.IOStreams
-	kubeCli client.Client
+	kubeCli       client.Client
+	GlobalOptions *globalflags.GlobalOptions
 }
 
-func newGetAccountClaimOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *getAccountClaimOptions {
+func newGetAccountClaimOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *getAccountClaimOptions {
 	return &getAccountClaimOptions{
-		flags:      flags,
-		printFlags: printer.NewPrintFlags(),
-		IOStreams:  streams,
+		flags:         flags,
+		printFlags:    printer.NewPrintFlags(),
+		IOStreams:     streams,
+		GlobalOptions: globalOpts,
 	}
 }
 
@@ -76,11 +78,9 @@ func (o *getAccountClaimOptions) complete(cmd *cobra.Command, _ []string) error 
 		return err
 	}
 
-	output, err := outputflag.GetOutput(cmd)
-	if err != nil {
-		return err
-	}
-	o.output = output
+	o.output = o.GlobalOptions.Output
+
+	fmt.Printf("Output: %s", o.GlobalOptions.Output)
 
 	return nil
 }

--- a/cmd/account/get/account-claim.go
+++ b/cmd/account/get/account-claim.go
@@ -7,13 +7,13 @@ import (
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/osdctl/cmd/common"
+	outputflag "github.com/openshift/osdctl/cmd/getoutput"
+	"github.com/openshift/osdctl/pkg/k8s"
+	"github.com/openshift/osdctl/pkg/printer"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/openshift/osdctl/cmd/common"
-	"github.com/openshift/osdctl/pkg/k8s"
-	"github.com/openshift/osdctl/pkg/printer"
 )
 
 // newCmdGetAccountClaim implements the get account-claim command which get
@@ -32,7 +32,6 @@ func newCmdGetAccountClaim(streams genericclioptions.IOStreams, flags *genericcl
 	}
 
 	ops.printFlags.AddFlags(getAccountClaimCmd)
-	getAccountClaimCmd.Flags().StringVarP(&ops.output, "output", "o", "", "Output format. One of: json|yaml|jsonpath=...|jsonpath-file=... see jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].")
 	getAccountClaimCmd.Flags().StringVar(&ops.accountNamespace, "account-namespace", common.AWSAccountNamespace,
 		"The namespace to keep AWS accounts. The default value is aws-account-operator.")
 	getAccountClaimCmd.Flags().StringVarP(&ops.accountName, "account", "a", "", "Account CR Name")
@@ -76,6 +75,12 @@ func (o *getAccountClaimOptions) complete(cmd *cobra.Command, _ []string) error 
 	if err != nil {
 		return err
 	}
+
+	output, err := outputflag.GetOutput(cmd)
+	if err != nil {
+		return err
+	}
+	o.output = output
 
 	return nil
 }

--- a/cmd/account/get/account-claim_test.go
+++ b/cmd/account/get/account-claim_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/osdctl/internal/utils/globalflags"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -14,6 +15,7 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
 	kubeFlags := genericclioptions.NewConfigFlags(false)
+	globalFlags := globalflags.GlobalOptions{Output: ""}
 	testCases := []struct {
 		title       string
 		option      *getAccountClaimOptions
@@ -23,8 +25,10 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 		{
 			title: "account id and account cr name empty at the same time",
 			option: &getAccountClaimOptions{
-				accountID:   "",
-				accountName: "",
+				accountID:     "",
+				accountName:   "",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
 			errContent:  "AWS account ID and Account CR Name cannot be empty at the same time",
@@ -32,8 +36,10 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 		{
 			title: "account id and account cr name set at the same time",
 			option: &getAccountClaimOptions{
-				accountID:   "foo",
-				accountName: "bar",
+				accountID:     "foo",
+				accountName:   "bar",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
 			errContent:  "AWS account ID and Account CR Name cannot be set at the same time",
@@ -41,8 +47,9 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 		{
 			title: "succeed",
 			option: &getAccountClaimOptions{
-				accountID: "foo",
-				flags:     kubeFlags,
+				accountID:     "foo",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
 		},
@@ -50,7 +57,7 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			cmd := newCmdGetAccountClaim(streams, kubeFlags)
+			cmd := newCmdGetAccountClaim(streams, kubeFlags, &globalFlags)
 			err := tc.option.complete(cmd, nil)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())

--- a/cmd/account/get/account.go
+++ b/cmd/account/get/account.go
@@ -12,15 +12,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/osdctl/cmd/common"
-	outputflag "github.com/openshift/osdctl/cmd/getoutput"
+	"github.com/openshift/osdctl/internal/utils/globalflags"
 	"github.com/openshift/osdctl/pkg/k8s"
 	"github.com/openshift/osdctl/pkg/printer"
 )
 
 // newCmdGetAccount implements the get account command which get the Account CR
 // related to the specified AWS Account ID or the specified Account Claim CR
-func newCmdGetAccount(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
-	ops := newGetAccountOptions(streams, flags)
+func newCmdGetAccount(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newGetAccountOptions(streams, flags, globalOpts)
 	getAccountCmd := &cobra.Command{
 		Use:               "account",
 		Short:             "Get AWS Account CR",
@@ -54,14 +54,16 @@ type getAccountOptions struct {
 	flags      *genericclioptions.ConfigFlags
 	printFlags *printer.PrintFlags
 	genericclioptions.IOStreams
-	kubeCli client.Client
+	kubeCli       client.Client
+	GlobalOptions *globalflags.GlobalOptions
 }
 
-func newGetAccountOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *getAccountOptions {
+func newGetAccountOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *getAccountOptions {
 	return &getAccountOptions{
-		flags:      flags,
-		printFlags: printer.NewPrintFlags(),
-		IOStreams:  streams,
+		flags:         flags,
+		printFlags:    printer.NewPrintFlags(),
+		IOStreams:     streams,
+		GlobalOptions: globalOpts,
 	}
 }
 
@@ -81,11 +83,9 @@ func (o *getAccountOptions) complete(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	output, err := outputflag.GetOutput(cmd)
-	if err != nil {
-		return err
-	}
-	o.output = output
+	o.output = o.GlobalOptions.Output
+
+	fmt.Printf("Output: %s", o.GlobalOptions.Output)
 
 	return nil
 }

--- a/cmd/account/get/account.go
+++ b/cmd/account/get/account.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/osdctl/cmd/common"
+	outputflag "github.com/openshift/osdctl/cmd/getoutput"
 	"github.com/openshift/osdctl/pkg/k8s"
 	"github.com/openshift/osdctl/pkg/printer"
 )
@@ -32,7 +33,6 @@ func newCmdGetAccount(streams genericclioptions.IOStreams, flags *genericcliopti
 	}
 
 	ops.printFlags.AddFlags(getAccountCmd)
-	getAccountCmd.Flags().StringVarP(&ops.output, "output", "o", "", "Output format. One of: json|yaml|jsonpath=...|jsonpath-file=... see jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].")
 	getAccountCmd.Flags().StringVar(&ops.accountNamespace, "account-namespace", common.AWSAccountNamespace,
 		"The namespace to keep AWS accounts. The default value is aws-account-operator.")
 	getAccountCmd.Flags().StringVarP(&ops.accountID, "account-id", "i", "", "AWS account ID")
@@ -80,6 +80,12 @@ func (o *getAccountOptions) complete(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+
+	output, err := outputflag.GetOutput(cmd)
+	if err != nil {
+		return err
+	}
+	o.output = output
 
 	return nil
 }

--- a/cmd/account/get/account_test.go
+++ b/cmd/account/get/account_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/osdctl/internal/utils/globalflags"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -14,6 +15,7 @@ func TestGetAccountCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
 	kubeFlags := genericclioptions.NewConfigFlags(false)
+	globalFlags := globalflags.GlobalOptions{Output: ""}
 	testCases := []struct {
 		title       string
 		option      *getAccountOptions
@@ -25,6 +27,8 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			option: &getAccountOptions{
 				accountID:        "",
 				accountClaimName: "",
+				flags:            kubeFlags,
+				GlobalOptions:    &globalFlags,
 			},
 			errExpected: true,
 			errContent:  "AWS account ID and AccountClaim CR Name cannot be empty at the same time",
@@ -34,6 +38,8 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			option: &getAccountOptions{
 				accountID:        "foo",
 				accountClaimName: "bar",
+				flags:            kubeFlags,
+				GlobalOptions:    &globalFlags,
 			},
 			errExpected: true,
 			errContent:  "AWS account ID and AccountClaim CR Name cannot be set at the same time",
@@ -41,8 +47,9 @@ func TestGetAccountCmdComplete(t *testing.T) {
 		{
 			title: "succeed",
 			option: &getAccountOptions{
-				accountID: "foo",
-				flags:     kubeFlags,
+				accountID:     "foo",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
 		},
@@ -51,6 +58,7 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			option: &getAccountOptions{
 				accountClaimName: "foo",
 				flags:            kubeFlags,
+				GlobalOptions:    &globalFlags,
 			},
 			errExpected: false,
 		},
@@ -58,7 +66,7 @@ func TestGetAccountCmdComplete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			cmd := newCmdGetAccount(streams, kubeFlags)
+			cmd := newCmdGetAccount(streams, kubeFlags, &globalFlags)
 			err := tc.option.complete(cmd, nil)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())

--- a/cmd/account/get/cmd.go
+++ b/cmd/account/get/cmd.go
@@ -22,7 +22,7 @@ func NewCmdGet(streams genericclioptions.IOStreams, flags *genericclioptions.Con
 	}
 
 	getCmd.AddCommand(newCmdGetAccount(streams, flags, globalOpts))
-	getCmd.AddCommand(newCmdGetAccountClaim(streams, flags))
+	getCmd.AddCommand(newCmdGetAccountClaim(streams, flags, globalOpts))
 	getCmd.AddCommand(newCmdGetLegalEntity(streams, flags))
 	getCmd.AddCommand(newCmdGetSecrets(streams, flags))
 	getCmd.AddCommand(newCmdGetAWSAccount(streams, flags))

--- a/cmd/account/get/cmd.go
+++ b/cmd/account/get/cmd.go
@@ -3,6 +3,7 @@ package get
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/osdctl/internal/utils/globalflags"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -11,7 +12,7 @@ const (
 )
 
 // NewCmdGet implements the get command to get AWS Account related resources
-func NewCmdGet(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+func NewCmdGet(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	getCmd := &cobra.Command{
 		Use:               "get",
 		Short:             "Get resources",
@@ -20,7 +21,7 @@ func NewCmdGet(streams genericclioptions.IOStreams, flags *genericclioptions.Con
 		Run:               help,
 	}
 
-	getCmd.AddCommand(newCmdGetAccount(streams, flags))
+	getCmd.AddCommand(newCmdGetAccount(streams, flags, globalOpts))
 	getCmd.AddCommand(newCmdGetAccountClaim(streams, flags))
 	getCmd.AddCommand(newCmdGetLegalEntity(streams, flags))
 	getCmd.AddCommand(newCmdGetSecrets(streams, flags))

--- a/cmd/account/get/secrets.go
+++ b/cmd/account/get/secrets.go
@@ -48,9 +48,6 @@ func newCmdGetSecrets(streams genericclioptions.IOStreams, flags *genericcliopti
 type getSecretsOptions struct {
 	accountID        string
 	accountNamespace string
-	secretName       string
-
-	output string
 
 	flags *genericclioptions.ConfigFlags
 	genericclioptions.IOStreams

--- a/cmd/account/list/account-claim_test.go
+++ b/cmd/account/list/account-claim_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/osdctl/internal/utils/globalflags"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -14,6 +15,7 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
 	kubeFlags := genericclioptions.NewConfigFlags(false)
+	globalFlags := globalflags.GlobalOptions{Output: ""}
 	testCases := []struct {
 		title       string
 		option      *listAccountClaimOptions
@@ -23,7 +25,9 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 		{
 			title: "incorrect state",
 			option: &listAccountClaimOptions{
-				state: "foo",
+				state:         "foo",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
 			errContent:  "unsupported account claim state foo",
@@ -31,32 +35,36 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 		{
 			title: "empty state",
 			option: &listAccountClaimOptions{
-				state: "",
-				flags: kubeFlags,
+				state:         "",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
 		},
 		{
 			title: "error state",
 			option: &listAccountClaimOptions{
-				state: "Error",
-				flags: kubeFlags,
+				state:         "Error",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
 		},
 		{
 			title: "pending state",
 			option: &listAccountClaimOptions{
-				state: "Pending",
-				flags: kubeFlags,
+				state:         "Pending",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
 		},
 		{
 			title: "ready state",
 			option: &listAccountClaimOptions{
-				state: "Ready",
-				flags: kubeFlags,
+				state:         "Ready",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
 		},
@@ -64,7 +72,7 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			cmd := newCmdListAccountClaim(streams, kubeFlags)
+			cmd := newCmdListAccountClaim(streams, kubeFlags, &globalFlags)
 			err := tc.option.complete(cmd, nil)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())

--- a/cmd/account/list/account.go
+++ b/cmd/account/list/account.go
@@ -7,15 +7,15 @@ import (
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/osdctl/cmd/common"
+	outputflag "github.com/openshift/osdctl/cmd/getoutput"
+	"github.com/openshift/osdctl/pkg/k8s"
+	"github.com/openshift/osdctl/pkg/printer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/openshift/osdctl/cmd/common"
-	"github.com/openshift/osdctl/pkg/k8s"
-	"github.com/openshift/osdctl/pkg/printer"
 )
 
 // newCmdListAccount implements the list account command to list account crs
@@ -33,7 +33,6 @@ func newCmdListAccount(streams genericclioptions.IOStreams, flags *genericcliopt
 	}
 
 	ops.printFlags.AddFlags(listAccountCmd)
-	listAccountCmd.Flags().StringVarP(&ops.output, "output", "o", "", "Output format. One of: json|yaml|jsonpath=...|jsonpath-file=... see jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].")
 	listAccountCmd.Flags().StringVar(&ops.accountNamespace, "account-namespace", common.AWSAccountNamespace,
 		"The namespace to keep AWS accounts. The default value is aws-account-operator.")
 	listAccountCmd.Flags().StringVarP(&ops.reused, "reuse", "r", "",
@@ -100,6 +99,12 @@ func (o *listAccountOptions) complete(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+
+	output, err := outputflag.GetOutput(cmd)
+	if err != nil {
+		return err
+	}
+	o.output = output
 
 	return nil
 }

--- a/cmd/account/list/account.go
+++ b/cmd/account/list/account.go
@@ -2,13 +2,14 @@ package list
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/osdctl/cmd/common"
-	outputflag "github.com/openshift/osdctl/cmd/getoutput"
+	"github.com/openshift/osdctl/internal/utils/globalflags"
 	"github.com/openshift/osdctl/pkg/k8s"
 	"github.com/openshift/osdctl/pkg/printer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,8 +20,8 @@ import (
 )
 
 // newCmdListAccount implements the list account command to list account crs
-func newCmdListAccount(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
-	ops := newListAccountOptions(streams, flags)
+func newCmdListAccount(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newListAccountOptions(streams, flags, globalOpts)
 	listAccountCmd := &cobra.Command{
 		Use:               "account",
 		Short:             "List AWS Account CR",
@@ -57,14 +58,16 @@ type listAccountOptions struct {
 	flags      *genericclioptions.ConfigFlags
 	printFlags *printer.PrintFlags
 	genericclioptions.IOStreams
-	kubeCli client.Client
+	kubeCli       client.Client
+	GlobalOptions *globalflags.GlobalOptions
 }
 
-func newListAccountOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *listAccountOptions {
+func newListAccountOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *listAccountOptions {
 	return &listAccountOptions{
-		flags:      flags,
-		printFlags: printer.NewPrintFlags(),
-		IOStreams:  streams,
+		flags:         flags,
+		printFlags:    printer.NewPrintFlags(),
+		IOStreams:     streams,
+		GlobalOptions: globalOpts,
 	}
 }
 
@@ -100,11 +103,9 @@ func (o *listAccountOptions) complete(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	output, err := outputflag.GetOutput(cmd)
-	if err != nil {
-		return err
-	}
-	o.output = output
+	o.output = o.GlobalOptions.Output
+
+	fmt.Printf("Output: %s", o.GlobalOptions.Output)
 
 	return nil
 }

--- a/cmd/account/list/account_test.go
+++ b/cmd/account/list/account_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-
+	"github.com/openshift/osdctl/internal/utils/globalflags"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -14,6 +14,7 @@ func TestGetAccountCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
 	kubeFlags := genericclioptions.NewConfigFlags(false)
+	globalFlags := globalflags.GlobalOptions{Output: ""}
 	testCases := []struct {
 		title       string
 		option      *listAccountOptions
@@ -23,7 +24,9 @@ func TestGetAccountCmdComplete(t *testing.T) {
 		{
 			title: "incorrect state",
 			option: &listAccountOptions{
-				state: "foo",
+				state:         "foo",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
 			errContent:  "unsupported account state foo",
@@ -31,31 +34,36 @@ func TestGetAccountCmdComplete(t *testing.T) {
 		{
 			title: "empty state",
 			option: &listAccountOptions{
-				state: "",
-				flags: kubeFlags,
+				state:         "",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
 		},
 		{
 			title: "all state",
 			option: &listAccountOptions{
-				state: "all",
-				flags: kubeFlags,
+				state:         "all",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
 		},
 		{
 			title: "Ready state",
 			option: &listAccountOptions{
-				state: "Ready",
-				flags: kubeFlags,
+				state:         "Ready",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
 		},
 		{
 			title: "bad reuse",
 			option: &listAccountOptions{
-				reused: "foo",
+				reused:        "foo",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
 			errContent:  "unsupported reused status filter foo",
@@ -63,7 +71,9 @@ func TestGetAccountCmdComplete(t *testing.T) {
 		{
 			title: "bad reused status",
 			option: &listAccountOptions{
-				reused: "foo",
+				reused:        "foo",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
 			errContent:  "unsupported reused status filter foo",
@@ -71,7 +81,9 @@ func TestGetAccountCmdComplete(t *testing.T) {
 		{
 			title: "bad claimed status",
 			option: &listAccountOptions{
-				claimed: "foo",
+				claimed:       "foo",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
 			errContent:  "unsupported claimed status filter foo",
@@ -79,26 +91,29 @@ func TestGetAccountCmdComplete(t *testing.T) {
 		{
 			title: "good reused true",
 			option: &listAccountOptions{
-				reused: "true",
-				flags:  kubeFlags,
+				reused:        "true",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
 		},
 		{
 			title: "good claim",
 			option: &listAccountOptions{
-				claimed: "false",
-				flags:   kubeFlags,
+				claimed:       "false",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
 		},
 		{
 			title: "success",
 			option: &listAccountOptions{
-				state:   "Ready",
-				reused:  "true",
-				claimed: "false",
-				flags:   kubeFlags,
+				state:         "Ready",
+				reused:        "true",
+				claimed:       "false",
+				flags:         kubeFlags,
+				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
 		},
@@ -106,7 +121,7 @@ func TestGetAccountCmdComplete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			cmd := newCmdListAccount(streams, kubeFlags)
+			cmd := newCmdListAccount(streams, kubeFlags, &globalFlags)
 			err := tc.option.complete(cmd, nil)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())

--- a/cmd/account/list/cmd.go
+++ b/cmd/account/list/cmd.go
@@ -1,12 +1,13 @@
 package list
 
 import (
+	"github.com/openshift/osdctl/internal/utils/globalflags"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 // NewCmdGet implements the get command to get AWS Account related resources
-func NewCmdList(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+func NewCmdList(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	listCmd := &cobra.Command{
 		Use:               "list",
 		Short:             "List resources",
@@ -15,8 +16,8 @@ func NewCmdList(streams genericclioptions.IOStreams, flags *genericclioptions.Co
 		Run:               help,
 	}
 
-	listCmd.AddCommand(newCmdListAccount(streams, flags))
-	listCmd.AddCommand(newCmdListAccountClaim(streams, flags))
+	listCmd.AddCommand(newCmdListAccount(streams, flags, globalOpts))
+	listCmd.AddCommand(newCmdListAccountClaim(streams, flags, globalOpts))
 
 	return listCmd
 }

--- a/cmd/cluster/health.go
+++ b/cmd/cluster/health.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	outputflag "github.com/openshift/osdctl/cmd/getoutput"
 	k8spkg "github.com/openshift/osdctl/pkg/k8s"
 	awsprovider "github.com/openshift/osdctl/pkg/provider/aws"
 	"github.com/openshift/osdctl/pkg/utils"
@@ -49,7 +50,6 @@ func newCmdHealth(streams genericclioptions.IOStreams, flags *genericclioptions.
 		},
 	}
 	ops.k8sclusterresourcefactory.AttachCobraCliFlags(healthCmd)
-	healthCmd.Flags().StringVarP(&ops.output, "out", "o", "default", "Output format [default | json | env]")
 	healthCmd.Flags().BoolVarP(&ops.verbose, "verbose", "", false, "Verbose output")
 
 	return healthCmd
@@ -83,7 +83,14 @@ func (o *healthOptions) complete(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	output, err := outputflag.GetOutput(cmd)
+	if err != nil {
+		return err
+	}
+	o.output = output
+
 	return nil
+
 }
 
 type ClusterHealthCondensedObject struct {

--- a/cmd/getoutput/getoutput.go
+++ b/cmd/getoutput/getoutput.go
@@ -15,8 +15,8 @@ func GetOutput(cmd *cobra.Command) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if out != "" && out != "json" && out != "yaml" {
-		return "", cmdutil.UsageErrorf(cmd, "Invalid output format: Valid formats are ['', 'json', 'yaml']")
+	if out != "" && out != "json" && out != "yaml" && out != "env" {
+		return "", cmdutil.UsageErrorf(cmd, "Invalid output format: Valid formats are ['', 'json', 'yaml', 'env']")
 	}
 	return out, nil
 }

--- a/internal/utils/globalflags/globalflags.go
+++ b/internal/utils/globalflags/globalflags.go
@@ -1,0 +1,37 @@
+package globalflags
+
+import (
+	"flag"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/utils/pointer"
+)
+
+// Defines a set of Global Options available to all commands
+type GlobalOptions struct {
+	Output string
+}
+
+// AddGlobalFlags adds the Global Flags to the root command
+func AddGlobalFlags(cmd *cobra.Command, opts *GlobalOptions) {
+	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", "", "Invalid output format: Valid formats are ['', 'json', 'yaml']")
+}
+
+// GetFlags adds the kubeFlags we care about and adds the flags from the provided command
+func GetFlags(cmd *cobra.Command) *genericclioptions.ConfigFlags {
+	// Reuse kubectl global flags to provide namespace, context and credential options.
+	// We are not using NewConfigFlags here to avoid adding too many flags
+	flags := &genericclioptions.ConfigFlags{
+		KubeConfig:  pointer.StringPtr(""),
+		ClusterName: pointer.StringPtr(""),
+		Context:     pointer.StringPtr(""),
+		APIServer:   pointer.StringPtr(""),
+		Timeout:     pointer.StringPtr("0"),
+		Insecure:    pointer.BoolPtr(false),
+		Impersonate: pointer.StringPtr(""),
+	}
+	flags.AddFlags(cmd.PersistentFlags())
+	return flags
+}


### PR DESCRIPTION
Some cmds are redefining the global output flag locally and this is causing osdctl to panic. This PR fixes the issue