### PR TITLE
Add a PR check for go mod tidy and fix the current error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ mockgen: ensure-mockgen
 	@git diff --exit-code -- ./pkg/provider/aws/mock
 
 ensure-mockgen:
-	GOBIN=${BASE_DIR}/bin/  go install github.com/golang/mock/mockgen@v1.5.0
+	GOBIN=${BASE_DIR}/bin/  go install github.com/golang/mock/mockgen@v1.6.0
 
 test:
 	go test ${BUILDFLAGS} ./... -covermode=atomic -coverpkg=./...

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SHELL := env PATH=$(PATH) /bin/bash
 
 all: format mod build test
 
-format: vet fmt mockgen ci-build docs
+format: vet mod fmt mockgen ci-build docs
 
 fmt:
 	@echo "gofmt"

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openshift/hive v1.0.5
 	github.com/openshift/osd-network-verifier v0.0.0-20220518154805-047e42cfe29f
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
-	github.com/prometheus/common v0.37.0
+	github.com/prometheus/common v0.37.0 // indirect
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0


### PR DESCRIPTION
Adding a check for `go mod tidy` to CI + fixing an existing error preventing successful builds

Also noticed we can bump mockgen safely