### PR TITLE
Create capability add and remove commands

### DIFF
--- a/cmd/capability/add.go
+++ b/cmd/capability/add.go
@@ -1,0 +1,110 @@
+package capability
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+type addOptions struct {
+	OrganizationID string
+	SubscriptionID string
+}
+
+func newAddCmd() *cobra.Command {
+	ops := addOptions{}
+	addCmd := &cobra.Command{
+		Use:   "add [capability] -g [organization ID]",
+		Short: "adds a specific capability to a specific OCM organization.\nAvailable capabilities: hibernation, autoscaling, ovn, upgradeChannelChange",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd, args))
+			cmdutil.CheckErr(ops.run(cmd, args[0]))
+		},
+	}
+
+	addCmd.Flags().StringVarP(&ops.OrganizationID, "organization-id", "g", "", "Specify an OCM Organization to apply a capability to")
+	addCmd.Flags().StringVarP(&ops.SubscriptionID, "subscription-id", "b", "", "Specify a Subscription to apply a capability to")
+
+	return addCmd
+}
+
+func (o *addOptions) complete(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("capability was not provided, please specifiy which capability to add")
+	}
+
+	if len(args) != 1 {
+		return fmt.Errorf("too many arguments. Expected 1 got %d", len(args))
+	}
+
+	// Ensure that the capability selected is valid
+	availableCapabilities := []string{hibernation, autoscaling, ovn, upgradeChannelChange}
+	for i, s := range availableCapabilities {
+		if args[0] == s {
+			break
+		}
+		if i == len(availableCapabilities)-1 {
+			return fmt.Errorf("invalid capability specified. Avaialbe capabilites are hibernation, autoscaling, ovn and upgradeChannelChange")
+		}
+	}
+
+	// Make sure only of of Org ID or Sub ID is set
+	if o.OrganizationID != "" && o.SubscriptionID != "" {
+		return fmt.Errorf("organization and subscription cannot both be set. Please only specify one")
+	}
+
+	// Make sure at least one of them is set
+	if o.OrganizationID == "" && o.SubscriptionID == "" {
+		return fmt.Errorf("no organization or subscription was provided, please specify organization using -g, or subscription using -b")
+	}
+
+	return nil
+}
+
+func (o *addOptions) run(cmd *cobra.Command, capability string) error {
+
+	// Initalize OCM connection
+	ocmClient := utils.CreateConnection()
+	defer func() {
+		if err := ocmClient.Close(); err != nil {
+			fmt.Printf("Cannot close the ocmClient (possible memory leak): %q", err)
+		}
+	}()
+
+	body := CapabilityBody{Internal: true, Value: "true"}
+
+	// Build request based on capability specified
+	request := ocmClient.Post()
+	if o.OrganizationID != "" {
+		body.ResourceType = "organization"
+		request.Path(fmt.Sprintf(organizationPath+"/%s"+labelsPath, o.OrganizationID))
+	} else {
+		// We know if OrgId isn't set, Subscription is
+		body.ResourceType = "subscription"
+		request.Path(fmt.Sprintf(subscriptionPath+"/%s"+labelsPath, o.SubscriptionID))
+	}
+
+	body.Key = getCapabilityKey(capability)
+
+	// Now that the body is filled out, convert it to bytes
+	messageBytes, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("cannot marshal template to json: %v", err)
+	}
+
+	request.Bytes(messageBytes)
+
+	// Post request
+	response, err := request.Send()
+	if err != nil {
+		return fmt.Errorf("cannot send request: %q", err)
+	}
+
+	fmt.Println(response)
+
+	return nil
+}

