### PR TITLE
Limited Support Commands

### DIFF
--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -1,15 +1,17 @@
 package cluster
 
 import (
+	"github.com/openshift/osdctl/cmd/cluster/support"
 	"github.com/openshift/osdctl/internal/utils/globalflags"
 	k8spkg "github.com/openshift/osdctl/pkg/k8s"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// NewCmdClusterHealth implements the base cluster health command
-func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+// NewCmdCluster implements the base cluster health command
+func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	clusterCmd := &cobra.Command{
 		Use:               "cluster",
 		Short:             "Provides information for a specified cluster",
@@ -20,6 +22,8 @@ func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions
 	clusterCmd.AddCommand(newCmdHealth(streams, flags, globalOpts))
 	clusterCmd.AddCommand(newCmdloggingCheck(streams, flags, globalOpts))
 	clusterCmd.AddCommand(newCmdOwner(streams, flags, globalOpts))
+	clusterCmd.AddCommand(support.NewCmdSupport(streams, flags, client, globalOpts))
+
 	return clusterCmd
 }
 

--- a/cmd/cluster/support/cmd.go
+++ b/cmd/cluster/support/cmd.go
@@ -1,0 +1,32 @@
+package support
+
+import (
+	"github.com/openshift/osdctl/internal/utils/globalflags"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewCmdSupport implements the get command to get support status
+// osdctl cluster support status
+// osdctl cluster support create --summary="" --reason=""
+// osdctl cluster support delete --reason=""
+func NewCmdSupport(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	supportCmd := &cobra.Command{
+		Use:               "support",
+		Short:             "Cluster Support",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		Run:               help,
+	}
+
+	supportCmd.AddCommand(newCmdstatus(streams, flags, globalOpts))
+	supportCmd.AddCommand(newCmdpost(streams, flags, globalOpts))
+	supportCmd.AddCommand(newCmddelete(streams, flags, globalOpts))
+
+	return supportCmd
+}
+
+func help(cmd *cobra.Command, _ []string) {
+	cmd.Help()
+}

--- a/cmd/cluster/support/common.go
+++ b/cmd/cluster/support/common.go
@@ -1,0 +1,39 @@
+package support
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	sdk "github.com/openshift-online/ocm-sdk-go"
+)
+
+func confirmSend() error {
+
+	fmt.Print("Continue? (y/N): ")
+	reader := bufio.NewReader(os.Stdin)
+	responseBytes, _, err := reader.ReadLine()
+	if err != nil {
+		return err
+	}
+	response := strings.ToUpper(string(responseBytes))
+
+	if response != "Y" && response != "YES" {
+		if response != "N" && response != "NO" && response != "" {
+			log.Fatal("Invalid response, expected 'YES' or 'Y' (case-insensitive). ")
+		}
+		log.Fatalf("Exiting...")
+	}
+	return nil
+}
+
+func sendRequest(request *sdk.Request) (*sdk.Response, error) {
+
+	response, err := request.Send()
+	if err != nil {
+		return nil, fmt.Errorf("cannot send request: %q", err)
+	}
+	return response, nil
+}

--- a/cmd/cluster/support/delete.go
+++ b/cmd/cluster/support/delete.go
@@ -1,0 +1,168 @@
+package support
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/osdctl/internal/support"
+	"github.com/openshift/osdctl/internal/utils/globalflags"
+	ctlutil "github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+type deleteOptions struct {
+	output                 string
+	verbose                bool
+	clusterID              string
+	limitedSupportReasonID string
+
+	genericclioptions.IOStreams
+	GlobalOptions *globalflags.GlobalOptions
+}
+
+func newCmddelete(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+
+	ops := newDeleteOptions(streams, flags, globalOpts)
+	deleteCmd := &cobra.Command{
+		Use:               "delete CLUSTER_ID",
+		Short:             "Delete specified limited support reason for a given cluster",
+		Args:              cobra.ExactArgs(1),
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd, args))
+			cmdutil.CheckErr(ops.run())
+		},
+	}
+
+	// Defined required flags
+	deleteCmd.Flags().StringVarP(&ops.limitedSupportReasonID, "limited-support-reason-id", "i", "", "Limited support reason ID")
+	deleteCmd.Flags().BoolVarP(&isDryRun, "dry-run", "d", false, "Dry-run - print the limited support reason about to be sent but don't send it.")
+	deleteCmd.Flags().BoolVarP(&ops.verbose, "verbose", "", false, "Verbose output")
+
+	// Mark limited-support-reason-id (-i) flag required
+	if err := deleteCmd.MarkFlagRequired("limited-support-reason-id"); err != nil {
+		log.Fatalln("limited-support-reason-id", err)
+	}
+
+	return deleteCmd
+}
+
+func newDeleteOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *deleteOptions {
+
+	return &deleteOptions{
+		IOStreams:     streams,
+		GlobalOptions: globalOpts,
+	}
+}
+
+func (o *deleteOptions) complete(cmd *cobra.Command, args []string) error {
+
+	if len(args) != 1 {
+		return cmdutil.UsageErrorf(cmd, "Provide exactly one internal cluster ID")
+	}
+
+	o.clusterID = args[0]
+	o.output = o.GlobalOptions.Output
+
+	return nil
+}
+
+func (o *deleteOptions) run() error {
+
+	ctx := context.Background()
+
+	// Create an OCM client to talk to the cluster API
+	token := os.Getenv("OCM_TOKEN")
+	if token == "" {
+		ocmToken, err := ctlutil.GetOCMAccessToken()
+		if err != nil {
+			log.Fatalf("OCM token not set. Please configure by using the OCM_TOKEN environment variable or the ocm cli")
+			os.Exit(1)
+		}
+		token = *ocmToken
+	}
+	connection, err := sdk.NewConnectionBuilder().
+		Tokens(token).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build connection: %v\n", err)
+		os.Exit(1)
+	}
+	defer connection.Close()
+
+	// Stop here if dry-run
+	if isDryRun {
+		return nil
+	}
+
+	// confirmSend prompt to confirm
+	confirmSend()
+
+	// Get cluster resource
+	clusterResource := connection.ClustersMgmt().V1().Clusters().Cluster(o.clusterID)
+	clusterResponse, err := clusterResource.Get().SendContext(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't retrieve cluster: %v\n", err)
+		os.Exit(1)
+	}
+	cluster := clusterResponse.Body()
+
+	deleteRequest, err := createDeleteRequest(connection, cluster, o.limitedSupportReasonID)
+	if err != nil {
+		fmt.Printf("failed post call %q\n", err)
+	}
+	deleteResponse, err := sendRequest(deleteRequest)
+	if err != nil {
+		fmt.Printf("Failed to get delete call response: %q\n", err)
+	}
+
+	err = checkDelete(deleteResponse)
+	if err != nil {
+		fmt.Printf("check for delete call failed: %q", err)
+	}
+
+	return nil
+}
+
+// createDeleteRequest sets the delete API and returns a request
+func createDeleteRequest(ocmClient *sdk.Connection, cluster *v1.Cluster, reasonID string) (request *sdk.Request, err error) {
+
+	targetAPIPath := "/api/clusters_mgmt/v1/clusters/" + cluster.ID() + "/limited_support_reasons/" + reasonID
+
+	request = ocmClient.Delete()
+	err = arguments.ApplyPathArg(request, targetAPIPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse API path '%s': %v", targetAPIPath, err)
+	}
+	return request, nil
+}
+
+// checkDelete checks the response from delete API call
+// 204 if success, otherwise error
+func checkDelete(response *sdk.Response) error {
+
+	var badReply *support.BadReply
+	body := response.Bytes()
+	if response.Status() == http.StatusNoContent {
+		fmt.Printf("Limited support reason deleted successfully\n")
+		return nil
+	}
+
+	if ok := json.Valid(body); !ok {
+		return fmt.Errorf("server returned invalid JSON")
+	}
+
+	if err := json.Unmarshal(body, &badReply); err != nil {
+		return fmt.Errorf("cannot parse the error JSON meessage: %q", err)
+	}
+	return nil
+}

