### PR TITLE
[OSD-11315] Add Cloudtrail events to cluster context command

### DIFF
--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -26,7 +26,7 @@ func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions
 	clusterCmd.AddCommand(newCmdLoggingCheck(streams, flags, globalOpts))
 	clusterCmd.AddCommand(newCmdOwner(streams, flags, globalOpts))
 	clusterCmd.AddCommand(support.NewCmdSupport(streams, flags, client, globalOpts))
-	clusterCmd.AddCommand(newCmdContext(streams, flags, globalOpts))
+	clusterCmd.AddCommand(newCmdContext())
 	clusterCmd.AddCommand(newCmdTransferOwner(streams, flags, globalOpts))
 	clusterCmd.AddCommand(access.NewCmdAccess(streams, flags))
 	clusterCmd.AddCommand(newCmdResizeControlPlaneNode(streams, flags, globalOpts))

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -11,6 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudtrail"
+	"github.com/aws/aws-sdk-go/service/cloudtrail/cloudtrailiface"
 	"github.com/aws/aws-sdk-go/service/costexplorer"
 	"github.com/aws/aws-sdk-go/service/costexplorer/costexploreriface"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -111,6 +113,9 @@ type Client interface {
 	GetCostAndUsage(input *costexplorer.GetCostAndUsageInput) (*costexplorer.GetCostAndUsageOutput, error)
 	CreateCostCategoryDefinition(input *costexplorer.CreateCostCategoryDefinitionInput) (*costexplorer.CreateCostCategoryDefinitionOutput, error)
 	ListCostCategoryDefinitions(input *costexplorer.ListCostCategoryDefinitionsInput) (*costexplorer.ListCostCategoryDefinitionsOutput, error)
+
+	// Cloudtrail
+	LookupEvents(input *cloudtrail.LookupEventsInput) (*cloudtrail.LookupEventsOutput, error)
 }
 
 type AwsClient struct {
@@ -122,6 +127,7 @@ type AwsClient struct {
 	orgClient           organizationsiface.OrganizationsAPI
 	resClient           resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
 	ceClient            costexploreriface.CostExplorerAPI
+	cloudTrailClient    cloudtrailiface.CloudTrailAPI
 }
 
 func NewAwsSession(profile, region, configFile string) (*session.Session, error) {
@@ -172,6 +178,7 @@ func NewAwsClient(profile, region, configFile string) (Client, error) {
 		orgClient:           organizations.New(sess),
 		ceClient:            costexplorer.New(sess),
 		resClient:           resourcegroupstaggingapi.New(sess),
+		cloudTrailClient:    cloudtrail.New(sess),
 	}
 
 	// Validate the creds
@@ -211,6 +218,7 @@ func NewAwsClientWithInput(input *AwsClientInput) (Client, error) {
 		orgClient:           organizations.New(s),
 		ceClient:            costexplorer.New(s),
 		resClient:           resourcegroupstaggingapi.New(s),
+		cloudTrailClient:    cloudtrail.New(s),
 	}, nil
 }
 
@@ -438,4 +446,8 @@ func (c *AwsClient) WaitUntilInstanceRunning(input *ec2.DescribeInstancesInput) 
 
 func (c *AwsClient) WaitUntilInstanceStopped(input *ec2.DescribeInstancesInput) error {
 	return c.ec2Client.WaitUntilInstanceStopped(input)
+}
+
+func (c *AwsClient) LookupEvents(input *cloudtrail.LookupEventsInput) (*cloudtrail.LookupEventsOutput, error) {
+	return c.cloudTrailClient.LookupEvents(input)
 }

--- a/pkg/provider/aws/mock/client.go
+++ b/pkg/provider/aws/mock/client.go
@@ -7,6 +7,7 @@ package mock
 import (
 	reflect "reflect"
 
+	cloudtrail "github.com/aws/aws-sdk-go/service/cloudtrail"
 	costexplorer "github.com/aws/aws-sdk-go/service/costexplorer"
 	ec2 "github.com/aws/aws-sdk-go/service/ec2"
 	iam "github.com/aws/aws-sdk-go/service/iam"
@@ -744,6 +745,21 @@ func (m *MockClient) ListUsers(arg0 *iam.ListUsersInput) (*iam.ListUsersOutput, 
 func (mr *MockClientMockRecorder) ListUsers(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUsers", reflect.TypeOf((*MockClient)(nil).ListUsers), arg0)
+}
+
+// LookupEvents mocks base method.
+func (m *MockClient) LookupEvents(input *cloudtrail.LookupEventsInput) (*cloudtrail.LookupEventsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LookupEvents", input)
+	ret0, _ := ret[0].(*cloudtrail.LookupEventsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LookupEvents indicates an expected call of LookupEvents.
+func (mr *MockClientMockRecorder) LookupEvents(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LookupEvents", reflect.TypeOf((*MockClient)(nil).LookupEvents), input)
 }
 
 // ModifyInstanceAttribute mocks base method.


### PR DESCRIPTION
Ticket ref: https://issues.redhat.com/browse/OSD-11315

Added pulling cloudtrail events to cluster context command.
Currently just blindly pulling the last 40 pages of events, and doing minor filtering on the events after the fact, as Cloudtrail limits the number of attributes you can filter on to 1 per request. Filtering out read-only event types. 

Example use:
./osdctl cluster context {clusterID} -p rhcontrol