--- a/cmd/capability/capability_test.go
+++ b/cmd/capability/capability_test.go
@@ -1,0 +1,208 @@
+package capability
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestGetCapabilityKeys(t *testing.T) {
+
+	tests := []struct {
+		Name         string
+		ExpectedResp string
+		Input        string
+	}{
+		{
+			Name:         "Hibernation capability key",
+			ExpectedResp: "capability.organization.hibernate_cluster",
+			Input:        "hibernation",
+		},
+		{
+			Name:         "Autoscaling capability key",
+			ExpectedResp: "capability.cluster.autoscale_clusters",
+			Input:        "autoscaling",
+		},
+		{
+			Name:         "Upgrade Channel capability key",
+			ExpectedResp: "capability.organization.allow_set_upgrade_channel_group",
+			Input:        "upgradeChannelChange",
+		},
+		{
+			Name:         "OVN capability key",
+			ExpectedResp: "capability.organization.ovn_cluster",
+			Input:        "ovn",
+		},
+		{
+			Name:         "Invalid capability key",
+			ExpectedResp: "Not a valid capability",
+			Input:        "foo",
+		},
+	}
+
+	for _, test := range tests {
+		result := getCapabilityKey(test.Input)
+		if result != test.ExpectedResp {
+			t.Fatalf("Test %s failed. Expected %s, got %s\n", test.Name, test.ExpectedResp, result)
+		}
+	}
+}
+
+func TestAddComplete(t *testing.T) {
+	tests := []struct {
+		Name          string
+		ErrorExpected bool
+		ErrorReason   string
+		Args          []string
+		AddOptions    addOptions
+	}{
+		{
+			Name:          "Providing Organization ID",
+			ErrorExpected: false,
+			Args:          []string{"hibernation"},
+			AddOptions:    addOptions{OrganizationID: "myOrganization"},
+		},
+		{
+			Name:          "Providing Subscription ID",
+			ErrorExpected: false,
+			Args:          []string{"hibernation"},
+			AddOptions:    addOptions{SubscriptionID: "mySubscription"},
+		},
+		{
+			Name:          "Providing Organization ID and Subscription ID",
+			ErrorExpected: true,
+			ErrorReason:   "organization and subscription cannot both be set. Please only specify one",
+			Args:          []string{"hibernation"},
+			AddOptions:    addOptions{OrganizationID: "myorganization", SubscriptionID: "mySubscription"},
+		},
+		{
+			Name:          "Providing neither Organization ID and Subscription ID",
+			ErrorExpected: true,
+			ErrorReason:   "no organization or subscription was provided, please specify organization using -g, or subscription using -b",
+			Args:          []string{"hibernation"},
+			AddOptions:    addOptions{},
+		},
+		{
+			Name:          "Providing hibernation capability",
+			ErrorExpected: false,
+			Args:          []string{"hibernation"},
+			AddOptions:    addOptions{OrganizationID: "myOrganization"},
+		},
+		{
+			Name:          "Providing invalid capability",
+			ErrorExpected: true,
+			ErrorReason:   "invalid capability specified. Avaialbe capabilites are hibernation, autoscaling, ovn and upgradeChannelChange",
+			Args:          []string{"invalid"},
+			AddOptions:    addOptions{OrganizationID: "myOrganization"},
+		},
+		{
+			Name:          "Providing no arguments",
+			ErrorExpected: true,
+			ErrorReason:   "capability was not provided, please specifiy which capability to add",
+			Args:          []string{},
+			AddOptions:    addOptions{OrganizationID: "myOrganization"},
+		},
+		{
+			Name:          "Providing too many arguments",
+			ErrorExpected: true,
+			ErrorReason:   "too many arguments. Expected 1 got 2",
+			Args:          []string{"hibernation", "foo"},
+			AddOptions:    addOptions{OrganizationID: "myOrganization"},
+		},
+	}
+
+	for _, test := range tests {
+		result := test.AddOptions.complete(&cobra.Command{}, test.Args)
+		if test.ErrorExpected {
+			if result == nil {
+				t.Fatalf("Test %s failed. Expected error %s, but got none", test.Name, test.ErrorReason)
+			}
+			if result.Error() != test.ErrorReason {
+				t.Fatalf("Test %s failed. Expected error %s, but got %s", test.Name, test.ErrorReason, result.Error())
+			}
+		}
+		if !test.ErrorExpected && result != nil {
+			t.Fatalf("Test %s failed. Expected no errors, but got %s", test.Name, result.Error())
+		}
+
+	}
+}
+
+func TestRemoveComplete(t *testing.T) {
+	tests := []struct {
+		Name          string
+		ErrorExpected bool
+		ErrorReason   string
+		Args          []string
+		RemoveOptions removeOptions
+	}{
+		{
+			Name:          "Providing Organization ID",
+			ErrorExpected: false,
+			Args:          []string{"hibernation"},
+			RemoveOptions: removeOptions{OrganizationID: "myOrganization"},
+		},
+		{
+			Name:          "Providing Subscription ID",
+			ErrorExpected: false,
+			Args:          []string{"hibernation"},
+			RemoveOptions: removeOptions{SubscriptionID: "mySubscription"},
+		},
+		{
+			Name:          "Providing Organization ID and Subscription ID",
+			ErrorExpected: true,
+			ErrorReason:   "organization and subscription cannot both be set. Please only specify one",
+			Args:          []string{"hibernation"},
+			RemoveOptions: removeOptions{OrganizationID: "myorganization", SubscriptionID: "mySubscription"},
+		},
+		{
+			Name:          "Providing neither Organization ID and Subscription ID",
+			ErrorExpected: true,
+			ErrorReason:   "no organization or subscription was provided, please specify organization using -g, or subscription using -b",
+			Args:          []string{"hibernation"},
+			RemoveOptions: removeOptions{},
+		},
+		{
+			Name:          "Providing hibernation capability",
+			ErrorExpected: false,
+			Args:          []string{"hibernation"},
+			RemoveOptions: removeOptions{OrganizationID: "myOrganization"},
+		},
+		{
+			Name:          "Providing invalid capability",
+			ErrorExpected: true,
+			ErrorReason:   "invalid capability specified. Avaialbe capabilites are hibernation, autoscaling, ovn and upgradeChannelChange",
+			Args:          []string{"invalid"},
+			RemoveOptions: removeOptions{OrganizationID: "myOrganization"},
+		},
+		{
+			Name:          "Providing no arguments",
+			ErrorExpected: true,
+			ErrorReason:   "capability was not provided, please specifiy which capability to add",
+			Args:          []string{},
+			RemoveOptions: removeOptions{OrganizationID: "myOrganization"},
+		},
+		{
+			Name:          "Providing too many arguments",
+			ErrorExpected: true,
+			ErrorReason:   "too many arguments. Expected 1 got 2",
+			Args:          []string{"hibernation", "foo"},
+			RemoveOptions: removeOptions{OrganizationID: "myOrganization"},
+		},
+	}
+
+	for _, test := range tests {
+		result := test.RemoveOptions.complete(&cobra.Command{}, test.Args)
+		if test.ErrorExpected {
+			if result == nil {
+				t.Fatalf("Test %s failed. Expected error %s, but got none", test.Name, test.ErrorReason)
+			}
+			if result.Error() != test.ErrorReason {
+				t.Fatalf("Test %s failed. Expected error %s, but got %s", test.Name, test.ErrorReason, result.Error())
+			}
+		}
+		if !test.ErrorExpected && result != nil {
+			t.Fatalf("Test %s failed. Expected no errors, but got %s", test.Name, result.Error())
+		}
+	}
+}