--- a/cmd/cluster/support/post.go
+++ b/cmd/cluster/support/post.go
@@ -1,0 +1,272 @@
+package support
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
+	"github.com/openshift-online/ocm-cli/pkg/dump"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/osdctl/internal/support"
+	"github.com/openshift/osdctl/internal/utils"
+	"github.com/openshift/osdctl/internal/utils/globalflags"
+	ctlutil "github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+var (
+	LimitedSupport support.LimitedSupport
+	template       string
+	isDryRun       bool
+)
+
+const (
+	defaultTemplate = ""
+)
+
+type postOptions struct {
+	output    string
+	verbose   bool
+	clusterID string
+
+	genericclioptions.IOStreams
+	GlobalOptions *globalflags.GlobalOptions
+}
+
+func newCmdpost(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+
+	ops := newPostOptions(streams, flags, globalOpts)
+	postCmd := &cobra.Command{
+		Use:               "post CLUSTER_ID",
+		Short:             "Send limited support reason to a given cluster",
+		Args:              cobra.ExactArgs(1),
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd, args))
+			cmdutil.CheckErr(ops.run())
+		},
+	}
+
+	// Define required flags
+	postCmd.Flags().StringVarP(&template, "template", "t", defaultTemplate, "Message template file or URL")
+	postCmd.Flags().BoolVarP(&isDryRun, "dry-run", "d", false, "Dry-run - print the limited support reason about to be sent but don't send it.")
+	postCmd.Flags().BoolVarP(&ops.verbose, "verbose", "", false, "Verbose output")
+
+	return postCmd
+}
+
+func newPostOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *postOptions {
+
+	return &postOptions{
+		IOStreams:     streams,
+		GlobalOptions: globalOpts,
+	}
+}
+
+func (o *postOptions) complete(cmd *cobra.Command, args []string) error {
+
+	if len(args) != 1 {
+		return cmdutil.UsageErrorf(cmd, "Provide exactly one internal cluster ID")
+	}
+
+	o.clusterID = args[0]
+	o.output = o.GlobalOptions.Output
+
+	return nil
+}
+
+func (o *postOptions) run() error {
+
+	ctx := context.Background()
+
+	// Parse the given JSON template provided via '-t' flag
+	// and load it into the LimitedSupport variable
+	readTemplate()
+
+	// Create an OCM client to talk to the cluster API
+	token := os.Getenv("OCM_TOKEN")
+	if token == "" {
+		ocmToken, err := ctlutil.GetOCMAccessToken()
+		if err != nil {
+			log.Fatalf("OCM token not set. Please configure by using the OCM_TOKEN environment variable or the ocm cli")
+			os.Exit(1)
+		}
+		token = *ocmToken
+	}
+	connection, err := sdk.NewConnectionBuilder().
+		Tokens(token).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build connection: %v\n", err)
+		os.Exit(1)
+	}
+	defer connection.Close()
+
+	// Print limited support template to be sent
+	fmt.Printf("The following limited support reason will be sent to %s:\n", o.clusterID)
+	if err := printTemplate(); err != nil {
+		fmt.Printf("Cannot read generated template: %q\n", err)
+		os.Exit(1)
+	}
+
+	// Stop here if dry-run
+	if isDryRun {
+		return nil
+	}
+
+	// confirmSend prompt to confirm
+	confirmSend()
+
+	// Get cluster resource
+	clusterResource := connection.ClustersMgmt().V1().Clusters().Cluster(o.clusterID)
+	clusterResponse, err := clusterResource.Get().SendContext(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't retrieve cluster: %v\n", err)
+		os.Exit(1)
+	}
+	cluster := clusterResponse.Body()
+
+	// postRequest calls createPostRequest and take in client and clustersmgmt/v1.cluster object
+	postRequest, err := createPostRequest(connection, cluster)
+	if err != nil {
+		fmt.Printf("failed to create post request %q\n", err)
+	}
+	postResponse, err := sendRequest(postRequest)
+	if err != nil {
+		fmt.Printf("Failed to get post call response: %q\n", err)
+	}
+
+	// check if response matches LimitedSupport
+	err = check(postResponse, LimitedSupport)
+	if err != nil {
+		fmt.Printf("Failed to check postResponse %q\n", err)
+	}
+	return nil
+}
+
+// createPostRequest create and populates the limited support post call
+// swagger code gen: https://api.openshift.com/?urls.primaryName=Clusters%20management%20service#/default/post_api_clusters_mgmt_v1_clusters__cluster_id__limited_support_reasons
+func createPostRequest(ocmClient *sdk.Connection, cluster *v1.Cluster) (request *sdk.Request, err error) {
+
+	targetAPIPath := "/api/clusters_mgmt/v1/clusters/" + cluster.ID() + "/limited_support_reasons"
+
+	request = ocmClient.Post()
+	err = arguments.ApplyPathArg(request, targetAPIPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse API path '%s': %v", targetAPIPath, err)
+	}
+
+	// pass template as `--body` of API call
+	arguments.ApplyBodyFlag(request, template)
+
+	return request, nil
+}
+
+// readTemplate loads the template into the LimitedSupport variable
+func readTemplate() {
+
+	if template == defaultTemplate {
+		log.Fatalf("Template file is not provided. Use '-t' to fix this.")
+	}
+
+	// check if this URL or file and if we can access it
+	file, err := accessFile(template)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err = parseTemplate(file); err != nil {
+		log.Fatalf("Cannot not parse the JSON template.\nError: %q\n", err)
+	}
+}
+
+// accessTemplate returns the contents of a local file or url, and any errors encountered
+func accessFile(filePath string) ([]byte, error) {
+
+	// when template is file on disk
+	if utils.FileExists(filePath) {
+		file, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			return file, fmt.Errorf("cannot read the file.\nError: %q", err)
+		}
+		return file, nil
+	}
+	if utils.FolderExists(filePath) {
+		return nil, fmt.Errorf("the provided path %q is a directory, not a file", filePath)
+	}
+
+	// when template is URL
+	if utils.IsValidUrl(filePath) {
+		urlPage, _ := url.Parse(filePath)
+		if err := utils.IsOnline(*urlPage); err != nil {
+			return nil, fmt.Errorf("host %q is not accessible", filePath)
+		}
+		return utils.CurlThis(urlPage.String())
+	}
+	return nil, fmt.Errorf("cannot read the file %q", filePath)
+}
+
+// parseTemplate reads the template file into a JSON struct
+func parseTemplate(jsonFile []byte) error {
+	return json.Unmarshal(jsonFile, &LimitedSupport)
+}
+
+func printTemplate() error {
+
+	limitedSupportMessage, err := json.Marshal(LimitedSupport)
+	if err != nil {
+		return err
+	}
+	return dump.Pretty(os.Stdout, limitedSupportMessage)
+}
+
+func validateGoodResponse(body []byte, limitedSupport support.LimitedSupport) (goodReply *support.GoodReply, err error) {
+
+	if !json.Valid(body) {
+		return nil, fmt.Errorf("Server returned invalid JSON")
+	}
+
+	if err = json.Unmarshal(body, &goodReply); err != nil {
+		return nil, fmt.Errorf("Cannot parse JSON template.\nError: %q", err)
+	}
+	return goodReply, nil
+}
+
+func validateBadResponse(body []byte) (badReply *support.BadReply, err error) {
+
+	if ok := json.Valid(body); !ok {
+		return nil, fmt.Errorf("Server returned invalid JSON")
+	}
+	if err = json.Unmarshal(body, &badReply); err != nil {
+		return nil, fmt.Errorf("Cannot parse the error JSON meessage: %q", err)
+	}
+	return badReply, nil
+}
+
+func check(response *sdk.Response, limitedSupport support.LimitedSupport) error {
+
+	body := response.Bytes()
+	if response.Status() == http.StatusCreated {
+		_, err := validateGoodResponse(body, limitedSupport)
+		if err != nil {
+			return fmt.Errorf("failed to validate good response: %q", err)
+		}
+		fmt.Printf("Limited support reason has been sent successfully\n")
+		return nil
+	}
+
+	badReply, err := validateBadResponse(body)
+	if err != nil {
+		return fmt.Errorf("failed to validate bad response: %v", err)
+	}
+	return fmt.Errorf("bad response reason is: %s", badReply.Reason)
+}

