### PR TITLE
fix(console): prepend region 

### DIFF
--- a/cmd/account/console.go
+++ b/cmd/account/console.go
@@ -107,7 +107,7 @@ func PrependRegionToURL(consoleURL, region string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("cannot parse consoleURL '%s' : %w", consoleURL, err)
 	}
-	urlValues, _ := url.ParseQuery(u.RawQuery)
+	urlValues, err := url.ParseQuery(u.RawQuery)
 	if err != nil {
 		return "", fmt.Errorf("cannot parse the queries '%s' : %w", u.RawQuery, err)
 	}


### PR DESCRIPTION
this PR will allow a user to `osdctl account console` into a cluster and it will open the console in the correct region

thanks to @mmazur for the suggestion in #182 