--- a/cmd/capability/cmd.go
+++ b/cmd/capability/cmd.go
@@ -1,0 +1,76 @@
+package capability
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	// All the base paths for OCM resources used for capabilities
+	basePath         = "/api/accounts_mgmt/v1"
+	labelsPath       = "/labels"
+	organizationPath = basePath + "/organizations"
+	subscriptionPath = basePath + "/subscriptions"
+
+	hibernation          = "hibernation"
+	autoscaling          = "autoscaling"
+	upgradeChannelChange = "upgradeChannelChange"
+	ovn                  = "ovn"
+
+	// Source for all capabilitiy keys. Add new keys here when adding a capability to the command
+	hibernationKey          = "capability.organization.hibernate_cluster"
+	autoscalingKey          = "capability.cluster.autoscale_clusters"
+	upgradeChannelChangeKey = "capability.organization.allow_set_upgrade_channel_group"
+	ovnKey                  = "capability.organization.ovn_cluster"
+)
+
+type CapabilityBody struct {
+	Internal     bool   `json:"internal"`
+	Key          string `json:"key"`
+	ResourceType string `json:"type"`
+	Value        string `json:"value"`
+}
+
+func NewCmdCapability() *cobra.Command {
+	var capabilityCmd = &cobra.Command{
+		Use:   "capability",
+		Short: "Manage capabilites for OCM Organizations",
+		Run: func(cmd *cobra.Command, args []string) {
+			err := cmd.Help()
+			if err != nil {
+				fmt.Println("Error calling cmd.Help(): ", err.Error())
+				return
+			}
+		},
+	}
+
+	// Add subcommands
+	capabilityCmd.AddCommand(newAddCmd())
+	capabilityCmd.AddCommand(newRemoveCmd())
+
+	return capabilityCmd
+}
+
+// Ideally, this function would instead be a map[string]string
+// However, maps cannot be initalized at the package scope so
+// to use a map, one would need to create a function that builds
+// the desired structure, i.e. getCapabilityMap() map[string]string
+// This function recreates the functionality of a map without the overhead
+// of needing to build the map every time its needed.
+// The use of constants prevents cases of mispellings
+func getCapabilityKey(capability string) string {
+
+	switch capability {
+	case hibernation:
+		return hibernationKey
+	case autoscaling:
+		return autoscalingKey
+	case ovn:
+		return ovnKey
+	case upgradeChannelChange:
+		return upgradeChannelChangeKey
+	}
+
+	return "Not a valid capability"
+}

