### PR TITLE
Not explicitly running the help target anymore for commands packing sub-commands

### DIFF
--- a/cmd/aao/cmd.go
+++ b/cmd/aao/cmd.go
@@ -12,7 +12,6 @@ func NewCmdAao(streams genericclioptions.IOStreams, flags *genericclioptions.Con
 		Short:             "AWS Account Operator Debugging Utilities",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
-		Run:               help,
 	}
 
 	aaoCmd.AddCommand(newCmdPool(streams, flags))

--- a/cmd/account/cmd.go
+++ b/cmd/account/cmd.go
@@ -19,7 +19,6 @@ func NewCmdAccount(streams genericclioptions.IOStreams, flags *genericclioptions
 		Short:             "AWS Account related utilities",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
-		Run:               help,
 	}
 
 	accountCmd.AddCommand(get.NewCmdGet(streams, flags, client, globalOpts))

--- a/cmd/account/get/cmd.go
+++ b/cmd/account/get/cmd.go
@@ -19,7 +19,6 @@ func NewCmdGet(streams genericclioptions.IOStreams, flags *genericclioptions.Con
 		Short:             "Get resources",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
-		Run:               help,
 	}
 
 	getCmd.AddCommand(newCmdGetAccount(streams, flags, client, globalOpts))

--- a/cmd/account/list/cmd.go
+++ b/cmd/account/list/cmd.go
@@ -14,7 +14,6 @@ func NewCmdList(streams genericclioptions.IOStreams, flags *genericclioptions.Co
 		Short:             "List resources",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
-		Run:               help,
 	}
 
 	listCmd.AddCommand(newCmdListAccount(streams, flags, client, globalOpts))

--- a/cmd/account/mgmt/cmd.go
+++ b/cmd/account/mgmt/cmd.go
@@ -13,7 +13,6 @@ func NewCmdMgmt(streams genericclioptions.IOStreams, flags *genericclioptions.Co
 		Short:             "AWS Account Management",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
-		Run:               help,
 	}
 
 	mgmtCmd.AddCommand(newCmdAccountList(streams, flags, globalOpts))

--- a/cmd/account/servicequotas/cmd.go
+++ b/cmd/account/servicequotas/cmd.go
@@ -12,7 +12,6 @@ func NewCmdServiceQuotas(streams genericclioptions.IOStreams, flags *genericclio
 		Short:             "Interact with AWS service-quotas",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
-		Run:               help,
 		Aliases:           []string{"service-quotas", "service-quota"},
 	}
 

--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -13,7 +13,6 @@ func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions
 		Short:             "Provides information for a specified cluster",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
-		Run:               help,
 	}
 
 	clusterCmd.AddCommand(newCmdHealth(streams, flags, globalOpts))

--- a/cmd/clusterdeployment/cmd.go
+++ b/cmd/clusterdeployment/cmd.go
@@ -13,7 +13,6 @@ func NewCmdClusterDeployment(streams genericclioptions.IOStreams, flags *generic
 		Short:             "cluster deployment related utilities",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
-		Run:               help,
 	}
 
 	cdCmd.AddCommand(newCmdList(streams, flags))

--- a/cmd/federatedrole/cmd.go
+++ b/cmd/federatedrole/cmd.go
@@ -13,7 +13,6 @@ func NewCmdFederatedRole(streams genericclioptions.IOStreams, flags *genericclio
 		Short:             "federated role related commands",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
-		Run:               help,
 	}
 
 	getCmd.AddCommand(newCmdApply(streams, flags, client))

--- a/cmd/network/cmd.go
+++ b/cmd/network/cmd.go
@@ -13,7 +13,6 @@ func NewCmdNetwork(streams genericclioptions.IOStreams, flags *genericclioptions
 		Short:             "network related utilities",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
-		Run:               help,
 	}
 
 	netCmd.AddCommand(newCmdPacketCapture(streams, flags, client))

--- a/cmd/sts/cmd.go
+++ b/cmd/sts/cmd.go
@@ -13,7 +13,6 @@ func NewCmdSts(streams genericclioptions.IOStreams, flags *genericclioptions.Con
 		Short:             "STS related utilities",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
-		Run:               help,
 	}
 
 	clusterCmd.AddCommand(newCmdPolicyDiff(streams, flags, client))


### PR DESCRIPTION
This does not change the way those commands behave when called without a sub-command.
This only changes the help displayed for those commands: the help no more encourage running those commands without a sub-command.
This generalizes hcnage done in [2124a930b143b27d5f92fbe14acc1f9c23fe871c](https://github.com/openshift/osdctl/commit/2124a930b143b27d5f92fbe14acc1f9c23fe871c) to all commands.