### PR TITLE
OSD-11287 Fix bug where region is being overriden in clusterresourcefactory

### DIFF
--- a/pkg/k8s/clusterresourcefactory.go
+++ b/pkg/k8s/clusterresourcefactory.go
@@ -147,14 +147,6 @@ func (factory *ClusterResourceFactoryOptions) GetCloudProvider(verbose bool) (aw
 		return nil, err
 	}
 
-	// Switch the region based on partition
-	switch roleArn.Partition {
-	case endpoints.AwsUsGovPartitionID:
-		factory.Awscloudfactory.Region = endpoints.UsGovWest1RegionID
-	default:
-		factory.Awscloudfactory.Region = endpoints.UsEast1RegionID
-	}
-
 	splitArn := strings.Split(roleArn.Resource, "/")
 	username := splitArn[1]
 	factory.Awscloudfactory.SessionName = fmt.Sprintf("RH-SRE-%s", username)


### PR DESCRIPTION
Fixes #212 , after this fix osdctl account console/credentials respects the `-r` flag again when specifying an account id with the `-i` flag