--- a/cmd/cluster/support/status.go
+++ b/cmd/cluster/support/status.go
@@ -1,0 +1,137 @@
+package support
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift/osdctl/internal/utils/globalflags"
+	"github.com/openshift/osdctl/pkg/printer"
+	"github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+type limitedSupportReasonItem struct {
+	ID      string
+	Summary string
+	Details string
+}
+
+// supportcheck defines the struct for running supportCheck command
+// This command requires the ocm API Token https://cloud.redhat.com/openshift/token to be available in the OCM_TOKEN env variable.
+
+type statusOptions struct {
+	output    string
+	verbose   bool
+	clusterID string
+
+	genericclioptions.IOStreams
+	GlobalOptions *globalflags.GlobalOptions
+}
+
+// newCmdsupportCheck implements the supportCheck command to show the support status of a cluster
+func newCmdstatus(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newStatusOptions(streams, flags, globalOpts)
+	statusCmd := &cobra.Command{
+		Use:               "status",
+		Short:             "Shows the support status of a specified cluster",
+		Args:              cobra.ExactArgs(1),
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd, args))
+			cmdutil.CheckErr(ops.run())
+		},
+	}
+	statusCmd.Flags().BoolVarP(&ops.verbose, "verbose", "", false, "Verbose output")
+
+	return statusCmd
+}
+
+func newStatusOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *statusOptions {
+	return &statusOptions{
+		IOStreams:     streams,
+		GlobalOptions: globalOpts,
+	}
+}
+
+func (o *statusOptions) complete(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return cmdutil.UsageErrorf(cmd, "Provide exactly one cluster ID")
+	}
+
+	o.clusterID = args[0]
+	o.output = o.GlobalOptions.Output
+
+	return nil
+}
+
+func (o *statusOptions) run() error {
+	// Create a context:
+	ctx := context.Background()
+	// Ocm token
+	token := os.Getenv("OCM_TOKEN")
+	if token == "" {
+		ocmToken, err := utils.GetOCMAccessToken()
+		if err != nil {
+			log.Fatalf("OCM token not set. Please configure by using the OCM_TOKEN environment variable or the ocm cli")
+			os.Exit(1)
+		}
+		token = *ocmToken
+	}
+	connection, err := sdk.NewConnectionBuilder().
+		Tokens(token).
+		Build()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't build connection: %v\n", err)
+		os.Exit(1)
+	}
+	defer connection.Close()
+
+	// Get the client for the resource that manages the collection of clusters:
+	collection := connection.ClustersMgmt().V1().Clusters()
+	// Get cluster resource
+	resource := collection.Cluster(o.clusterID).LimitedSupportReasons()
+	// Send the request to retrieve the list of limited support reasons:
+	response, err := resource.List().SendContext(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Can't retrieve cluster limited support reasons: %v\n", err)
+		os.Exit(1)
+	}
+
+	reasons, _ := response.GetItems()
+
+	var clusterLimitedSupportReasons []*limitedSupportReasonItem
+
+	reasons.Each(func(limitedSupportReason *cmv1.LimitedSupportReason) bool {
+		clusterLimitedSupportReason := limitedSupportReasonItem{
+			ID:      limitedSupportReason.ID(),
+			Summary: limitedSupportReason.Summary(),
+			Details: limitedSupportReason.Details(),
+		}
+		clusterLimitedSupportReasons = append(clusterLimitedSupportReasons, &clusterLimitedSupportReason)
+		return true
+	})
+
+	// No reasons found, cluster is fully supported
+	if len(clusterLimitedSupportReasons) == 0 {
+		fmt.Printf("Cluster is fully supported\n")
+		return nil
+	}
+
+	table := printer.NewTablePrinter(os.Stdout, 20, 1, 3, ' ')
+	table.AddRow([]string{"Reason ID", "Summary", "Details"})
+	for _, clusterLimitedSupportReason := range clusterLimitedSupportReasons {
+		table.AddRow([]string{clusterLimitedSupportReason.ID, clusterLimitedSupportReason.Summary, clusterLimitedSupportReason.Details})
+	}
+	// Add empty row for readability
+	table.AddRow([]string{})
+	table.Flush()
+
+	return nil
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -49,7 +49,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	// add sub commands
 	rootCmd.AddCommand(aao.NewCmdAao(streams, kubeFlags))
 	rootCmd.AddCommand(account.NewCmdAccount(streams, kubeFlags, kubeClient, globalOpts))
