### PR TITLE
[OSD-10470] Now displaying flags and global flags in help

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,6 @@ import (
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/kubectl/pkg/util/templates"
 
 	"github.com/openshift/osdctl/cmd/aao"
 	"github.com/openshift/osdctl/cmd/account"
@@ -67,7 +66,6 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	rootCmd.AddCommand(newCmdCompletion(streams))
 
 	// add options command to list global flags
-	templates.ActsAsRootCommand(rootCmd, []string{"options"})
 	rootCmd.AddCommand(newCmdOptions(streams))
 
 	// Add cost command to use AWS Cost Manager


### PR DESCRIPTION
The help for `osdctl cost -h` after that:

```                           
The cost command allows for cost management on the AWS platform (other 
platforms may be added in the future)

Usage:
  osdctl cost [command]

Available Commands:
  create      Create a cost category for the given OU
  get         Get total cost of a given OU
  list        List the cost of each Account/OU under given OU
  reconcile   Checks if there's a cost category for every OU. If an OU is missing a cost category, creates the cost category

Flags:
  -a, --aws-access-key-id string       AWS Access Key ID
  -c, --aws-config string              specify AWS config file path
  -p, --aws-profile string             specify AWS profile
  -g, --aws-region string              specify AWS region (default "us-east-1")
  -x, --aws-secret-access-key string   AWS Secret Access Key
  -h, --help                           help for cost

Global Flags:
      --alsologtostderr                  log to standard error as well as files
      --as string                        Username to impersonate for the operation
      --cluster string                   The name of the kubeconfig cluster to use
      --context string                   The name of the kubeconfig context to use
      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files
  -o, --output string                    Invalid output format: Valid formats are ['', 'json', 'yaml']
      --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                    The address and port of the Kubernetes API server
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          log level for V logs
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

Use "osdctl cost [command] --help" for more information about a command.
```

Sub-command `options` at root level is still there but is not displayed anymore when shooting `osdctl -h`. Remark that as discussed in below issue on `minikube`, a solution could be to explicitly implement an `options` sub-command at root level:
https://github.com/kubernetes/minikube/issues/5036
Here the code for that `options` sub-command:
https://github.com/kubernetes/minikube/pull/6144/files
Not sure we really want to go in that way as `osdctl options` still displays the same before and after my change; also [Cobra](https://github.com/spf13/cobra) is perfectly able to display in a nicely manner all flags & global flags available for each command in the tree.
Hope I am not breaking anything by removing the call to `templates.ActsAsRootCommand`. Please tell me if that's the case.