### PR TITLE
Do not allow passing -u *and* -i

### DIFF
--- a/cmd/account/mgmt/account-unassign.go
+++ b/cmd/account/mgmt/account-unassign.go
@@ -60,6 +60,9 @@ func (o *accountUnassignOptions) complete(cmd *cobra.Command, _ []string) error 
 	if o.username == "" && o.accountID == "" {
 		return cmdutil.UsageErrorf(cmd, "Please provide either an username or account ID")
 	}
+	if o.username != "" && o.accountID != "" {
+		return cmdutil.UsageErrorf(cmd, "Please provider only a username or an account ID, not both.")
+	}
 	return nil
 }
 func (o *accountUnassignOptions) run() error {

--- a/cmd/account/mgmt/account-unassign_test.go
+++ b/cmd/account/mgmt/account-unassign_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/openshift/osdctl/pkg/provider/aws/mock"
 
+	"github.com/openshift/osdctl/internal/utils/globalflags"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 func TestAssumeRoleForAccount(t *testing.T) {
@@ -601,5 +603,20 @@ func TestUntagAccount(t *testing.T) {
 	err := o.untagAccount(accountId)
 	if err != nil {
 		t.Errorf("failed to untag aws account")
+	}
+}
+
+func TestConflictingOptions(t *testing.T) {
+	s := genericclioptions.IOStreams{}
+	f := genericclioptions.ConfigFlags{}
+	g := globalflags.GlobalOptions{}
+	cmd := newCmdAccountAssign(s, &f, &g)
+	o := &accountUnassignOptions{}
+	o.payerAccount = "fake account"
+	o.accountID = "123456"
+	o.username = "testuser"
+	err := o.complete(cmd, []string{})
+	if err == nil {
+		t.Errorf("An error should have been raised")
 	}
 }


### PR DESCRIPTION
Right now when passing -u and -i the -u flag will take precedence.

This is very confusing, so instead of just unassigning everything, don't
allow passing both flags at once.