-	rootCmd.AddCommand(cluster.NewCmdCluster(streams, kubeFlags, globalOpts))
+	rootCmd.AddCommand(cluster.NewCmdCluster(streams, kubeFlags, kubeClient, globalOpts))
 	rootCmd.AddCommand(clusterdeployment.NewCmdClusterDeployment(streams, kubeFlags, kubeClient))
 	rootCmd.AddCommand(env.NewCmdEnv(streams, kubeFlags))
 	rootCmd.AddCommand(federatedrole.NewCmdFederatedRole(streams, kubeFlags, kubeClient))

--- a/internal/support/template.go
+++ b/internal/support/template.go
@@ -1,0 +1,36 @@
+package support
+
+import (
+	"time"
+)
+
+// GoodReply is the template for good reply
+type GoodReply struct {
+	ID                string    `json:"id"`
+	Kind              string    `json:"kind"`
+	Href              string    `json:"href"`
+	Details           string    `json:"details"`
+	DetectionType     string    `json:"detection_type"`
+	Summary           string    `json:"summary"`
+	CreationTimestamp time.Time `json:"creation_timestamp"`
+}
+
+// BadReply is the template for bad reply
+type BadReply struct {
+	ID      string `json:"id"`
+	Kind    string `json:"kind"`
+	Href    string `json:"href"`
+	Code    string `json:"code"`
+	Reason  string `json:"reason"`
+	Details []struct {
+		Description string `json:"description"`
+	} `json:"details"`
+}
+
+// LimitedSupport is the base limited_support_reasons template
+type LimitedSupport struct {
+	ID         string `json:"id"`
+	TemplateID string `json:"template_id,omitempty"`
+	Summary    string `json:"summary"`
+	Details    string `json:"details"`
+}