--- a/cmd/capability/remove.go
+++ b/cmd/capability/remove.go
@@ -1,0 +1,102 @@
+package capability
+
+import (
+	"fmt"
+
+	"github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+type removeOptions struct {
+	OrganizationID string
+	SubscriptionID string
+}
+
+func newRemoveCmd() *cobra.Command {
+	ops := removeOptions{}
+	addCmd := &cobra.Command{
+		Use:   "remove [capability] -g [organization ID]",
+		Short: "Removes a specific capability to a specific OCM organization.\nAvailable capabilities: hibernation, autoscaling, ovn, upgradeChannelChange",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd, args))
+			cmdutil.CheckErr(ops.run(cmd, args[0]))
+		},
+	}
+
+	addCmd.Flags().StringVarP(&ops.OrganizationID, "organization-id", "g", "", "Specify an OCM Organization to apply a capability to")
+	addCmd.Flags().StringVarP(&ops.SubscriptionID, "subscription-id", "b", "", "Specify a Subscription to apply a capability to")
+
+	return addCmd
+}
+
+func (o *removeOptions) complete(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("capability was not provided, please specifiy which capability to add")
+	}
+
+	if len(args) != 1 {
+		return fmt.Errorf("too many arguments. Expected 1 got %d", len(args))
+	}
+
+	// Ensure that the capability selected is valid
+	availableCapabilities := []string{hibernation, autoscaling, ovn, upgradeChannelChange}
+	for i, s := range availableCapabilities {
+		if args[0] == s {
+			break
+		}
+		if i == len(availableCapabilities)-1 {
+			return fmt.Errorf("invalid capability specified. Avaialbe capabilites are hibernation, autoscaling, ovn and upgradeChannelChange")
+		}
+	}
+
+	// Make sure only of of Org ID or Sub ID is set
+	if o.OrganizationID != "" && o.SubscriptionID != "" {
+		return fmt.Errorf("organization and subscription cannot both be set. Please only specify one")
+	}
+
+	// Make sure at least one of them is set
+	if o.OrganizationID == "" && o.SubscriptionID == "" {
+		return fmt.Errorf("no organization or subscription was provided, please specify organization using -g, or subscription using -b")
+	}
+
+	return nil
+}
+
+func (o *removeOptions) run(cmd *cobra.Command, capability string) error {
+
+	// Initalize OCM connection
+	ocmClient := utils.CreateConnection()
+	defer func() {
+		if err := ocmClient.Close(); err != nil {
+			fmt.Printf("Cannot close the ocmClient (possible memory leak): %q", err)
+		}
+	}()
+
+	// Build the base of the request path
+	var base string
+	if o.OrganizationID != "" {
+		// If the organization
+		base = organizationPath + "/" + o.OrganizationID
+	} else {
+		// If organization ID isn't spcified, we know subscription ID is
+		base = subscriptionPath + "/" + o.SubscriptionID
+	}
+
+	// Build href path for capability
+	href := fmt.Sprintf(base + labelsPath + "/" + getCapabilityKey(capability))
+
+	// Create a deletion request and add the href as the path
+	request := ocmClient.Delete()
+	request.Path(href)
+
+	// Send the request
+	response, err := request.Send()
+	if err != nil {
+		fmt.Println(response)
+		return fmt.Errorf("cannot send request: %q", err)
+	}
+
+	return nil
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	routev1 "github.com/openshift/api/route/v1"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/pkg/apis/aws/v1alpha1"
 	gcpv1alpha1 "github.com/openshift/gcp-project-operator/pkg/apis"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/openshift/osdctl/cmd/aao"
 	"github.com/openshift/osdctl/cmd/account"
+	"github.com/openshift/osdctl/cmd/capability"
 	"github.com/openshift/osdctl/cmd/cluster"
 	"github.com/openshift/osdctl/cmd/clusterdeployment"
 	"github.com/openshift/osdctl/cmd/cost"
@@ -77,6 +79,8 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 
 	// Add upgradeCmd for upgrading the currently running executable in-place.
 	rootCmd.AddCommand(upgradeCmd)
+
+	rootCmd.AddCommand(capability.NewCmdCapability())
 
 	return rootCmd
 }


### PR DESCRIPTION
This PR adds two new commands, 
```
osdctl capability add [hibernation|autoscaling|ovn|upgradeChannelChange] [-g $OrgID | -b $SubscriptionID]

osdctl capability remove [hibernation|autoscaling|ovn|upgradeChannelChange] [-g $OrgID | -b $SubscriptionID]
```
This allows for adding and removing a specific capability to an OCM Organization or Subscription. The capabilities initially supported are: hibernation, autoscaling, ovn, and upgradeChannelChange.

Ref: https://issues.redhat.com/browse/OSD-12627