### PR TITLE
Change display_name to name

### DIFF
--- a/pkg/utils/ocm.go
+++ b/pkg/utils/ocm.go
@@ -57,7 +57,7 @@ func ApplyFilters(ocmClient *sdk.Connection, filters []string) ([]*v1.Cluster, e
 
 // GenerateQuery returns an OCM search query to retrieve all clusters matching an expression (ie- "foo%")
 func GenerateQuery(clusterIdentifier string) string {
-	return strings.TrimSpace(fmt.Sprintf("(id like '%[1]s' or external_id like '%[1]s' or display_name like '%[1]s')", clusterIdentifier))
+	return strings.TrimSpace(fmt.Sprintf("(id like '%[1]s' or external_id like '%[1]s' or name like '%[1]s')", clusterIdentifier))
 }
 
 func CreateConnection() *sdk.Connection {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -55,7 +55,7 @@ func GetCluster(connection *sdk.Connection, key string) (cluster *cmv1.Cluster, 
 
 	// Try to find a matching subscription:
 	subsSearch := fmt.Sprintf(
-		"(display_name = '%s' or cluster_id = '%s' or external_cluster_id = '%s') and "+
+		"(name = '%s' or cluster_id = '%s' or external_cluster_id = '%s') and "+
 			"status in ('Reserved', 'Active')",
 		key, key, key,
 	)


### PR DESCRIPTION
Recent ocm sdk changes on STAGE is breaking osdctl. `display_name` is no longer a valid field name and has been replaced with `name`. This PR fixes errors like these `2022/08/15 12:59:10 error while retrieving cluster(s) from ocm: status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400' and operation identifier is 'e6bce9cc-fe94-4a36-8b81-0a0ebb9b0d6d': display_name is not a valid field name`