### PR TITLE
feat: implement latest version via Github API

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	routev1 "github.com/openshift/api/route/v1"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	gcpv1alpha1 "github.com/openshift/gcp-project-operator/pkg/apis"
@@ -26,12 +24,6 @@ import (
 	"github.com/openshift/osdctl/pkg/k8s"
 )
 
-// GitCommit is the short git commit hash from the environment
-var GitCommit string
-
-// Version is the tag version from the environment
-var Version string
-
 func init() {
 	_ = awsv1alpha1.AddToScheme(scheme.Scheme)
 	_ = routev1.AddToScheme(scheme.Scheme)
@@ -44,7 +36,6 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	globalOpts := &globalflags.GlobalOptions{}
 	rootCmd := &cobra.Command{
 		Use:               "osdctl",
-		Version:           fmt.Sprintf("%s, GitCommit: %s", Version, GitCommit),
 		Short:             "OSD CLI",
 		Long:              `CLI tool to provide OSD related utilities`,
 		DisableAutoGenTag: true,
@@ -77,8 +68,12 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	templates.ActsAsRootCommand(rootCmd, []string{"options"})
 	rootCmd.AddCommand(newCmdOptions(streams))
 
-	//Add cost command to use AWS Cost Manager
+	// Add cost command to use AWS Cost Manager
 	rootCmd.AddCommand(cost.NewCmdCost(streams, globalOpts))
+
+	// Add version subcommand. Using the in-build --version flag does not work with cobra
+	// because there is no way to hook a function to the --version flag in cobra.
+	rootCmd.AddCommand(versionCmd)
 
 	return rootCmd
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// GitCommit is the short git commit hash from the environment
+	GitCommit string
+
+	// Version is the tag version from the environment
+	Version string
+)
+
+// githubResponse is a necessary struct for the JSON unmarshalling that is happening
+// in the getLatestVersion().
+type gitHubResponse struct {
+	TagName string `json:"tag_name"`
+}
+
+// versionResponse is necessary for the JSON version response. It uses the three
+// variables that get set during the build.
+type versionResponse struct {
+	Commit  string `json:"commit"`
+	Version string `json:"version"`
+	Latest  string `json:"latest"`
+}
+
+// versionCmd is the subcommand "osdctl version" for cobra.
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Display the version",
+	Long:  "Display version of osdctl",
+	RunE:  version,
+}
+
+// version returns the osdctl version marshalled in JSON
+func version(cmd *cobra.Command, args []string) error {
+	latest, _ := getLatestVersion() // let's ignore this error, just in case we have no internet access
+	ver, err := json.MarshalIndent(&versionResponse{
+		Commit:  GitCommit,
+		Version: Version,
+		Latest:  latest,
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(ver))
+	return nil
+}
+
+// getLatestVersion connects to the GitHub API and returns the latest osdctl tag name
+// Interesting Note: GitHub only shows the latest "stable" tag. This means, that
+// tags with a suffix like *-rc.1 are not returned. We will always show the latest stable on master branch.
+func getLatestVersion() (latest string, err error) {
+	url := "https://api.github.com/repos/openshift/osdctl/releases/latest"
+	client := http.Client{
+		Timeout: time.Second * 2,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return latest, err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return latest, err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return latest, err
+	}
+
+	githubResp := gitHubResponse{}
+	err = json.Unmarshal(body, &githubResp)
+	if err != nil {
+		return latest, err
+	}
+
+	return githubResp.TagName, nil
+}


### PR DESCRIPTION
This PR implements the latest tag via callling the Github API.

Unfortunately, I had to introduce a new `version` subcommand, because the cobra in-built version flag `--version` is not capable of running a function as a hook before rootCmd initialization.

Furthermore, I have modified the version output a little bit. We are now printing valid JSON (like kubectl does):

```
❯ ./osdctl version
{
  "commit": "",
  "version": "",
  "latest": "v0.9.3"
}
```


This PR closes: [OSD-10247](https://issues.redhat.com/browse/OSD-10247)