### PR TITLE
OSD-9325: add clusterID to servicelog post payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,9 +302,9 @@ osdctl servicelog list ${CLUSTERID} --all-messages
 #### Post servicelogs
 
 ```bash
-EXTERNAL_ID= # an external id for a cluster
+CLUSTER_ID= # the unique cluster name, or internal, external id for a cluster
 TEMPLATE= # file or url in which the template exists in
-osdctl servicelog post --param=CLUSTER_UUID=${EXTERNAL_ID} --template=${TEMPLATE} --dry-run
+osdctl servicelog post ${CLUSTER_ID} --template=${TEMPLATE} --dry-run
 
 QUERIES_HERE= # queries that can be run on ocm's `clusters` resoruce
 TEMPLATE= # file or url in which the template exists in
@@ -319,14 +319,14 @@ EOF
 TEMPLATE= # file or url in which the template exists in
 osdctl servicelog post --template=${TEMPLATE} --query-file=query_file.txt --dry-run
 
-EXTERNAL_ID= # an external id for a cluster
-ANOTHER_EXTERNAL_ID= # similar, but shows how to  have multiple clusters as input
+CLUSTER_ID= # the unique cluster name, or internal, external id for a cluster
+ANOTHER_CLUSTER_ID= # similar, but shows how to  have multiple clusters as input
 # clusters_list.json will have the custom list of clusters to iterate on
 cat << EOF > clusters_list.json
 {
   "clusters": [
-    "${EXTERNAL_ID}",
-    "${ANOTHER_EXTERNAL_ID}"
+    "${CLUSTER_ID}",
+    "${ANOTHER_CLUSTER_ID}"
   ]
 }
 EOF

--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -373,6 +373,10 @@ func createPostRequest(ocmClient *sdk.Connection, cluster *v1.Cluster) (request 
 
 	Message.ClusterUUID = cluster.ExternalID()
 	Message.ClusterID = cluster.ID()
+	if subscription := cluster.Subscription(); subscription != nil {
+		Message.SubscriptionID = cluster.Subscription().ID()
+	}
+
 	messageBytes, err := json.Marshal(Message)
 	if err != nil {
 		return nil, fmt.Errorf("cannot marshal template to json: %v", err)

--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -51,6 +51,22 @@ var postCmd = &cobra.Command{
 		readFilterFile()      // parse the ocm filters in file provided via '-f' flag
 		readTemplate()        // parse the given JSON template provided via '-t' flag
 
+		if len(args) < 1 && filtersFromFile == "" && clustersFile == "" {
+			log.Fatalf("No cluster identifier has been found.")
+		}
+
+		var queries []string
+		for _, clusterIds := range args {
+			queries = append(queries, generateQuery(clusterIds))
+		}
+
+		if len(queries) > 0 {
+			if len(filterParams) > 0 {
+				log.Warnf("A cluster identifier was passed with the '-q' flag. This will apply logical AND between the search query and the cluster given, potentially resulting in no matches")
+			}
+			filterParams = append(filterParams, strings.Join(queries, " or "))
+		}
+
 		// For every '-p' flag, replace its related placeholder in the template & filterFiles
 		for k := range userParameterNames {
 			replaceFlags(userParameterNames[k], userParameterValues[k])
@@ -137,7 +153,7 @@ var postCmd = &cobra.Command{
 		}()
 
 		for _, cluster := range clusters {
-			request, err := createPostRequest(ocmClient, cluster.ExternalID())
+			request, err := createPostRequest(ocmClient, cluster)
 			if err != nil {
 				failedClusters[cluster.ExternalID()] = err.Error()
 				continue
@@ -169,7 +185,6 @@ func init() {
 
 // parseUserParameters parse all the '-p FOO=BAR' parameters and checks for syntax errors
 func parseUserParameters() {
-	var queries []string // interpret all '-p CLUSTER_UUID' parameters as queries to be made to the ocmClient
 	for _, v := range templateParams {
 		if !strings.Contains(v, "=") {
 			log.Fatalf("Wrong syntax of '-p' flag. Please use it like this: '-p FOO=BAR'")
@@ -180,19 +195,8 @@ func parseUserParameters() {
 			log.Fatalf("Wrong syntax of '-p' flag. Please use it like this: '-p FOO=BAR'")
 		}
 
-		if param[0] != "CLUSTER_UUID" {
-			userParameterNames = append(userParameterNames, fmt.Sprintf("${%v}", param[0]))
-			userParameterValues = append(userParameterValues, param[1])
-		} else {
-			queries = append(queries, generateQuery(param[1]))
-		}
-	}
-
-	if len(queries) != 0 {
-		if len(filterParams) != 0 {
-			log.Warnf("At least one $CLUSTER_UUID parameter was passed with the '-q' flag. This will apply logical AND between the search query and the cluster(s) given, potentially resulting in no matches")
-		}
-		filterParams = append(filterParams, strings.Join(queries, " or "))
+		userParameterNames = append(userParameterNames, fmt.Sprintf("${%v}", param[0]))
+		userParameterValues = append(userParameterValues, param[1])
 	}
 }
 
@@ -359,7 +363,7 @@ func printTemplate() (err error) {
 	return dump.Pretty(os.Stdout, exampleMessage)
 }
 
-func createPostRequest(ocmClient *sdk.Connection, clusterId string) (request *sdk.Request, err error) {
+func createPostRequest(ocmClient *sdk.Connection, cluster *v1.Cluster) (request *sdk.Request, err error) {
 	// Create and populate the request:
 	request = ocmClient.Post()
 	err = arguments.ApplyPathArg(request, targetAPIPath)
@@ -367,7 +371,8 @@ func createPostRequest(ocmClient *sdk.Connection, clusterId string) (request *sd
 		return nil, fmt.Errorf("cannot parse API path '%s': %v", targetAPIPath, err)
 	}
 
-	Message.ClusterUUID = clusterId
+	Message.ClusterUUID = cluster.ExternalID()
+	Message.ClusterID = cluster.ID()
 	messageBytes, err := json.Marshal(Message)
 	if err != nil {
 		return nil, fmt.Errorf("cannot marshal template to json: %v", err)

--- a/internal/servicelog/reply.go
+++ b/internal/servicelog/reply.go
@@ -10,7 +10,6 @@ type GoodReply struct {
 	Severity      string    `json:"severity"`
 	ServiceName   string    `json:"service_name"`
 	ClusterUUID   string    `json:"cluster_uuid"`
-	ClusterID     string    `json:"cluster_id"`
 	Summary       string    `json:"summary"`
 	Description   string    `json:"description"`
 	EventStreamID string    `json:"event_stream_id"`

--- a/internal/servicelog/reply.go
+++ b/internal/servicelog/reply.go
@@ -10,6 +10,7 @@ type GoodReply struct {
 	Severity      string    `json:"severity"`
 	ServiceName   string    `json:"service_name"`
 	ClusterUUID   string    `json:"cluster_uuid"`
+	ClusterID     string    `json:"cluster_id"`
 	Summary       string    `json:"summary"`
 	Description   string    `json:"description"`
 	EventStreamID string    `json:"event_stream_id"`

--- a/internal/servicelog/template.go
+++ b/internal/servicelog/template.go
@@ -9,7 +9,8 @@ import (
 type Message struct {
 	Severity      string `json:"severity"`
 	ServiceName   string `json:"service_name"`
-	ClusterUUID   string `json:"cluster_uuid"`
+	ClusterUUID   string `json:"cluster_uuid,omitempty"`
+	ClusterID     string `json:"cluster_id,omitempty"`
 	Summary       string `json:"summary"`
 	Description   string `json:"description"`
 	InternalOnly  bool   `json:"internal_only"`
@@ -26,6 +27,10 @@ func (m *Message) GetServiceName() string {
 
 func (m *Message) GetClusterUUID() string {
 	return m.ClusterUUID
+}
+
+func (m *Message) GetClusterID() string {
+	return m.ClusterID
 }
 
 func (m *Message) GetSummary() string {
@@ -48,6 +53,7 @@ func (m *Message) ReplaceWithFlag(variable, value string) {
 	m.Severity = strings.ReplaceAll(m.Severity, variable, value)
 	m.ServiceName = strings.ReplaceAll(m.ServiceName, variable, value)
 	m.ClusterUUID = strings.ReplaceAll(m.ClusterUUID, variable, value)
+	m.ClusterID = strings.ReplaceAll(m.ClusterID, variable, value)
 	m.Summary = strings.ReplaceAll(m.Summary, variable, value)
 	m.Description = strings.ReplaceAll(m.Description, variable, value)
 	m.EventStreamID = strings.ReplaceAll(m.EventStreamID, variable, value)
@@ -61,6 +67,9 @@ func (m *Message) SearchFlag(placeholder string) (found bool) {
 		return found
 	}
 	if found = strings.Contains(m.ClusterUUID, placeholder); found == true {
+		return found
+	}
+	if found = strings.Contains(m.ClusterID, placeholder); found == true {
 		return found
 	}
 	if found = strings.Contains(m.Summary, placeholder); found == true {

--- a/internal/servicelog/template.go
+++ b/internal/servicelog/template.go
@@ -7,14 +7,15 @@ import (
 
 // Message is the base template structure
 type Message struct {
-	Severity      string `json:"severity"`
-	ServiceName   string `json:"service_name"`
-	ClusterUUID   string `json:"cluster_uuid,omitempty"`
-	ClusterID     string `json:"cluster_id,omitempty"`
-	Summary       string `json:"summary"`
-	Description   string `json:"description"`
-	InternalOnly  bool   `json:"internal_only"`
-	EventStreamID string `json:"event_stream_id"`
+	Severity       string `json:"severity"`
+	ServiceName    string `json:"service_name"`
+	ClusterUUID    string `json:"cluster_uuid,omitempty"`
+	ClusterID      string `json:"cluster_id,omitempty"`
+	Summary        string `json:"summary"`
+	Description    string `json:"description"`
+	InternalOnly   bool   `json:"internal_only"`
+	EventStreamID  string `json:"event_stream_id"`
+	SubscriptionID string `json:"subscription_id,omitempty"`
 }
 
 func (m *Message) GetSeverity() string {
@@ -49,6 +50,10 @@ func (m *Message) GetEventStreamID() string {
 	return m.EventStreamID
 }
 
+func (m *Message) GetSubscriptionID() string {
+	return m.SubscriptionID
+}
+
 func (m *Message) ReplaceWithFlag(variable, value string) {
 	m.Severity = strings.ReplaceAll(m.Severity, variable, value)
 	m.ServiceName = strings.ReplaceAll(m.ServiceName, variable, value)
@@ -57,6 +62,7 @@ func (m *Message) ReplaceWithFlag(variable, value string) {
 	m.Summary = strings.ReplaceAll(m.Summary, variable, value)
 	m.Description = strings.ReplaceAll(m.Description, variable, value)
 	m.EventStreamID = strings.ReplaceAll(m.EventStreamID, variable, value)
+	m.SubscriptionID = strings.ReplaceAll(m.SubscriptionID, variable, value)
 }
 
 func (m *Message) SearchFlag(placeholder string) (found bool) {
@@ -79,6 +85,9 @@ func (m *Message) SearchFlag(placeholder string) (found bool) {
 		return found
 	}
 	if found = strings.Contains(m.EventStreamID, placeholder); found == true {
+		return found
+	}
+	if found = strings.Contains(m.SubscriptionID, placeholder); found == true {
 		return found
 	}
 	return false


### PR DESCRIPTION
This PR removes the requirement to specify the Cluster_UUID as a -p parameter and the ${CLUSTER_UUID} definition in the template. Instead, the cluster identifier (UUID, ID, or display Name) is passed directly after the post. Based on this osdctl adds the values that are required by the ocm API. 

E.g.: 
To send one service log use 
```
  osdctl servicelog post clusterID -t github/path/to/template -p arg1="foo"
```
To send SL to several clusters:
```
  osdctl servicelog post {clusterID1, clusterID2} -t github/path/to/template -p arg1="foo"
```
It also further supports the definition of a query list and cluster list file. 