### PR TITLE
[OSD-12483]Adding SL output to cluster context command

### DIFF
--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+
 	"github.com/openshift/osdctl/cmd/cluster/support"
 	"github.com/openshift/osdctl/internal/utils/globalflags"
 	k8spkg "github.com/openshift/osdctl/pkg/k8s"
@@ -21,10 +22,10 @@ func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions
 	}
 
 	clusterCmd.AddCommand(newCmdHealth(streams, flags, globalOpts))
-	clusterCmd.AddCommand(newCmdloggingCheck(streams, flags, globalOpts))
+	clusterCmd.AddCommand(newCmdLoggingCheck(streams, flags, globalOpts))
 	clusterCmd.AddCommand(newCmdOwner(streams, flags, globalOpts))
 	clusterCmd.AddCommand(support.NewCmdSupport(streams, flags, client, globalOpts))
-	clusterCmd.AddCommand(newCmdcontext(streams, flags, globalOpts))
+	clusterCmd.AddCommand(newCmdContext(streams, flags, globalOpts))
 
 	return clusterCmd
 }

--- a/cmd/cluster/loggincheck.go
+++ b/cmd/cluster/loggincheck.go
@@ -29,8 +29,8 @@ type loggingCheckOptions struct {
 	GlobalOptions *globalflags.GlobalOptions
 }
 
