### PR TITLE
Fixes minor typo capabilities add.go

### DIFF
--- a/cmd/capability/add.go
+++ b/cmd/capability/add.go
@@ -48,7 +48,7 @@ func (o *addOptions) complete(cmd *cobra.Command, args []string) error {
 			break
 		}
 		if i == len(availableCapabilities)-1 {
-			return fmt.Errorf("invalid capability specified. Avaialbe capabilites are hibernation, autoscaling, ovn and upgradeChannelChange")
+			return fmt.Errorf("invalid capability specified. Available capabilites are hibernation, autoscaling, ovn and upgradeChannelChange")
 		}
 	}
 

--- a/cmd/capability/capability_test.go
+++ b/cmd/capability/capability_test.go
@@ -91,7 +91,7 @@ func TestAddComplete(t *testing.T) {
 		{
 			Name:          "Providing invalid capability",
 			ErrorExpected: true,
-			ErrorReason:   "invalid capability specified. Avaialbe capabilites are hibernation, autoscaling, ovn and upgradeChannelChange",
+			ErrorReason:   "invalid capability specified. Available capabilites are hibernation, autoscaling, ovn and upgradeChannelChange",
 			Args:          []string{"invalid"},
 			AddOptions:    addOptions{OrganizationID: "myOrganization"},
 		},
@@ -171,7 +171,7 @@ func TestRemoveComplete(t *testing.T) {
 		{
 			Name:          "Providing invalid capability",
 			ErrorExpected: true,
-			ErrorReason:   "invalid capability specified. Avaialbe capabilites are hibernation, autoscaling, ovn and upgradeChannelChange",
+			ErrorReason:   "invalid capability specified. Available capabilites are hibernation, autoscaling, ovn and upgradeChannelChange",
 			Args:          []string{"invalid"},
 			RemoveOptions: removeOptions{OrganizationID: "myOrganization"},
 		},

--- a/cmd/capability/remove.go
+++ b/cmd/capability/remove.go
@@ -47,7 +47,7 @@ func (o *removeOptions) complete(cmd *cobra.Command, args []string) error {
 			break
 		}
 		if i == len(availableCapabilities)-1 {
-			return fmt.Errorf("invalid capability specified. Avaialbe capabilites are hibernation, autoscaling, ovn and upgradeChannelChange")
+			return fmt.Errorf("invalid capability specified. Available capabilites are hibernation, autoscaling, ovn and upgradeChannelChange")
 		}
 	}
 
@@ -77,7 +77,7 @@ func (o *removeOptions) run(cmd *cobra.Command, capability string) error {
 	// Build the base of the request path
 	var base string
 	if o.OrganizationID != "" {
-		// If the organization
+		// If the organizationID is set
 		base = organizationPath + "/" + o.OrganizationID
 	} else {
 		// If organization ID isn't spcified, we know subscription ID is


### PR DESCRIPTION
Fixes the spelling of Available in print output.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
