### PR TITLE
[OSD-11388] Fix for osdctl can assign suspended accounts

### DIFF
--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -97,6 +97,7 @@ type Client interface {
 	UntagResource(input *organizations.UntagResourceInput) (*organizations.UntagResourceOutput, error)
 	ListTagsForResource(input *organizations.ListTagsForResourceInput) (*organizations.ListTagsForResourceOutput, error)
 	MoveAccount(input *organizations.MoveAccountInput) (*organizations.MoveAccountOutput, error)
+	DescribeAccount(input *organizations.DescribeAccountInput) (*organizations.DescribeAccountOutput, error)
 
 	// Resources
 	GetResources(input *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error)
@@ -391,6 +392,10 @@ func (c *AwsClient) ListTagsForResource(input *organizations.ListTagsForResource
 
 func (c *AwsClient) MoveAccount(input *organizations.MoveAccountInput) (*organizations.MoveAccountOutput, error) {
 	return c.orgClient.MoveAccount(input)
+}
+
+func (c *AwsClient) DescribeAccount(input *organizations.DescribeAccountInput) (*organizations.DescribeAccountOutput, error) {
+	return c.orgClient.DescribeAccount(input)
 }
 
 func (c *AwsClient) GetResources(input *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {

--- a/pkg/provider/aws/mock/client.go
+++ b/pkg/provider/aws/mock/client.go
@@ -296,6 +296,21 @@ func (mr *MockClientMockRecorder) DeleteUserPolicy(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserPolicy", reflect.TypeOf((*MockClient)(nil).DeleteUserPolicy), arg0)
 }
 
+// DescribeAccount mocks base method.
+func (m *MockClient) DescribeAccount(input *organizations.DescribeAccountInput) (*organizations.DescribeAccountOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeAccount", input)
+	ret0, _ := ret[0].(*organizations.DescribeAccountOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeAccount indicates an expected call of DescribeAccount.
+func (mr *MockClientMockRecorder) DescribeAccount(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAccount", reflect.TypeOf((*MockClient)(nil).DescribeAccount), input)
+}
+
 // DescribeCreateAccountStatus mocks base method.
 func (m *MockClient) DescribeCreateAccountStatus(input *organizations.DescribeCreateAccountStatusInput) (*organizations.DescribeCreateAccountStatusOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Ticket Ref: https://issues.redhat.com/browse/OSD-11388

Adding check to account mgmt assign to ensure we only assign active accounts. 
Added a unit test

This PR still remains untested with actual account assignment

