### PR TITLE
Do not use a default accountAssignID

### DIFF
--- a/cmd/account/mgmt/account-assign.go
+++ b/cmd/account/mgmt/account-assign.go
@@ -123,7 +123,7 @@ func (o *accountAssignOptions) run() error {
 		// otherwise, create a new account
 		seed := time.Now().UnixNano()
 		accountAssignID, err = o.buildAccount(seed)
-		accountAssignID = "12345"
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When trying to create an additional account the following error occurred:

```
Creating account
error: InvalidInputException: You provided a value that does not match the required pattern.
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "ada9947f-13f1-455a-ac3d-4be0541c5b90"
  },
  Message_: "You provided a value that does not match the required pattern.",
  Reason: "INVALID_PATTERN:RESOURCE_ID"
}
```

The issue was that a default string was assigned irrespective of the error status of the `buildAccount`.