### PR TITLE
Add date to cluster context SL output, and safety checking

### DIFF
--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -258,6 +258,12 @@ func (o *statusOptions) printPDAlerts() error {
 		oauthtoken = o.oauthtoken
 	} else {
 		pdConfig := config.LoadPDConfig("/.config/pagerduty-cli/config.json")
+		if len(pdConfig.MySubdomain) == 0 {
+			return fmt.Errorf("unable to parse PagerDuty config")
+		}
+		if len(pdConfig.MySubdomain[0].AccessToken) == 0 {
+			return fmt.Errorf("unable to locate oauth accesstoken in PagerDuty config")
+		}
 		oauthtoken = pdConfig.MySubdomain[0].AccessToken
 	}
 	client := pd.NewOAuthClient(oauthtoken)

--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -244,7 +244,7 @@ func (o *statusOptions) printServiceLogs() error {
 	} else {
 		// Non verbose only prints the summaries
 		for i, errorServiceLog := range errorServiceLogs {
-			fmt.Printf("%d. %s \n", i, errorServiceLog.Summary)
+			fmt.Printf("%d. %s (%s)\n", i, errorServiceLog.Summary, errorServiceLog.CreatedAt.Format(time.RFC3339))
 		}
 	}
 	fmt.Println()


### PR DESCRIPTION
## What it does

- Add service log creation date to the `cluster context` service log output
- Add safety checking to the extraction of the oauth token from pagerduty config

## Background

I :heart: `cluster context` and have been using it all week, but the thing I really needed was more context around when service logs have been sent - helps me make a judgement call on whether to invest time in re-verifying an issue still exists.

Likewise I initially had trouble with the pagerduty alert reporting because I was using an ancient version of the `pagerduty-cli`'s `config.json` which did not have the structure expected by `osdctl`, so it would code-panic. I added some safety checking to prevent that.

