### PR TITLE
Error out during role assumption if no AWS Account ID is provided

### DIFF
--- a/pkg/k8s/clusterresourcefactory.go
+++ b/pkg/k8s/clusterresourcefactory.go
@@ -136,6 +136,11 @@ func (factory *ClusterResourceFactoryOptions) GetCloudProvider(verbose bool) (aw
 		isBYOC = false
 	}
 
+	if factory.AccountID == "" {
+		klog.Error("No account ID provided or in Account Claim. Please use -i or ensure ID is in Account Claim referenced in -C or the Account referenced in -A")
+		return nil, fmt.Errorf("no account ID provided")
+	}
+
 	callerIdentityOutput, err := awsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 	if err != nil {
 		klog.Error("Fail to get caller identity. Could you please validate the credentials?")


### PR DESCRIPTION
Currently, if no account id is provided via `-i`, the code still builds the arn and tries to assume the role, which will always fail. This change catches this early and errors before any assume role is attempted. This will also handle the case where an AccountClaim or Account is missing an Account ID.