### PR TITLE
Ensure kubecli is set for packet-capture cmd

### DIFF
--- a/cmd/network/packet-capture.go
+++ b/cmd/network/packet-capture.go
@@ -81,6 +81,7 @@ func newPacketCaptureOptions(streams genericclioptions.IOStreams, flags *generic
 	return &packetCaptureOptions{
 		flags:     flags,
 		IOStreams: streams,
+		kubeCli:   client,
 	}
 }
 


### PR DESCRIPTION
This PR addresses a `panic` that I observed when attempting to run an `osdctl network packet-capture` call. The `kubeCli` variable was not being set and hence was a nil pointer when first used.

Upon further investigation it was observed that it was being ignored in the `newPacketCaptureOptions` function. This PR ensures that it is set as part of that function call.

Successfully tested on a cluster to ensure that the command now behaves appropriately.