### PR TITLE
OSD-11989 mock interface and refactors.

### DIFF
--- a/cmd/cluster/support/delete.go
+++ b/cmd/cluster/support/delete.go
@@ -77,6 +77,13 @@ func (o *deleteOptions) complete(cmd *cobra.Command, args []string) error {
 
 func (o *deleteOptions) run() error {
 
+	// Check that the cluster key (name, identifier or external identifier) given by the user
+	// is reasonably safe so that there is no risk of SQL injection
+	err := ctlutil.IsValidClusterKey(o.clusterID)
+	if err != nil {
+		return err
+	}
+
 	// Create an OCM client to talk to the cluster API
 	connection := ctlutil.CreateConnection()
 	defer func() {
@@ -92,7 +99,7 @@ func (o *deleteOptions) run() error {
 	}
 
 	// confirmSend prompt to confirm
-	err := confirmSend()
+	err = confirmSend()
 	if err != nil {
 		fmt.Println("failed to confirmSend(): ", err.Error())
 		return err
@@ -123,7 +130,9 @@ func (o *deleteOptions) run() error {
 }
 
 // createDeleteRequest sets the delete API and returns a request
-func createDeleteRequest(ocmClient *sdk.Connection, cluster *v1.Cluster, reasonID string) (request *sdk.Request, err error) {
+//SDKConnection is an interface that is satisfied by the sdk.Connection and by our mock connection
+//this facilitates unit test and allow us to mock Post() and Delete() api calls
+func createDeleteRequest(ocmClient SDKConnection, cluster *v1.Cluster, reasonID string) (request *sdk.Request, err error) {
 
 	targetAPIPath := "/api/clusters_mgmt/v1/clusters/" + cluster.ID() + "/limited_support_reasons/" + reasonID
 

--- a/cmd/cluster/support/post.go
+++ b/cmd/cluster/support/post.go
@@ -89,6 +89,14 @@ func (o *postOptions) run() error {
 	// and load it into the LimitedSupport variable
 	readTemplate()
 
+	// Check that the cluster key (name, identifier or external identifier) given by the user
+	// is reasonably safe so that there is no risk of SQL injection
+	err := ctlutil.IsValidClusterKey(o.clusterID)
+	if err != nil {
+		return err
+	}
+
+	//if the cluster key is on the right format
 	//create connection to sdk
 	connection := ctlutil.CreateConnection()
 	defer func() {
@@ -111,7 +119,7 @@ func (o *postOptions) run() error {
 	}
 
 	// confirmSend prompt to confirm
-	err := confirmSend()
+	err = confirmSend()
 	if err != nil {
 		fmt.Println("failed to confirmSend(): ", err.Error())
 		return err
@@ -144,7 +152,9 @@ func (o *postOptions) run() error {
 
 // createPostRequest create and populates the limited support post call
 // swagger code gen: https://api.openshift.com/?urls.primaryName=Clusters%20management%20service#/default/post_api_clusters_mgmt_v1_clusters__cluster_id__limited_support_reasons
-func createPostRequest(ocmClient *sdk.Connection, cluster *v1.Cluster) (request *sdk.Request, err error) {
+//SDKConnection is an interface that is satisfied by the sdk.Connection and by our mock connection
+//this facilitates unit test and allow us to mock Post() and Delete() api calls
+func createPostRequest(ocmClient SDKConnection, cluster *v1.Cluster) (request *sdk.Request, err error) {
 
 	targetAPIPath := "/api/clusters_mgmt/v1/clusters/" + cluster.ID() + "/limited_support_reasons"
 

--- a/cmd/cluster/support/sdkmock.go
+++ b/cmd/cluster/support/sdkmock.go
@@ -1,0 +1,27 @@
+package support
+
+import sdk "github.com/openshift-online/ocm-sdk-go"
+
+type SDKConnection interface {
+	Post() *sdk.Request
+	Delete() *sdk.Request
+}
+
+var (
+	Client SDKConnection
+)
+
+//sdk client structure
+type MockClient struct {
+	//empty structure to satisfy interface
+}
+
+//Mock POST request to the API for unit tests
+func (m *MockClient) Post() *sdk.Request {
+	return &sdk.Request{}
+}
+
+//Mock Delete request to the API for unit tests
+func (m *MockClient) Delete() *sdk.Request {
+	return &sdk.Request{}
+}

--- a/cmd/cluster/support/status.go
+++ b/cmd/cluster/support/status.go
@@ -60,6 +60,13 @@ func (o *statusOptions) complete(cmd *cobra.Command, args []string) error {
 
 func (o *statusOptions) run() error {
 
+	// Check that the cluster key (name, identifier or external identifier) given by the user
+	// is reasonably safe so that there is no risk of SQL injection
+	err := ctlutil.IsValidClusterKey(o.clusterID)
+	if err != nil {
+		return err
+	}
+
 	//create connection to sdk
 	connection := ctlutil.CreateConnection()
 	defer func() {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -27,6 +28,23 @@ func GetOCMAccessToken() (*string, error) {
 	accessToken := strings.TrimSuffix(string(ocmOutput), "\n")
 
 	return &accessToken, nil
+}
+
+var clusterKeyRE = regexp.MustCompile(`^(\w|-)+$`)
+
+func IsValidKey(clusterKey string) bool {
+	return clusterKeyRE.MatchString(clusterKey)
+}
+
+func IsValidClusterKey(clusterKey string) (err error) {
+	if !IsValidKey(clusterKey) {
+		return fmt.Errorf(
+			"Cluster name, identifier or external identifier '%s' isn't valid: it "+
+				"must contain only letters, digits, dashes and underscores",
+			clusterKey,
+		)
+	}
+	return nil
 }
 
 //GetCluster Function allows to get a single cluster with any identifier (displayname, ID, or external ID)


### PR DESCRIPTION
mock sdk connection basic requests (post, delete), refactor code to accommodate api mocking for unit tests, added validation to clusterID format before sending requests to API.