### PR TITLE
[OSD-9246] Fix account reset with resetlegalentityid

### DIFF
--- a/cmd/account/reset.go
+++ b/cmd/account/reset.go
@@ -147,14 +147,17 @@ func (o *resetOptions) run() error {
 		}
 		parentId := *parent.Parents[0].Id
 
-		//move the account from the current OU to rootOU
-		_, err = awsClient.MoveAccount(&organizations.MoveAccountInput{
-			AccountId:           aws.String(accountId),
-			DestinationParentId: aws.String(rootId),
-			SourceParentId:      aws.String(parentId),
-		})
-		if err != nil {
-			return err
+		// To avoid DuplicateAccountException, validate we're not trying to move the account to an OU it's already in.
+		if rootId != parentId {
+			//move the account from the current OU to rootOU
+			_, err = awsClient.MoveAccount(&organizations.MoveAccountInput{
+				AccountId:           aws.String(accountId),
+				DestinationParentId: aws.String(rootId),
+				SourceParentId:      aws.String(parentId),
+			})
+			if err != nil {
+				return err
+			}
 		}
 
 		//reset account Spec


### PR DESCRIPTION
Previously if you attempted to reset an account and move it up an OU it was already part of, AWS would throw a DuplicateAccountException error. We were not handling that case. These changes ensure that we're not trying to move an account to an OU it is already part of. 

This issue was encountered as part of research into dangling account crs [[OSD-9246]](https://issues.redhat.com/browse/OSD-9246)