### PR TITLE
implement in-place upgrades for osdctl

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,14 @@ builds:
     goarch:
       - amd64
     ldflags:
-      - -s -w -X github.com/openshift/osdctl/cmd.GitCommit={{.ShortCommit}} -X github.com/openshift/osdctl/cmd.Version={{.Version}}
+      # the following line will inject the current git commit and git tag in the binary during the build process.
+      # .ShortCommit and .Version are template variables that will be set during the GoReleaser run
+      # The "-X" go flag injects the strings into the two global variables GitCommit and Version
+      # See also: https://pkg.go.dev/cmd/link
+      - -s
+      - -w 
+      - -X github.com/openshift/osdctl/cmd.GitCommit={{.ShortCommit}}
+      - -X github.com/openshift/osdctl/cmd.Version={{.Version}}
       - "-extldflags=-zrelro" # binary hardening: For further explanation look here: https://www.redhat.com/en/blog/hardening-elf-binaries-using-relocation-read-only-relro
       - "-extldflags=-znow"
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ OS := $(shell go env GOOS | sed 's/[a-z]/\U&/')
 ARCH := $(shell go env GOARCH)
 .PHONY: download-goreleaser
 download-goreleaser:
-	GOBIN=${BASE_DIR}/bin/ go install github.com/goreleaser/goreleaser@latest
+	GOBIN=${BASE_DIR}/bin/ go install github.com/goreleaser/goreleaser@v1.6.3
 
 # CI build containers don't include goreleaser by default,
 # so they need to get it first, and then run the build

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,6 +75,9 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	// because there is no way to hook a function to the --version flag in cobra.
 	rootCmd.AddCommand(versionCmd)
 
