### PR TITLE
bump ocm sdk version

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,18 +1,18 @@
-# Validate the goReleaser configuration
+# Create a project release automatically on tag creation
 
-name: validate_goreleaser
+name: create_release_on_tag
 
 on:
   push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+    tags:
+      - "*" # triggers only if push new tag version, like `0.8.4`
 
 jobs:
-  validate_goreleaser:
+  build:
+    name: create_release_on_tag
     runs-on: ubuntu-latest
+    permissions:
+      repository-projects: write
 
     steps:
       - name: Check out code into the Go module directory
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.15.2
+          go-version: 1.16.8
         id: go
 
       - name: Download GoReleaser
@@ -33,3 +33,12 @@ jobs:
       - name: Check goreleaser validity
         run: |
           ./bin/goreleaser check
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@master
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/golang/mock v1.5.0
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/onsi/gomega v1.13.0
+	github.com/onsi/gomega v1.16.0
 	github.com/openshift-online/ocm-cli v0.1.59
-	github.com/openshift-online/ocm-sdk-go v0.1.204
+	github.com/openshift-online/ocm-sdk-go v0.1.205
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/aws-account-operator/pkg/apis v0.0.0-20210611151019-01b1df7a3e9e
 	github.com/openshift/gcp-project-operator v0.0.0-20210906153132-ce9b2425f1a7

--- a/go.sum
+++ b/go.sum
@@ -1832,8 +1832,9 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/onsi/gomega v1.13.0 h1:7lLHu94wT9Ij0o6EWWclhu0aOh32VxhkwEJvzuWPeak=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
+github.com/onsi/gomega v1.16.0 h1:6gjqkI8iiRHMvdccRJM8rVKjCWk6ZIm6FTm3ddIe4/c=
+github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -1849,8 +1850,9 @@ github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mo
 github.com/openshift-metal3/terraform-provider-ironic v0.2.1/go.mod h1:G79T6t60oBpYfZK/x960DRzYsNHdz5YVCHINx6QlmtU=
 github.com/openshift-online/ocm-cli v0.1.59 h1:yS32dQInuBi572wL5rAEvycbnRaV6MXkroS4O9wVGl8=
 github.com/openshift-online/ocm-cli v0.1.59/go.mod h1:z5MCjQ8Frc7Bhv59rp0deR2kyEs8901uie95+Xk7THY=
-github.com/openshift-online/ocm-sdk-go v0.1.204 h1:SWqCItOqSTneVYjowFhtdevwlNFv5PXApeej2orO1pg=
 github.com/openshift-online/ocm-sdk-go v0.1.204/go.mod h1:RNoKwEJaFMJJvKWKPzv5iQvRau/eHL7py6eOhCgnfwU=
+github.com/openshift-online/ocm-sdk-go v0.1.205 h1:DhvfTf55jpQsTFpI283/z3b0Tab8x26oelPDuao7IiM=
+github.com/openshift-online/ocm-sdk-go v0.1.205/go.mod h1:iOhkt/6nFp9v7hasdmGbYlR/YKeUoaZKq5ZBrtyKwKg=
 github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/api v0.0.0-20200320142426-0de0d539b0c3/go.mod h1:7k3+uZYOir97walbYUqApHUA2OPhkQpVJHt0n7GJ6P4=
 github.com/openshift/api v0.0.0-20200323095748-e7041f8762a3/go.mod h1:7k3+uZYOir97walbYUqApHUA2OPhkQpVJHt0n7GJ6P4=


### PR DESCRIPTION
- Adds Goreleaser release on new tag creation
- Adds Goreleaser release on new tag creation
- Bump ocm-sdk to v0.1.205