-// newCmdloggingCheck implements the loggingCheck command to show the logging support status of a cluster
-func newCmdloggingCheck(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+// newCmdLoggingCheck implements the loggingCheck command to show the logging support status of a cluster
+func newCmdLoggingCheck(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	ops := newloggingCheckOptions(streams, flags, globalOpts)
 	loggingCheckCmd := &cobra.Command{
 		Use:               "loggingCheck",

--- a/cmd/servicelog/list.go
+++ b/cmd/servicelog/list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/osdctl/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 // listCmd represents the list command
@@ -18,62 +19,72 @@ var listCmd = &cobra.Command{
 	Short:         "gets all servicelog messages for a given cluster",
 	Args:          cobra.ArbitraryArgs,
 	SilenceErrors: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			err := cmd.Help()
-			if err != nil {
-				return fmt.Errorf("error calling cmd.Help(): %w", err)
-
-			}
-			return fmt.Errorf("cluster-identifier was not provided. please provide a cluster id, UUID, or name")
-		}
-
-		// Create an OCM client to talk to the cluster API
-		// the user has to be logged in (e.g. 'ocm login')
-		ocmClient := utils.CreateConnection()
-		defer func() {
-			if err := ocmClient.Close(); err != nil {
-				log.Errorf("Cannot close the ocmClient (possible memory leak): %q", err)
-			}
-		}()
-
-		if len(args) != 1 {
-			log.Infof("Too many arguments. Expected 1 got %d", len(args))
-		}
-
-		// Use the OCM client to retrieve clusters
-		clusters := utils.GetClusters(ocmClient, args)
-
-		// send it as logservice and validate the response
-		for _, cluster := range clusters {
-			response, err := sendRequest(createListRequest(ocmClient, cluster.ExternalID(), serviceLogListAllMessagesFlag))
-			if err != nil {
-				return err
-			}
-
-			err = dump.Pretty(os.Stdout, response.Bytes())
-			if err != nil {
-				err := cmd.Help()
-				if err != nil {
-					return err
-				}
-				return err
-			}
-		}
-		return nil
+	Run: func(cmd *cobra.Command, args []string) {
+		cmdutil.CheckErr(complete(cmd, args))
+		cmdutil.CheckErr(run(cmd, args[0]))
 	},
+}
+
+func complete(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		err := cmd.Help()
+		if err != nil {
+			return fmt.Errorf("error calling cmd.Help(): %w", err)
+
+		}
+		return fmt.Errorf("cluster-identifier was not provided. please provide a cluster id, UUID, or name")
+	}
+
+	if len(args) != 1 {
+		log.Infof("Too many arguments. Expected 1 got %d", len(args))
+	}
+
+	return nil
+}
+
+func run(cmd *cobra.Command, clusterID string) error {
+	response, err := FetchServiceLogs(clusterID)
+	err = dump.Pretty(os.Stdout, response.Bytes())
+	if err != nil {
+		err := cmd.Help()
+		if err != nil {
+			return err
+		}
+		return err
+	}
+	return nil
 }
 
 var serviceLogListAllMessagesFlag = false
 
-const listServiceLogAPIPath = "/api/service_logs/v1/clusters/%s/cluster_logs"
+func FetchServiceLogs(clusterID string) (*sdk.Response, error) {
+	// Create OCM client to talk to cluster API
+	ocmClient := utils.CreateConnection()
+	defer func() {
+		if err := ocmClient.Close(); err != nil {
+			fmt.Printf("Cannot close the ocmClient (possible memory leak): %q", err)
+		}
+	}()
+
+	// Use the OCM client to retrieve clusters
+	clusters := utils.GetClusters(ocmClient, []string{clusterID})
+	if len(clusters) != 1 {
+		return nil, fmt.Errorf("GetClusters expected to return 1 cluster, got: %d", len(clusters))
+	}
+	cluster := clusters[0]
+
+	serviceLogListAllMessagesFlag := false
+
+	// Now get the SLs for the cluster
+	return sendRequest(CreateListSLRequest(ocmClient, cluster.ExternalID(), serviceLogListAllMessagesFlag))
+}
 
 func init() {
 	// define required flags
 	listCmd.Flags().BoolVarP(&serviceLogListAllMessagesFlag, "all-messages", "A", serviceLogListAllMessagesFlag, "Toggle if we should see all of the messages or only SRE-P specific ones")
 }
 
-func createListRequest(ocmClient *sdk.Connection, clusterId string, allMessages bool) *sdk.Request {
+func CreateListSLRequest(ocmClient *sdk.Connection, clusterId string, allMessages bool) *sdk.Request {
 	// Create and populate the request:
 	request := ocmClient.Get()
 	err := arguments.ApplyPathArg(request, targetAPIPath)

--- a/internal/servicelog/reply.go
+++ b/internal/servicelog/reply.go
@@ -16,14 +16,27 @@ type GoodReply struct {
 	CreatedAt     time.Time `json:"created_at"`
 }
 
+type ServiceLogShort struct {
+	Summary     string    `json:"summary"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+	Severity    string    `json:"severity"`
+}
+
 type ClusterListGoodReply struct {
-	Kind  string `json:"kind"`
-	Page  int    `json:"page"`
-	Size  int    `json:"size"`
-	Total int    `json:"total"`
-	Items []struct {
-		ExternalID string `json:"external_id"`
-	} `json:"items"`
+	Kind  string      `json:"kind"`
+	Page  int         `json:"page"`
+	Size  int         `json:"size"`
+	Total int         `json:"total"`
+	Items []GoodReply `json:"items"`
+}
+
+type ServiceLogShortList struct {
+	Kind  string            `json:"kind"`
+	Page  int               `json:"page"`
+	Size  int               `json:"size"`
+	Total int               `json:"total"`
+	Items []ServiceLogShort `json:"items"`
 }
 
 type BadReply struct {

--- a/pkg/utils/ocm.go
+++ b/pkg/utils/ocm.go
@@ -36,8 +36,6 @@ func ApplyFilters(ocmClient *sdk.Connection, filters []string) ([]*v1.Cluster, e
 	requestSize := 50
 	full_filters := strings.Join(filters, " and ")
 
-	fmt.Printf("running the command: 'ocm list clusters --parameter=search=\"%s\"'\n", full_filters)
-
 	request := ocmClient.ClustersMgmt().V1().Clusters().List().Search(full_filters).Size(requestSize)
 	response, err := request.Send()
 	if err != nil {


### PR DESCRIPTION
Ticket Ref: https://issues.redhat.com/browse/OSD-12483

Pulling Servicelogs as part of the cluster context command
- Only displaying the Error Servicelogs
- Shows SLs for the past 30 days by default, but the days value is configurable
- Shows only the SL summary by default, will show Summary, Description, Creation Timestamp and Severity when viewed in verbose mode.