+	// Add upgradeCmd for upgrading the currently running executable in-place.
+	rootCmd.AddCommand(upgradeCmd)
+
 	return rootCmd
 }
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/spf13/cobra"
+)
+
+var upgradeCmd = &cobra.Command{
+	Use:           "upgrade",
+	Short:         "Upgrade osdctl",
+	Long:          "Fetch latest osdctl from GitHub and replace the running binary",
+	RunE:          upgrade,
+	SilenceErrors: true,
+}
+
+func upgrade(cmd *cobra.Command, args []string) error {
+	// rootName ensures that the upgrade will fail if we ever decide to rename osdctl
+	// between releases :-)
+	rootName := cmd.Root().Name()
+
+	latest, err := getLatestVersion()
+	if err != nil {
+		return err
+	}
+	latestWithoutPrefix := strings.TrimPrefix(latest, "v")
+	// check if an upgrade is necessary
+	currentSemVer := semver.New(Version)
+	latestSemVer := semver.New(latestWithoutPrefix)
+	if !currentSemVer.LessThan(*latestSemVer) {
+		return fmt.Errorf("we are already up to date")
+	}
+	// upgrade necessary
+	client := http.Client{
+		Timeout: time.Second * 60,
+	}
+
+	addr := fmt.Sprintf(versionAddressTemplate,
+		latestWithoutPrefix,
+		latestWithoutPrefix,
+		parseGOOS(runtime.GOOS),
+		parseGOARCH(runtime.GOARCH))
+
+	req, err := http.NewRequest(http.MethodGet, addr, nil)
+	if err != nil {
+		return err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	gzf, err := gzip.NewReader(res.Body)
+	if err != nil {
+		return err
+	}
+
+	tr := tar.NewReader(gzf)
+	for {
+		f, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if f.Name != rootName {
+			continue
+		}
+		// For replacing a running executable we have to use the syscall "rename".
+		// "rename" can only be called on executables (old/new destination/name)
+		// that are stored on the same filesystem. This is the reason, why we cannot
+		// use a directory on ramfs here (f.e. /tmp/). Instead, we are creating a
+		// temp dir in the user's $HOME.
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+
+		dir, err := ioutil.TempDir(homeDir, ".*")
+		if err != nil {
+			return err
+		}
+
+		defer os.RemoveAll(dir)
+
+		tmpFilePath := filepath.Join(dir, rootName)
+
+		tmpFile, err := os.OpenFile(tmpFilePath, os.O_CREATE|os.O_RDWR, 0755)
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Copy(tmpFile, tr)
+		if err != nil {
+			return err
+		}
+
+		// get path of current executable
+		exe, err := os.Executable()
+		if err != nil {
+			return err
+		}
+
+		os.Rename(tmpFilePath, filepath.Join(filepath.Dir(exe), rootName))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func parseGOOS(goos string) string {
+	switch goos {
+	case "linux":
+		return "Linux"
+	case "darwin":
+		return "Darwin"
+	case "windows":
+		return "Windows"
+	default:
+		return ""
+	}
+}
+
+func parseGOARCH(goarch string) string {
+	switch goarch {
+	case "amd64":
+		return "x86_64"
+	default:
+		return ""
+	}
+}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -35,12 +35,11 @@ func upgrade(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	latestWithoutPrefix := strings.TrimPrefix(latest, "v")
-	// check if an upgrade is necessary
 	currentSemVer := semver.New(Version)
 	latestSemVer := semver.New(latestWithoutPrefix)
 	if !currentSemVer.LessThan(*latestSemVer) {
-               fmt.Println("Already up to date, nothing to do!")
-	       return nil
+		fmt.Println("Already up to date, nothing to do!")
+		return nil
 	}
 	// upgrade necessary
 	client := http.Client{

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -39,7 +39,8 @@ func upgrade(cmd *cobra.Command, args []string) error {
 	currentSemVer := semver.New(Version)
 	latestSemVer := semver.New(latestWithoutPrefix)
 	if !currentSemVer.LessThan(*latestSemVer) {
-		return fmt.Errorf("we are already up to date")
+               fmt.Println("Already up to date, nothing to do!")
+	       return nil
 	}
 	// upgrade necessary
 	client := http.Client{

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,9 +5,15 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+)
+
+const (
+	versionAPIEndpoint     = "https://api.github.com/repos/openshift/osdctl/releases/latest"
+	versionAddressTemplate = "https://github.com/openshift/osdctl/releases/download/v%s/osdctl_%s_%s_%s.tar.gz" // version, version, GOOS, GOARCH
 )
 
 var (
@@ -46,7 +52,7 @@ func version(cmd *cobra.Command, args []string) error {
 	ver, err := json.MarshalIndent(&versionResponse{
 		Commit:  GitCommit,
 		Version: Version,
-		Latest:  latest,
+		Latest:  strings.TrimPrefix(latest, "v"),
 	}, "", "  ")
 	if err != nil {
 		return err
@@ -59,12 +65,11 @@ func version(cmd *cobra.Command, args []string) error {
 // Interesting Note: GitHub only shows the latest "stable" tag. This means, that
 // tags with a suffix like *-rc.1 are not returned. We will always show the latest stable on master branch.
 func getLatestVersion() (latest string, err error) {
-	url := "https://api.github.com/repos/openshift/osdctl/releases/latest"
 	client := http.Client{
 		Timeout: time.Second * 2,
 	}
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, versionAPIEndpoint, nil)
 	if err != nil {
 		return latest, err
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,9 +18,13 @@ const (
 
 var (
 	// GitCommit is the short git commit hash from the environment
+	// Will be set during build process via GoReleaser
+	// See also: https://pkg.go.dev/cmd/link
 	GitCommit string
 
 	// Version is the tag version from the environment
+	// Will be set during build process via GoReleaser
+	// See also: https://pkg.go.dev/cmd/link
 	Version string
 )
 


### PR DESCRIPTION
This PR implements in-place upgrades for osdctl. For doing this there are a few requirements:

1. We are getting the latest release URL via the GitHub API
2. Our releases should not change and **must** follow the same patterns: osdctl_0.9.3_Linux_x86_64.tar.gz, osdctl_0.9.3_Darwin_x86_64.tar.gz

This is an early POC (it works) and is based on one of my other PRs that implements the `version` subcommand.

To test this PR:

1.  goreleaser build --skip-validate --rm-dist
2. cd dist/osdctl_linux_amd64 
3. ./osdctl version
4. ./osdctl upgrade
5. ./osdctl version


Expected Output:

```
❯ ./osdctl version
{
  "commit": "ccce3bc",
  "version": "0.9.2",
  "latest": "v0.9.3"
}

❯ ./osdctl upgrade

❯ ./osdctl --version
osdctl version 0.9.3, GitCommit: aaa1cd7
```

Note the old `--version` flag for 0.9.3, that's because my new version subcommand is not yet on the main branch.

This PR closes: [OSD-10248](https://issues.redhat.com/browse/OSD-10248)