### PR TITLE
Not advertising to shoot root command without a sub-command in usage anymore

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,7 +39,6 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 		Short:             "OSD CLI",
 		Long:              `CLI tool to provide OSD related utilities`,
 		DisableAutoGenTag: true,
-		Run:               help,
 	}
 
 	globalflags.AddGlobalFlags(rootCmd, globalOpts)


### PR DESCRIPTION
Removed the following usage from root command:
```
  osdctl [flags]
```
Now the usage displayed by the root command is just:
```
Usage:
  osdctl [command]

```
This make sense as the root command is not supposed to be shot without a sub-command.
Remark that this change also makes the root command consistent with some sub-commands (such as `osdctl cost`) which are also not displaying any `[flags]` usage. However some other descendant commands still display this misleading `[flags]` usage and could probably benefit from the same solution (i.e. deleting `Run:` definition when the target is the `help` function)
```
grep -rFI 'Run:' . | grep -F help        
./cmd/cluster/cmd.go:		Run:               help,
./cmd/federatedrole/cmd.go:		Run:               help,
./cmd/network/cmd.go:		Run:               help,
./cmd/clusterdeployment/cmd.go:		Run:               help,
./cmd/aao/cmd.go:		Run:               help,
./cmd/account/servicequotas/cmd.go:		Run:               help,
./cmd/account/cmd.go:		Run:               help,
./cmd/account/mgmt/cmd.go:		Run:               help,
./cmd/account/get/cmd.go:		Run:               help,
./cmd/account/list/cmd.go:		Run:               help,
./cmd/sts/cmd.go:		Run:               help,
```

Remark that:
- This change only affects the displayed help. Commands will still behave and exit with the same status before and after this change.
- Those misleading `[flags]` usage were revealed by this change: https://github.com/openshift/osdctl/pull/205