### PR TITLE
[OSD-10928] Added CLUSTER_ID as param of 'osdctl servicelog post' in help

### DIFF
--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -43,7 +43,7 @@ const (
 
 // postCmd represents the post command
 var postCmd = &cobra.Command{
-	Use:   "post",
+	Use:   "post CLUSTER_ID",
 	Short: "Send a servicelog message to a given cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 


### PR DESCRIPTION
After that change `osdctl servicelog post -h` will output as follows:
```
Send a servicelog message to a given cluster

Options:
  -c, --clusters-file='': Read a list of clusters to post the servicelog to. the format of the file is:
{"clusters":["$CLUSTERID"]}
  -d, --dry-run=false: Dry-run - print the service log about to be sent but don't send it.
  -p, --param=[]: Specify a key-value pair (eg. -p FOO=BAR) to set/override a parameter value in the template.
  -q, --query=[]: Specify a search query (eg. -q "name like foo") for a bulk-post to matching clusters.
  -f, --query-file=[]: File containing search queries to apply. All lines in the file will be concatenated into a single
query. If this flag is called multiple times, every file's search query will be combined with logical AND.
  -t, --template='': Message template file or URL
  -y, --yes=false: Skips all prompts.

Usage:
  osdctl servicelog post CLUSTER_ID [flags] [options]

Use "osdctl options" for a list of global command-line options (applies to all commands).
```

Please tell me if this is okay for you.
Thanks!
   Nico