### PR TITLE
OSD-10993 - Split user params only once to avoid truncation

### DIFF
--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -193,7 +193,7 @@ func parseUserParameters() {
 			log.Fatalf("Wrong syntax of '-p' flag. Please use it like this: '-p FOO=BAR'")
 		}
 
-		param := strings.Split(v, "=")
+		param := strings.SplitN(v, "=", 2)
 		if param[0] == "" || param[1] == "" {
 			log.Fatalf("Wrong syntax of '-p' flag. Please use it like this: '-p FOO=BAR'")
 		}


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OSD-10993.

---

User parameters for servicelog templates will be truncated if they contain more than on `=`. This was found to be because the `parseUserParameters` function only takes the second token after dividing along every `=` separator in the user parameter string.

By only dividing the string a single time, the full parameter is successfully added to the template. 