### PR TITLE
Remove unused PersistentFlag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,8 +33,6 @@ var GitCommit string
 // Version is the tag version from the environment
 var Version string
 
-var Output string
-
 func init() {
 	_ = awsv1alpha1.AddToScheme(scheme.Scheme)
 	_ = routev1.AddToScheme(scheme.Scheme)
@@ -54,7 +52,6 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
-	rootCmd.PersistentFlags().StringVarP(&Output, "output", "o", "", "Invalid output format: Valid formats are ['', 'json', 'yaml']")
 
 	// Reuse kubectl global flags to provide namespace, context and credential options.
 	// We are not using NewConfigFlags here to avoid adding too many flags


### PR DESCRIPTION
Removing an unused PersistentFlag, that is overridden by at least one subcommand, resulting in the following error:
```
$ aws account cli

panic: unable to redefine 'o' shorthand in "cli" flagset: it's already used for "out" flag
```