### PR DESCRIPTION
Currently the only way to enable limited support is via ocm API. This PR introduces three new commands to osdctl to make dealing with limited support easier for SRE:
```
1.  osdctl cluster support status <internalClusterID>
2.  osdctl cluster support post <internalClusterID> -t <limitedSupportTemplate.json>
3.  osdctl cluster support delete <internalClusterID> -i <limitedSupportReasonID>
```

Here's how I've tested this
```
❯ osdctl cluster support status 1sqen55r91ppvep84f3jcdpn7j1a3d8q
Reason ID                              Summary                             Details
54033567-eb32-11ec-af34-0a580a82040e   [Testing] Limited Support Summary   [snguyen - testing] Limited Support Details

❯ osdctl cluster support post 1sqen55r91ppvep84f3jcdpn7j1a3d8q -t lsReason.json            
The following limited support reason will be sent to 1sqen55r91ppvep84f3jcdpn7j1a3d8q:{
  "id": "",
  "summary": "[Testing] Sample summary",
  "details": "[snguyen - testing] sample details"
}
Continue? (y/N): y
limited support reason has been sent successfully%      

❯ osdctl cluster support status 1sqen55r91ppvep84f3jcdpn7j1a3d8q               
Reason ID                              Summary                             Details
54033567-eb32-11ec-af34-0a580a82040e   [Testing] Limited Support Summary   [snguyen - testing] Limited Support Details
b3e251e8-eb59-11ec-90c3-0a580a820212   [Testing] Sample summary            [snguyen - testing] sample details

❯ osdctl cluster support delete 1sqen55r91ppvep84f3jcdpn7j1a3d8q -i 54033567-eb32-11ec-af34-0a580a82040e
limited support reason deleted successfully
```
