### PR TITLE
fix: add missing arm64 GOOS for auto upgrades

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -139,6 +139,8 @@ func parseGOARCH(goarch string) string {
 	switch goarch {
 	case "amd64":
 		return "x86_64"
+	case "arm64":
+		return "arm64"
 	default:
 		return ""
 	}


### PR DESCRIPTION
This adds a missing GOOS case to the new upgrade command.

@georgettica  you might want to cut a new release.


TBH, we should remove the override in the goreleaser here:
```
archives:
  - replacements:
      darwin: Darwin
      linux: Linux
      amd64: x86_64
```

If we remove this section, we could get rid of the switch statements in the upgrade command.... because due to this replacements we have to maintain a mapping between the GOOS and GOARCH and our custom replacements. 
This leads to problems.


@cblecker's PR is related to this one: https://github.com/openshift/osdctl/pull/200 (I don't blame him.. he couldn't know that we have introduced the new upgrade command... we really should think about generating a changelog on the long term).