### PR TITLE
[OSD-10363] Add support for the AWS GovCloud partition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ OS := $(shell go env GOOS | sed 's/[a-z]/\U&/')
 ARCH := $(shell go env GOARCH)
 .PHONY: download-goreleaser
 download-goreleaser:
-	GOBIN=${BASE_DIR}/bin/ go install github.com/goreleaser/goreleaser@latest
+	GOBIN=${BASE_DIR}/bin/ go install github.com/goreleaser/goreleaser@v1.6.3
 
 # CI build containers don't include goreleaser by default,
 # so they need to get it first, and then run the build

--- a/cmd/aao/pool.go
+++ b/cmd/aao/pool.go
@@ -5,9 +5,7 @@ import (
 	"os/exec"
 
 	"github.com/spf13/cobra"
-
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	//"k8s.io/klog"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 

--- a/cmd/account/console.go
+++ b/cmd/account/console.go
@@ -80,9 +80,17 @@ func (o *consoleOptions) run() error {
 		return err
 	}
 
-	consoleURL, err := awsprovider.RequestSignInToken(awsClient, &o.k8sclusterresourcefactory.Awscloudfactory.ConsoleDuration,
-		aws.String(o.k8sclusterresourcefactory.Awscloudfactory.SessionName), aws.String(fmt.Sprintf("arn:aws:iam::%s:role/%s",
-			o.k8sclusterresourcefactory.AccountID, o.k8sclusterresourcefactory.Awscloudfactory.RoleName)))
+	partition, err := awsprovider.GetAwsPartition(awsClient)
+	if err != nil {
+		return err
+	}
+
+	consoleURL, err := awsprovider.RequestSignInToken(
+		awsClient,
+		&o.k8sclusterresourcefactory.Awscloudfactory.ConsoleDuration,
+		aws.String(o.k8sclusterresourcefactory.Awscloudfactory.SessionName),
+		aws.String(fmt.Sprintf("arn:%s:iam::%s:role/%s", partition, o.k8sclusterresourcefactory.AccountID, o.k8sclusterresourcefactory.Awscloudfactory.RoleName)),
+	)
 	if err != nil {
 		fmt.Fprintf(o.IOStreams.Out, "Generating console failed. If CCS cluster, customer removed or denied access to the ManagedOpenShiftSupport role.")
 		return err

--- a/cmd/cluster/health.go
+++ b/cmd/cluster/health.go
@@ -20,8 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/klog"
-
+	"k8s.io/klog/v2"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	k8s.io/apimachinery v0.18.5
 	k8s.io/cli-runtime v0.18.3
 	k8s.io/client-go v12.0.0+incompatible
-	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/kubectl v0.18.3
 	k8s.io/utils v0.0.0-20200327001022-6496210b90e8

--- a/pkg/provider/aws/iam.go
+++ b/pkg/provider/aws/iam.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/klog"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
 )
 
 type awsStatement struct {

--- a/pkg/provider/aws/s3.go
+++ b/pkg/provider/aws/s3.go
@@ -1,10 +1,10 @@
 package aws
 
 import (
-	"k8s.io/klog"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/s3"
+	"k8s.io/klog/v2"
 )
 
 // Delete all S3 buckets with the specified prefix

--- a/pkg/provider/aws/sts_test.go
+++ b/pkg/provider/aws/sts_test.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"encoding/json"
 	"errors"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/golang/mock/gomock"
 	"github.com/openshift/osdctl/pkg/provider/aws/mock"


### PR DESCRIPTION
- In the "front-end" CLI, I've abstracted out the partition such that it should work for any partition
- In the "back-end", I've also abstracted out the partition, but added support specifically for the GovCloud partition. As more partitions are added, `GetFederationEndpointUrl` and `GetConsoleUrl` can grow.
  - Previously the backend assumed us-east-1 as a safe default; I [added a retry](https://github.com/openshift/osdctl/compare/master...mjlshen:OSD-10363?expand=1#diff-a6eb9c64557660244a5986e0e7a0bfc80590bab12c6ad1393bc25bdfc0f473bdR185) for us-gov-west-1 (the default GovCloud region) if it fails.

- klog --> klog/v2
- Seems like prow was failing due to GoReleaser's latest version using `strings.Cut` that is part of Go 1.18. Unsure if we want to bump this project up to Go 1.18, so pinning GoReleaser for now