### PR TITLE
Allow using external cluster ID to run logging check

### DIFF
--- a/cmd/cluster/loggincheck.go
+++ b/cmd/cluster/loggincheck.go
@@ -69,9 +69,6 @@ func (o *loggingCheckOptions) complete(cmd *cobra.Command, args []string) error 
 		}
 	}()
 
-	if len(args) != 1 {
-		return fmt.Errorf("too many arguments. Expected 1 got %d", len(args))
-	}
 	clusters := utils.GetClusters(ocmClient, args)
 	if len(clusters) != 1 {
 		return fmt.Errorf("unexpected number of clusters matched input. Expected 1 got %d", len(clusters))

--- a/cmd/servicelog/common.go
+++ b/cmd/servicelog/common.go
@@ -3,13 +3,9 @@ package servicelog
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
-	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	sdk "github.com/openshift-online/ocm-sdk-go"
-	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/osdctl/internal/servicelog"
-	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -22,56 +18,6 @@ const (
 	// https://api.openshift.com/?urls.primaryName=Service%20logs#/default/post_api_service_logs_v1_cluster_logs
 	targetAPIPath = "/api/service_logs/v1/cluster_logs"
 )
-
-func createConnection() *sdk.Connection {
-	connection, err := ocm.NewConnection().Build()
-	if err != nil {
-		if strings.Contains(err.Error(), "Not logged in, run the") {
-			log.Fatalf("Failed to create OCM connection: Authentication error, run the 'ocm login' command first.")
-		}
-		log.Fatalf("Failed to create OCM connection: %v", err)
-	}
-	return connection
-}
-
-// generateQuery returns an OCM search query to retrieve all clusters matching an expression (ie- "foo%")
-func generateQuery(clusterIdentifier string) string {
-	return strings.TrimSpace(fmt.Sprintf("(id like '%[1]s' or external_id like '%[1]s' or display_name like '%[1]s')", clusterIdentifier))
-}
-
-// getFilteredClusters retrieves clusters in OCM which match the filters given
-func applyFilters(ocmClient *sdk.Connection, filters []string) ([]*v1.Cluster, error) {
-	if len(filters) < 1 {
-		return nil, nil
-	}
-
-	for k, v := range filters {
-		filters[k] = fmt.Sprintf("(%s)", v)
-	}
-
-	requestSize := 50
-	full_filters := strings.Join(filters, " and ")
-
-	log.Infof(`running the command: 'ocm list clusters --parameter=search="%s"'`, full_filters)
-
-	request := ocmClient.ClustersMgmt().V1().Clusters().List().Search(full_filters).Size(requestSize)
-	response, err := request.Send()
-	if err != nil {
-		return nil, err
-	}
-
-	items := response.Items().Slice()
-	for response.Size() >= requestSize {
-		request.Page(response.Page() + 1)
-		response, err = request.Send()
-		if err != nil {
-			return nil, err
-		}
-		items = append(items, response.Items().Slice()...)
-	}
-
-	return items, err
-}
 
 func sendRequest(request *sdk.Request) (*sdk.Response, error) {
 	response, err := request.Send()

--- a/cmd/servicelog/list.go
+++ b/cmd/servicelog/list.go
@@ -3,12 +3,11 @@ package servicelog
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	"github.com/openshift-online/ocm-cli/pkg/dump"
 	sdk "github.com/openshift-online/ocm-sdk-go"
-	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/osdctl/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -27,7 +26,7 @@ var listCmd = &cobra.Command{
 
 		// Create an OCM client to talk to the cluster API
 		// the user has to be logged in (e.g. 'ocm login')
-		ocmClient := createConnection()
+		ocmClient := utils.CreateConnection()
 		defer func() {
 			if err := ocmClient.Close(); err != nil {
 				log.Errorf("Cannot close the ocmClient (possible memory leak): %q", err)
@@ -39,7 +38,7 @@ var listCmd = &cobra.Command{
 		}
 
 		// Use the OCM client to retrieve clusters
-		clusters := getClusters(ocmClient, args)
+		clusters := utils.GetClusters(ocmClient, args)
 
 		// send it as logservice and validate the response
 		for _, cluster := range clusters {
@@ -65,19 +64,6 @@ const listServiceLogAPIPath = "/api/service_logs/v1/clusters/%s/cluster_logs"
 func init() {
 	// define required flags
 	listCmd.Flags().BoolVarP(&serviceLogListAllMessagesFlag, "all-messages", "A", serviceLogListAllMessagesFlag, "Toggle if we should see all of the messages or only SRE-P specific ones")
-}
-
-func getClusters(ocmClient *sdk.Connection, clusterIds []string) []*v1.Cluster {
-	for i, id := range clusterIds {
-		clusterIds[i] = generateQuery(id)
-	}
-
-	clusters, err := applyFilters(ocmClient, []string{strings.Join(clusterIds, " or ")})
-	if err != nil {
-		log.Fatalf("Error while retrieving cluster(s) from ocm: %[1]s", err)
-	}
-
-	return clusters
 }
 
 func createListRequest(ocmClient *sdk.Connection, clusterId string, allMessages bool) *sdk.Request {

--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/osdctl/internal/servicelog"
 	"github.com/openshift/osdctl/internal/utils"
 	"github.com/openshift/osdctl/pkg/printer"
+	ocmutils "github.com/openshift/osdctl/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -60,7 +61,7 @@ var postCmd = &cobra.Command{
 			log.Infof("Too many arguments. Expected 1 got %d", len(args))
 		}
 		for _, clusterIds := range args {
-			queries = append(queries, generateQuery(clusterIds))
+			queries = append(queries, ocmutils.GenerateQuery(clusterIds))
 		}
 
 		if len(queries) > 0 {
@@ -81,7 +82,7 @@ var postCmd = &cobra.Command{
 
 		// Create an OCM client to talk to the cluster API
 		// the user has to be logged in (e.g. 'ocm login')
-		ocmClient := createConnection()
+		ocmClient := ocmutils.CreateConnection()
 		defer func() {
 			if err := ocmClient.Close(); err != nil {
 				log.Errorf("Cannot close the ocmClient (possible memory leak): %q", err)
@@ -109,12 +110,12 @@ var postCmd = &cobra.Command{
 			query := []string{}
 			for i := range ClustersFile.Clusters {
 				cluster := ClustersFile.Clusters[i]
-				query = append(query, generateQuery(cluster))
+				query = append(query, ocmutils.GenerateQuery(cluster))
 			}
 			filterParams = append(filterParams, strings.Join(query, " or "))
 		}
 
-		clusters, err := applyFilters(ocmClient, filterParams)
+		clusters, err := ocmutils.ApplyFilters(ocmClient, filterParams)
 
 		if err != nil {
 			log.Fatalf("Cannot retrieve clusters: %q", err)

--- a/pkg/utils/ocm.go
+++ b/pkg/utils/ocm.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+func GetClusters(ocmClient *sdk.Connection, clusterIds []string) []*v1.Cluster {
+	for i, id := range clusterIds {
+		clusterIds[i] = GenerateQuery(id)
+	}
+
+	clusters, err := ApplyFilters(ocmClient, []string{strings.Join(clusterIds, " or ")})
+	if err != nil {
+		log.Fatalf("error while retrieving cluster(s) from ocm: %[1]s", err)
+	}
+
+	return clusters
+}
+
+// ApplyFilters retrieves clusters in OCM which match the filters given
+func ApplyFilters(ocmClient *sdk.Connection, filters []string) ([]*v1.Cluster, error) {
+	if len(filters) < 1 {
+		return nil, nil
+	}
+
+	for k, v := range filters {
+		filters[k] = fmt.Sprintf("(%s)", v)
+	}
+
+	requestSize := 50
+	full_filters := strings.Join(filters, " and ")
+
+	fmt.Printf("running the command: 'ocm list clusters --parameter=search=\"%s\"'\n", full_filters)
+
+	request := ocmClient.ClustersMgmt().V1().Clusters().List().Search(full_filters).Size(requestSize)
+	response, err := request.Send()
+	if err != nil {
+		return nil, err
+	}
+
+	items := response.Items().Slice()
+	for response.Size() >= requestSize {
+		request.Page(response.Page() + 1)
+		response, err = request.Send()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, response.Items().Slice()...)
+	}
+
+	return items, err
+}
+
+// GenerateQuery returns an OCM search query to retrieve all clusters matching an expression (ie- "foo%")
+func GenerateQuery(clusterIdentifier string) string {
+	return strings.TrimSpace(fmt.Sprintf("(id like '%[1]s' or external_id like '%[1]s' or display_name like '%[1]s')", clusterIdentifier))
+}
+
+func CreateConnection() *sdk.Connection {
+	connection, err := ocm.NewConnection().Build()
+	if err != nil {
+		if strings.Contains(err.Error(), "Not logged in, run the") {
+			log.Fatalf("Failed to create OCM connection: Authentication error, run the 'ocm login' command first.")
+		}
+		log.Fatalf("Failed to create OCM connection: %v", err)
+	}
+	return connection
+}


### PR DESCRIPTION
* Alerts contain external ID as label
* This change will prevent an additional manual lookup step

jira: [OSD-12082](https://issues.redhat.com//browse/OSD-12082)