### PR TITLE
Remove local var that overrides package-scoped var definition

### DIFF
--- a/cmd/servicelog/list.go
+++ b/cmd/servicelog/list.go
@@ -80,8 +80,6 @@ func FetchServiceLogs(clusterID string) (*sdk.Response, error) {
 	}
 	cluster := clusters[0]
 
-	serviceLogListAllMessagesFlag := false
-
 	// Now get the SLs for the cluster
 	return sendRequest(CreateListSLRequest(ocmClient, cluster.ExternalID(), serviceLogListAllMessagesFlag, serviceLogListInternalOnlyFlag))
 }


### PR DESCRIPTION
Fixes a bug where -A is ignored in `osdctl servicelog list -A`. The flag is mapped to a package-scoped bool, but was being overwritten locally in the `FetchServiceLogs` function.