### PR TITLE
fix: remove custom replacements and mapping

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,12 +30,6 @@ builds:
       - "-extldflags=-zrelro" # binary hardening: For further explanation look here: https://www.redhat.com/en/blog/hardening-elf-binaries-using-relocation-read-only-relro
       - "-extldflags=-znow"
 
-archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      amd64: x86_64
-
 checksum:
   name_template: 'sha256sum.txt'
   algorithm: sha256

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -49,8 +49,8 @@ func upgrade(cmd *cobra.Command, args []string) error {
 	addr := fmt.Sprintf(versionAddressTemplate,
 		latestWithoutPrefix,
 		latestWithoutPrefix,
-		parseGOOS(runtime.GOOS),
-		parseGOARCH(runtime.GOARCH))
+		runtime.GOOS,
+		runtime.GOARCH)
 
 	req, err := http.NewRequest(http.MethodGet, addr, nil)
 	if err != nil {
@@ -120,26 +120,4 @@ func upgrade(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return nil
-}
-
-func parseGOOS(goos string) string {
-	switch goos {
-	case "linux":
-		return "Linux"
-	case "darwin":
-		return "Darwin"
-	case "windows":
-		return "Windows"
-	default:
-		return ""
-	}
-}
-
-func parseGOARCH(goarch string) string {
-	switch goarch {
-	case "amd64":
-		return "x86_64"
-	default:
-		return ""
-	}
 }


### PR DESCRIPTION
This PR removes the custom archive replacements and custom GOOS/GOARCH mappings in our upgrade command.
I do suggest, that we cut a 0.10.0 release, because this feature is  a breaking change in the current upgrade behavior.