### PR TITLE
Added 'access' subcommand and associated unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,19 @@ osdctl federatedrole apply -u <URL>
 osdctl federatedrole apply -f <yaml file>
 ```
 
+### Cluster break-glass access
+#### Access cluster
+```bash
+# Login to the cluster's hive shard
+osdctl cluster break-glass <cluster identifier> --as backplane-cluster-admin
+```
+
+#### Drop cluster access
+```bash
+osdctl cluster break-glass cleanup <cluster identifier>
+# Non-PrivateLink - remove any Kubeconfig files saved locally in /tmp/
+```
+
 ### Send a servicelog to a cluster
 
 #### List servicelogs

--- a/cmd/cluster/access/access.go
+++ b/cmd/cluster/access/access.go
@@ -1,0 +1,451 @@
+package access
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	fpath "path/filepath"
+	"strings"
+	"time"
+
+	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/osdctl/pkg/k8s"
+	osdctlutil "github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	corev1 "k8s.io/api/core/v1"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	clientcmdapiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// impersonateUser represents the user SREs are allowed to impersonate in order to retrieve a cluster's kubeconfig.
+	impersonateUser     = "backplane-cluster-admin"
+	kubeconfigSecretKey = "kubeconfig"
+
+	// PrivateLink "jump pod" configuration
+	jumpImage         = "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest"
+	jumpContainerName = "jump"
+	jumpPodLabelKey   = "automated-break-glass-access/cluster"
+
+	// Lifespan for jump pods in seconds. Currently, PrivateLink jump pods will expire after 8 hours
+	jumpPodLifespan = 28800
+)
+
+var (
+	jumpPodPollInterval = 5 * time.Second
+	jumpPodPollTimeout  = 5 * time.Minute
+)
+
+// NewCmdCluster implements the 'cluster access' subcommand
+func NewCmdAccess(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	accessCmd := &cobra.Command{
+		Use:               "break-glass <cluster identifier>",
+		Short:             "Emergency access to a cluster",
+		Long:              "Obtain emergency credentials to access the given cluster. You must be logged into the cluster's hive shard",
+		Args:              cobra.ExactArgs(1),
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(accessCmdComplete(cmd, args))
+			// Prior to creating k8s client, verify the user has elevated permissions
+			cmdutil.CheckErr(verifyPermissions(streams, flags))
+			client := k8s.NewClient(flags)
+			clusterAccess := newClusterAccessOptions(client, streams, flags)
+			cmdutil.CheckErr(clusterAccess.Run(cmd, args))
+		},
+	}
+	accessCmd.AddCommand(newCmdCleanup(streams, flags))
+
+	return accessCmd
+}
+
+// clusterCmdComplete verifies the command's invocation, returning an error if the usage is invalid
+func accessCmdComplete(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return cmdutil.UsageErrorf(cmd, "Exactly one cluster identifier was expected")
+	}
+	return osdctlutil.IsValidClusterKey(args[0])
+}
+
+// verifyPermissions determines if the user has supplied the correct permissions in order to retrieve a KubeConfig secret from hive.
+// If the user attempts to impersonate an unexpected account, an error is returned.
+// If the user hasn't attempted to impersonate anyone, it prompts whether they would like to do so automatically.
+func verifyPermissions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) error {
+	if flags.Impersonate != nil && *flags.Impersonate != "" {
+		if *flags.Impersonate != impersonateUser {
+			osdctlutil.StreamPrintln(streams, "")
+			return fmt.Errorf("Unauthorized impersonation as user '%s'. Only requests to impersonate '%s' are allowed.", *flags.Impersonate, impersonateUser)
+		}
+	} else {
+		osdctlutil.StreamPrintln(streams, "")
+		osdctlutil.StreamPrintln(streams, fmt.Sprintf("No impersonation request detected. By design, SREs do not have sufficient permission to retrieve a cluster Kubeconfig from hive, and should impersonate '%s' to do so.", impersonateUser))
+		osdctlutil.StreamPrint(streams, fmt.Sprintf("Would you like to continue as '%s'? (You can disable this prompt in the future by rerunning this command with '--as %s') [y/N] ", impersonateUser, impersonateUser))
+
+		input, err := osdctlutil.StreamRead(streams, '\n')
+		if err != nil {
+			return err
+		}
+		if !isAffirmative(strings.TrimSpace(input)) {
+			return fmt.Errorf("Did not impersonate '%s'", impersonateUser)
+		}
+		*flags.Impersonate = impersonateUser
+		osdctlutil.StreamPrintln(streams, fmt.Sprintf("Continuing as '%s'", impersonateUser))
+		osdctlutil.StreamPrintln(streams, "")
+	}
+	return nil
+}
+
+// clusterAccessOptions contains the objects and information required to access a cluster
+type clusterAccessOptions struct {
+	*genericclioptions.ConfigFlags
+	genericclioptions.IOStreams
+	kclient.Client
+}
+
+// newAccessOptions creates a clusterAccessOptions object
+func newClusterAccessOptions(client kclient.Client, streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) clusterAccessOptions {
+	a := clusterAccessOptions{
+		IOStreams:   streams,
+		ConfigFlags: flags,
+		Client:      client,
+	}
+	return a
+}
+
+// Println appends a newline then prints the given msg using the clusterAccessOptions' IOStreams
+func (c *clusterAccessOptions) Println(msg string) {
+	osdctlutil.StreamPrintln(c.IOStreams, msg)
+}
+
+// Print prints the given msg using the clusterAccessOptions' IOStreams
+func (c *clusterAccessOptions) Print(msg string) {
+	osdctlutil.StreamPrint(c.IOStreams, msg)
+}
+
+// Errorln appends a newline then prints the given error msg using the clusterAccessOptions' IOStreams
+func (c *clusterAccessOptions) Errorln(msg string) {
+	osdctlutil.StreamErrorln(c.IOStreams, msg)
+}
+
+// Readln reads a single line of user input using the clusterAccessOptions' IOStreams. User input is returned with all
+// procceeding and following whitespace trimmed
+func (c *clusterAccessOptions) Readln() (string, error) {
+	in, err := osdctlutil.StreamRead(c.IOStreams, '\n')
+	return strings.TrimSpace(in), err
+}
+
+// Run executes the 'cluster' access subcommand
+func (c *clusterAccessOptions) Run(cmd *cobra.Command, args []string) error {
+	clusterIdentifier := args[0]
+	c.Println(fmt.Sprintf("Retrieving Kubeconfig for cluster '%s'", clusterIdentifier))
+
+	// Connect to ocm
+	conn := osdctlutil.CreateConnection()
+	defer func() {
+		cmdutil.CheckErr(conn.Close())
+	}()
+
+	cluster, err := osdctlutil.GetCluster(conn, clusterIdentifier)
+	if err != nil {
+		return err
+	}
+	c.Println(fmt.Sprintf("Internal Cluster ID: %s", cluster.ID()))
+
+	// Retrieve the kubeconfig secret from the cluster's namespace on hive
+	ns, err := getClusterNamespace(c.Client, cluster.ID())
+	if err != nil {
+		return err
+	}
+	c.Println(fmt.Sprintf("Cluster namespace: %s", ns.Name))
+
+	kubeconfigSecret, err := c.getKubeConfigSecret(ns)
+	if err != nil {
+		return err
+	}
+	c.Println(fmt.Sprintf("Kubeconfig Secret: %s", kubeconfigSecret.Name))
+
+	// If Cluster is PrivateLink - access via jump pod on hive
+	if cluster.AWS().PrivateLink() {
+		c.Println("")
+		c.Println("Cluster is PrivateLink, and is only accessible via a jump pod on Hive")
+		return c.createJumpPodAccess(cluster, kubeconfigSecret)
+	}
+
+	// Otherwise, Cluster is not PrivateLink - save kubeconfig locally
+	c.Println("")
+	c.Println("Cluster is accessible via a local Kubeconfig file")
+	return c.createLocalKubeconfigAccess(cluster, kubeconfigSecret)
+}
+
+// createJumpPodAccess grants access to a cluster by creating a pod for users to exec into
+func (c *clusterAccessOptions) createJumpPodAccess(cluster *clustersmgmtv1.Cluster, kubeconfigSecret corev1.Secret) error {
+	c.Println("Attempting to spin up a pod to use for access")
+
+	pod, err := c.createJumpPod(kubeconfigSecret, cluster.ID())
+	if err != nil {
+		c.Errorln("Failed to create pod")
+		return err
+	}
+
+	c.Println(fmt.Sprintf("Jump pod created. Waiting for it to start"))
+	c.Println("")
+
+	err = c.waitForJumpPod(pod, jumpPodPollInterval, jumpPodPollTimeout)
+	if err != nil {
+		c.Errorln("Timed out waiting for pod to start.")
+		c.Println(fmt.Sprintf("You can check the status of the pod using\n\n    oc describe pods %s -n %s\n", pod.Name, pod.Namespace))
+		c.Println("Once the pod is running:")
+	} else {
+		c.Println("Pod detected as running")
+	}
+	c.Println(fmt.Sprintf("Use \n\n    oc exec -it --as %s -n %s %s -- /bin/bash\n\nto run commands in the pod. All 'oc' commands run within the pod will be executed against the cluster '%s' (this can be verified by running `oc cluster-info` in the pod)", impersonateUser, pod.Namespace, pod.Name, cluster.Name()))
+	return err
+}
+
+// createLocalKubeconfigAccess grants access to a cluster by writing the cluster's kubeconfig file to the local filesystem and (optionally) updating the user's cli environment
+func (c *clusterAccessOptions) createLocalKubeconfigAccess(cluster *clustersmgmtv1.Cluster, kubeconfigSecret corev1.Secret) error {
+	c.Println("Retrieving kubeconfig secret from Hive")
+
+	kubeconfigFilePath := fpath.Join(os.TempDir(), kubeconfigSecret.Name)
+	rawKubeconfig, found := kubeconfigSecret.Data[kubeconfigSecretKey]
+	if !found {
+		// Kubeconfig secret doesn't contain the expected key - write the obtained secret to a temp location so the user can troubleshoot or manually parse
+		c.Errorln(fmt.Sprintf("\nExpected key '%s' not found in Secret", kubeconfigSecretKey))
+		c.Println("Attempting to save Secret locally")
+
+		rawData, err := json.Marshal(kubeconfigSecret)
+		if err != nil {
+			c.Errorln("Failed to marshal secret to raw data")
+			return err
+		}
+
+		err = saveAsLocalFile(rawData, kubeconfigFilePath)
+		if err != nil {
+			c.Errorln("Failed to write Secret to file")
+			return err
+		}
+
+		c.Println(fmt.Sprintf("File has been written to '%s' for manual use", kubeconfigFilePath))
+		return fmt.Errorf("Could not parse cluster's kubeconfig Secret")
+	}
+
+	// Determine if cluster utilizes a Private API
+	listening, listeningOK := cluster.API().GetListening()
+	if !listeningOK {
+		// Do not return if we can't determine the listening status of the apiserver - in both cases (private or non-private), the kubeconfig is needed locally, so we
+		// should pull it anyway, but give clear warning that additional manual action may be required if the kubeconfig fails to work.
+		c.Errorln("\nFailed to determine if the cluster is private.\nIf you're not able to access the cluster, try modifying the resulting kubeconfig according to the SOP: https://github.com/openshift/ops-sop/blob/master/v4/howto/break-glass-kubeadmin.md#for-clusters-with-private-api")
+	} else if listening == clustersmgmtv1.ListeningMethodInternal {
+		// If the cluster has a private API, it must be accessed using a special API url from one of the bastions
+		return c.createPrivateAPIAccess(rawKubeconfig, kubeconfigFilePath)
+	}
+
+	// Write the kubeconfig to the temp filesystem
+	c.Println("Saving kubeconfig")
+	err := saveAsLocalFile(rawKubeconfig, kubeconfigFilePath)
+	if err != nil {
+		c.Errorln("Failed to save kubeconfig")
+		return err
+	}
+
+	c.Println("")
+	c.Println(fmt.Sprintf("Kubeconfig successfully written to '%s'", kubeconfigFilePath))
+	c.Println("")
+
+	c.Print(fmt.Sprintf("Would you like to open a new shell that uses 'KUBECONFIG=%s'? [y/N] ", kubeconfigFilePath))
+	input, err := c.Readln()
+	if err != nil {
+		c.Errorln("Failed to read user input")
+		return err
+	}
+
+	if isAffirmative(input) {
+		err = os.Setenv("KUBECONFIG", kubeconfigFilePath)
+		if err != nil {
+			c.Errorln("Failed to set $KUBECONFIG")
+			return err
+		}
+
+		shell, found := os.LookupEnv("SHELL")
+		if !found {
+			c.Println("$SHELL appears to be unset - defaulting to '/bin/bash'")
+			shell = "/bin/bash"
+		}
+
+		c.Println("")
+		c.Println(fmt.Sprintf("A new shell will be spawned, with $KUBECONFIG set to '%s'.", kubeconfigFilePath))
+		c.Println("")
+		c.Println(fmt.Sprintf("`oc` commands should therefore execute against the cluster '%s' (you can verify this by running `oc cluster-info`)", cluster.Name()))
+		c.Println(fmt.Sprintf("To add this capability to other terminals, run\n\n    export KUBECONFIG=%s\n\nwherever you'd like to execute commands against this cluster", kubeconfigFilePath))
+		c.Println("When you are done, type 'exit' (or use ctl-D) to return to the original terminal")
+
+		// Spawn a new shell
+		cmd := exec.Command(shell)
+		cmd.Stdout = os.Stdout
+		cmd.Stdin = os.Stdin
+		cmd.Stderr = os.Stderr
+		err = cmd.Run()
+		if err != nil {
+			c.Errorln(fmt.Sprintf("Error while running in shell: %v", err))
+		}
+		c.Println(fmt.Sprintf("Finished executing against cluster '%s'", cluster.Name()))
+	} else {
+		c.Println("Shell not updated")
+		c.Println(fmt.Sprintf("Run\n\n    export KUBECONFIG=%s\n\nin the terminal you would like to use for executing commands against '%s'", kubeconfigFilePath, cluster.Name()))
+	}
+
+	return nil
+}
+
+// createPrivateAPIAccess provides the necessary changes to access clusters with Private APIs
+func (c *clusterAccessOptions) createPrivateAPIAccess(rawKubeconfig []byte, kubeconfigFilePath string) error {
+	c.Println("Cluster is private. Updating kubeconfig to execute commands against the rh-api")
+	formattedKubeconfig := clientcmdapiv1.Config{}
+
+	err := yaml.Unmarshal(rawKubeconfig, &formattedKubeconfig)
+	if err != nil {
+		c.Errorln("Failed to unmarshal kubeconfig")
+		return err
+	}
+
+	// Replace the server URL w/ the URL for the RH-api
+	for i := range formattedKubeconfig.Clusters {
+		originalServerURL := formattedKubeconfig.Clusters[i].Cluster.Server
+		formattedKubeconfig.Clusters[i].Cluster.Server = strings.Replace(originalServerURL, "api.", "rh-api.", 1)
+	}
+
+	rawKubeconfig, err = yaml.Marshal(formattedKubeconfig)
+	if err != nil {
+		c.Errorln("Failed to re-marshal kubeconfig")
+		return err
+	}
+
+	// Write the kubeconfig to the temp filesystem
+	c.Println("Saving kubeconfig")
+	err = saveAsLocalFile(rawKubeconfig, kubeconfigFilePath)
+	if err != nil {
+		c.Errorln("Failed to save kubeconfig")
+		return err
+	}
+
+	c.Println("")
+	c.Println(fmt.Sprintf("Kubeconfig successfully written to '%s'", kubeconfigFilePath))
+	c.Println("")
+	c.Println("Next steps are detailed in the Private API SOP: https://github.com/openshift/ops-sop/blob/master/v4/howto/break-glass-kubeadmin.md#for-clusters-with-private-api")
+	c.Println("")
+	c.Println(fmt.Sprintf("    scp %s bastion:.private/", kubeconfigFilePath))
+	c.Println("")
+	c.Println("    ssh bastion")
+	c.Println("")
+	c.Println(fmt.Sprintf("    export KUBECONFIG=$HOME/.private/%s", fpath.Base(kubeconfigFilePath)))
+
+	return nil
+}
+
+// getKubeConfigSecret returns the first secret in the given namespace which contains the "hive.openshift.io/secret-type: kubeconfig" label
+func (c *clusterAccessOptions) getKubeConfigSecret(ns corev1.Namespace) (corev1.Secret, error) {
+	secretList := corev1.SecretList{}
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"hive.openshift.io/secret-type": "kubeconfig"}}
+	selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
+	if err != nil {
+		return corev1.Secret{}, err
+	}
+	err = c.Client.List(context.TODO(), &secretList, &kclient.ListOptions{Namespace: ns.Name, LabelSelector: selector})
+	if err != nil {
+		return corev1.Secret{}, err
+	}
+
+	if len(secretList.Items) == 0 {
+		return corev1.Secret{}, fmt.Errorf("Kubeconfig secret not found in namespace '%s'", ns.Name)
+	}
+
+	// Just return the first item in list
+	// TODO: What do if we have >1 secret?
+	return secretList.Items[0], nil
+}
+
+// saveAsLocalFile writes data as a file on the local filesystem with mode 0600
+func saveAsLocalFile(data []byte, path string) error {
+	return os.WriteFile(path, data, os.FileMode(0600))
+}
+
+// createJumpPod creates a deployment on hive to access a PrivateLink cluster from.
+func (c *clusterAccessOptions) createJumpPod(kubeconfigSecret corev1.Secret, clusterid string) (corev1.Pod, error) {
+	name := fmt.Sprintf("jumphost-%s-%d", time.Now().Format("20060102-150405-"), (time.Now().Nanosecond() / 1000000))
+	ns := kubeconfigSecret.Namespace
+	label := map[string]string{jumpPodLabelKey: clusterid}
+
+	deploy := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    label,
+		},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name: kubeconfigSecretKey,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: kubeconfigSecret.Name,
+						},
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyOnFailure,
+			Containers: []corev1.Container{
+				{
+					Name:    jumpContainerName,
+					Image:   jumpImage,
+					Command: []string{"/bin/sh"},
+					Args:    []string{"-c", fmt.Sprintf("sleep %d", jumpPodLifespan)},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "KUBECONFIG",
+							Value: fmt.Sprintf("/tmp/%s", kubeconfigSecretKey),
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      kubeconfigSecretKey,
+							MountPath: "/tmp",
+						},
+					},
+				},
+			},
+		},
+	}
+	err := c.Client.Create(context.TODO(), &deploy)
+	return deploy, err
+}
+
+// waitForPod polls until the given pod is ready
+func (c *clusterAccessOptions) waitForJumpPod(pod corev1.Pod, interval time.Duration, timeout time.Duration) error {
+	key := types.NamespacedName{
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+	}
+	return wait.PollImmediate(interval, timeout, func() (done bool, err error) {
+		err = c.Client.Get(context.TODO(), key, &pod)
+		if kerr.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
+			return false, err
+		}
+		for _, container := range pod.Status.ContainerStatuses {
+			if container.Name == jumpContainerName && *container.Started {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}

--- a/cmd/cluster/access/access_test.go
+++ b/cmd/cluster/access/access_test.go
@@ -1,0 +1,494 @@
+package access
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	fpath "path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	clientcmdapiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestAccessCmdComplete ensures clusterAccessOptions.Complete allows for only a single cluster to be passed to the 'cluster' subcommand
+func TestAccessCmdComplete(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Args          []string
+		ErrorExpected bool
+	}{
+		{
+			Name:          "Single cluster provided",
+			Args:          []string{"testCluster"},
+			ErrorExpected: false,
+		},
+		{
+			Name:          "No cluster provided",
+			Args:          []string{},
+			ErrorExpected: true,
+		},
+		{
+			Name:          "Multiple clusters provided",
+			Args:          []string{"testCluster", "testCluster2"},
+			ErrorExpected: true,
+		},
+		{
+			Name:          "Invalid cluster provided",
+			Args:          []string{"inv@lid/cluster"},
+			ErrorExpected: true,
+		},
+		{
+			Name:          "Multiple invalid clusters provided",
+			Args:          []string{"inv@lid/cluster1", "inv@lid/cluster2"},
+			ErrorExpected: true,
+		},
+	}
+
+	for _, test := range tests {
+		err := accessCmdComplete(&cobra.Command{}, test.Args)
+		if test.ErrorExpected {
+			if err == nil {
+				t.Fatalf("Test '%s' failed. Expected error, but got none", test.Name)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("Test '%s' failed. Expected no error, but got '%v'", test.Name, err)
+			}
+		}
+	}
+}
+
+func TestVerifyPermissions(t *testing.T) {
+	privUser := impersonateUser
+	unprivUser := "not-backplane-cluster-admin"
+	noUser := ""
+
+	tests := []struct {
+		Name    string
+		Flags   *genericclioptions.ConfigFlags
+		Streams genericclioptions.IOStreams
+		Allowed bool
+	}{
+		{
+			Name: "Impersonate Privileged User",
+			Flags: &genericclioptions.ConfigFlags{
+				Impersonate: &privUser,
+			},
+			Streams: genericclioptions.NewTestIOStreamsDiscard(),
+			Allowed: true,
+		},
+		{
+			Name: "Impersonate Unprivileged User",
+			Flags: &genericclioptions.ConfigFlags{
+				Impersonate: &unprivUser,
+			},
+			Streams: genericclioptions.NewTestIOStreamsDiscard(),
+			Allowed: false,
+		},
+		{
+			Name:  "No Impersonation, default choice",
+			Flags: &genericclioptions.ConfigFlags{},
+			Streams: genericclioptions.IOStreams{
+				Out:    genericclioptions.NewTestIOStreamsDiscard().Out,
+				ErrOut: genericclioptions.NewTestIOStreamsDiscard().ErrOut,
+				In:     strings.NewReader("\n"),
+			},
+			Allowed: false,
+		},
+		{
+			Name:  "No Impersonation, explicit deny",
+			Flags: &genericclioptions.ConfigFlags{},
+			Streams: genericclioptions.IOStreams{
+				Out:    genericclioptions.NewTestIOStreamsDiscard().Out,
+				ErrOut: genericclioptions.NewTestIOStreamsDiscard().ErrOut,
+				In:     strings.NewReader("n\n"),
+			},
+			Allowed: false,
+		},
+		{
+			Name:  "No Impersonation, nonsense input",
+			Flags: &genericclioptions.ConfigFlags{},
+			Streams: genericclioptions.IOStreams{
+				Out:    genericclioptions.NewTestIOStreamsDiscard().Out,
+				ErrOut: genericclioptions.NewTestIOStreamsDiscard().ErrOut,
+				In:     strings.NewReader("%\n"),
+			},
+			Allowed: false,
+		},
+		{
+			Name: "No Impersonation, explicit accept",
+			Flags: &genericclioptions.ConfigFlags{
+				// Must initialize Impersonate field for acceptance test - else segfault :)
+				Impersonate: &noUser,
+			},
+			Streams: genericclioptions.IOStreams{
+				Out:    genericclioptions.NewTestIOStreamsDiscard().Out,
+				ErrOut: genericclioptions.NewTestIOStreamsDiscard().ErrOut,
+				In:     strings.NewReader("y\n"),
+			},
+			Allowed: true,
+		},
+	}
+	for _, test := range tests {
+		fmt.Printf("Testing '%s'\n", test.Name)
+		err := verifyPermissions(test.Streams, test.Flags)
+		if test.Allowed {
+			if err != nil {
+				t.Errorf("Failed '%s': expected permissions to be sufficient, but found that they were not. Err: %v", test.Name, err)
+			}
+		} else {
+			if err == nil {
+				t.Errorf("Failed '%s': expected permissions to be insufficient, but found that they were not. Err: %v", test.Name, err)
+			}
+		}
+	}
+}
+
+// TestClusterAccessOptions_createLocalKubeconfigAccess tests the clusterAccessOptions' createLocalKubeconfigAccess function
+func TestClusterAccessOptions_createLocalKubeconfigAccess(t *testing.T) {
+	ns := "uhc-production-testfakecluster1234"
+	validKubeconfigKey := "kubeconfig"
+
+	type secretCfg struct {
+		Name string
+		Key  string
+	}
+
+	tests := []struct {
+		Name          string
+		Secret        secretCfg
+		UpdateEnvResp string
+		PrivateAPI    bool
+		ExpectErr     bool
+	}{
+		{
+			Name: "Valid Secret, update env",
+			Secret: secretCfg{
+				Name: "valid-secret",
+				Key:  validKubeconfigKey,
+			},
+			UpdateEnvResp: "y",
+			PrivateAPI:    false,
+			ExpectErr:     false,
+		}, {
+			Name: "Valid secret, don't update env",
+			Secret: secretCfg{
+				Name: "valid-secret",
+				Key:  validKubeconfigKey,
+			},
+			UpdateEnvResp: "n",
+			PrivateAPI:    false,
+			ExpectErr:     false,
+		},
+		{
+			Name: "Invalid Secret Key",
+			Secret: secretCfg{
+				Name: "broken-secret",
+				Key:  "broken-kubeconfig",
+			},
+			UpdateEnvResp: "",
+			PrivateAPI:    false,
+			ExpectErr:     true,
+		},
+		{
+			Name: "Private API",
+			Secret: secretCfg{
+				Name: "valid-secret",
+				Key:  validKubeconfigKey,
+			},
+			UpdateEnvResp: "y",
+			PrivateAPI:    true,
+			ExpectErr:     false,
+		},
+	}
+
+	for _, test := range tests {
+		// Run test as anonymous function in order to cleanup saved files between runs
+		func() {
+			fmt.Printf("Testing '%s'\n", test.Name)
+
+			// Setup Environment
+			updateEnvResponse := fmt.Sprintf("%s\n", test.UpdateEnvResp)
+			streams := genericclioptions.IOStreams{In: strings.NewReader(updateEnvResponse), Out: os.Stdout, ErrOut: os.Stderr}
+			flags := genericclioptions.ConfigFlags{}
+			client := fake.NewFakeClientWithScheme(runtime.NewScheme())
+			access := newClusterAccessOptions(client, streams, &flags)
+
+			// Generate test objects
+			cluster := generateClusterObjectForTesting("test-cluster", "test-cluster-id", false, test.PrivateAPI)
+			serverURL := "https://api.test-cluster.fakedomain.devshift.org:6443"
+			secretName := fmt.Sprintf("test-osdctl-access-cluster-%s-%d-secret-%s", time.Now().Format("20060102-150405-"), (time.Now().Nanosecond() / 1000000), test.Secret.Name)
+			secret, expectedKubeconfig := generateKubeconfigSecretObjectForTesting(secretName, ns, test.Secret.Key, serverURL)
+			defer func(secretName string) {
+				kubeconfigFilePath := fpath.Join(os.TempDir(), secretName)
+				err := os.Remove(kubeconfigFilePath)
+				if err != nil {
+					t.Fatalf("Failed to cleanup file '%s': %v", kubeconfigFilePath, err)
+				}
+			}(secretName)
+
+			// Run test
+			_, found := os.LookupEnv("KUBECONFIG")
+			if found && isAffirmative(test.UpdateEnvResp) {
+				t.Skipf("Skipping '%s': test would overwrite currently set environment variable '$KUBECONFIG'. Unset $KUBECONFIG to run this test in the future.", test.Name)
+			}
+			err := access.createLocalKubeconfigAccess(&cluster, secret)
+			defer func() {
+				if isAffirmative(test.UpdateEnvResp) {
+					err = os.Unsetenv("KUBECONFIG")
+					if err != nil {
+						t.Errorf("Failed '%s': could not unset environment variable $KUBECONFIG: %v", test.Name, err)
+					}
+				}
+			}()
+
+			// Validate results
+			// Verify err
+			if test.ExpectErr {
+				if err == nil {
+					t.Errorf("Failed '%s': expected to receive err, but got %v. ", test.Name, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Failed '%s': did not expect to recieve err, but got %v. ", test.Name, err)
+				}
+			}
+
+			// Verify local file
+			expectedFilePath := fpath.Join(os.TempDir(), secret.Name)
+			metadata, err := os.Stat(expectedFilePath)
+			if os.IsNotExist(err) {
+				t.Errorf("Failed '%s': local file not written to expected location: %s", test.Name, expectedFilePath)
+			} else if err != nil {
+				t.Errorf("Failed '%s': could not retrieve local file: %v", test.Name, err)
+			}
+
+			if metadata.Mode() != os.FileMode(0600) {
+				t.Errorf("Failed '%s': local file not written with expected mode 0600", test.Name)
+			}
+
+			file, err := os.ReadFile(expectedFilePath)
+			if err != nil {
+				t.Errorf("Failed '%s': unable to open local file: %v", test.Name, err)
+			}
+			if test.ExpectErr {
+				// Since we expect the createLocalKubeconfigAccess func to throw an error in this test, we also expect the local file to be the raw secret
+				localSecret := corev1.Secret{}
+				err = json.Unmarshal(file, &localSecret)
+				if err != nil {
+					t.Errorf("Failed '%s': could not unmarshal local file to Secret: %v", test.Name, err)
+				}
+				if !reflect.DeepEqual(secret, localSecret) {
+					t.Errorf("Failed '%s': Secrets are not equivalent. Original Secret: %v\n\nWritten Secret: %v", test.Name, secret, localSecret)
+				}
+			} else {
+				// Since we don't expect the createLocalKubeconfigAccess func to throw an error in this test, we also expect the local file to be a valid kubeconfig
+				localKubeconfig := clientcmdapiv1.Config{}
+				err = yaml.Unmarshal(file, &localKubeconfig)
+				if err != nil {
+					t.Errorf("Failed '%s': could not unmarshal local file to Config: %v", test.Name, err)
+				}
+				if test.PrivateAPI {
+					// Update expected kubeconfig with the private API URL
+					expectedServerURL := "https://rh-api.test-cluster.fakedomain.devshift.org:6443"
+					expectedKubeconfig.Clusters[0].Cluster.Server = expectedServerURL
+					// After updating the kubeconfig, we have to re- Marshal & Unmarshal the yaml for the following DeepEqual call to succeed
+					rawNestedKubeconfig, err := yaml.Marshal(expectedKubeconfig)
+					if err != nil {
+						t.Errorf("Failed '%s': could not marshal kubeconfig after updating for private API: %v", test.Name, err)
+					}
+					err = yaml.Unmarshal(rawNestedKubeconfig, &expectedKubeconfig)
+					if err != nil {
+						t.Errorf("Failed '%s': could not unmarshal kubeconfig after updating for private API: %v", test.Name, err)
+					}
+				}
+
+				if !reflect.DeepEqual(expectedKubeconfig, localKubeconfig) {
+					t.Errorf("Failed '%s': Kubeconfigs are not equivalent.\nOriginal kubeconfig: %v\n\nWritten kubeconfig:%v", test.Name, expectedKubeconfig, localKubeconfig)
+				}
+			}
+
+			// Verify environment
+			// Environment should never be updated for clusters with a PrivateAPI, since they must be accessed via bastion
+			kubeconfigEnvVar, found := os.LookupEnv("KUBECONFIG")
+			if isAffirmative(test.UpdateEnvResp) && !test.PrivateAPI {
+				if !found {
+					t.Errorf("Failed '%s': KUBECONFIG environment variable not set, but expected to be", test.Name)
+				}
+				if kubeconfigEnvVar != expectedFilePath {
+					t.Errorf("Failed '%s': KUBECONFIG environment variable not set to expected value. Found: %s, expected: %s", test.Name, kubeconfigEnvVar, expectedFilePath)
+				}
+			} else {
+				if found {
+					t.Errorf("Failed '%s': KUBECONFIG environment variable set, expected it to be unset", test.Name)
+				}
+			}
+		}()
+	}
+}
+
+func TestClusterAccessOptions_createJumpPod(t *testing.T) {
+	tests := []struct {
+		Name string
+	}{
+		{
+			Name: "createJumpPod",
+		},
+	}
+
+	for _, test := range tests {
+		fmt.Printf("Testing '%s'\n", test.Name)
+
+		// Setup Environment
+		scheme := runtime.NewScheme()
+		err := corev1.AddToScheme(scheme)
+		if err != nil {
+			t.Fatalf("Failed to add corev1 to scheme: %v", err)
+		}
+		client := fake.NewFakeClientWithScheme(scheme)
+
+		flags := genericclioptions.ConfigFlags{}
+		streams := genericclioptions.IOStreams{In: genericclioptions.NewTestIOStreamsDiscard().In, Out: os.Stdout, ErrOut: os.Stderr}
+		access := newClusterAccessOptions(client, streams, &flags)
+
+		// Generate test objects
+		serverURL := "https://api.test-cluster.fakedomain.devshift.org:6443"
+		secretName := fmt.Sprintf("test-osdctl-access-cluster-%s-%d-secret-%s", time.Now().Format("20060102-150405-"), (time.Now().Nanosecond() / 1000000), "test-createJumpPod")
+		secretNS := "uhc-production-testclusterns"
+		secret, _ := generateKubeconfigSecretObjectForTesting(secretName, secretNS, "kubeconfig", serverURL)
+
+		// Run test
+		pod, err := access.createJumpPod(secret, "fake-cluster-uuid-123456")
+		if err != nil {
+			t.Errorf("Failed %s: error while creating pod: %v", test.Name, err)
+		}
+
+		// Verify pod was built correctly
+		// Verify volume
+		if len(pod.Spec.Volumes) != 1 {
+			t.Errorf("Unexpected number of volumes: expected 1, got %d", len(pod.Spec.Volumes))
+		} else if pod.Spec.Volumes[0].VolumeSource.Secret.SecretName != secretName {
+			t.Errorf("Pod's volume does not reference the kubeconfig secret")
+		}
+
+		// Verify container - confirm that the mount path and the environment variables align so users needn't set anything manually for the pod to function
+		if len(pod.Spec.Containers) != 1 {
+			t.Errorf("Unexpected number of containers in pod: expected 1, got %d", len(pod.Spec.Containers))
+		}
+
+		container := pod.Spec.Containers[0]
+		expectedMountPath := "/tmp"
+		if len(container.VolumeMounts) != 1 {
+			t.Errorf("Unexpected number of volumeMounts: expected 1, got %d", len(container.VolumeMounts))
+		} else if container.VolumeMounts[0].Name != kubeconfigSecretKey {
+			t.Errorf("Unexpected mount name for kubeconfig secret: expected '%s', got '%s'", kubeconfigSecretKey, container.VolumeMounts[0].Name)
+		} else if container.VolumeMounts[0].MountPath != expectedMountPath {
+			t.Errorf("Unexpected mount path for kubeconfig secret: expected '%s', got '%s'", expectedMountPath, container.VolumeMounts[0].MountPath)
+		}
+
+		expectedEnvValue := fmt.Sprintf("/tmp/%s", kubeconfigSecretKey)
+		if len(container.Env) != 1 {
+			t.Errorf("Unexpected number of environment variables: expected 1, got %d", len(container.Env))
+		} else if container.Env[0].Name != "KUBECONFIG" {
+			t.Errorf("Unexpected environment variable set: expected 'KUBECONFIG', got '%s'", container.Env[0].Name)
+		} else if container.Env[0].Value != expectedEnvValue {
+			t.Errorf("Unexpected environment variable set: expected 'KUBECONFIG', got '%s'", container.Env[0].Name)
+		}
+	}
+}
+
+// TestUpdateEnv ensures the updateEnv function is operating correctly
+func TestUpdateEnv(t *testing.T) {
+	tests := []struct {
+		Name   string
+		Input  string
+		Expect bool
+	}{
+		{
+			Name:   "Input Y",
+			Input:  "Y",
+			Expect: true,
+		},
+		{
+			Name:   "Input y",
+			Input:  "y",
+			Expect: true,
+		},
+		{
+			Name:   "Input nothing",
+			Input:  "",
+			Expect: false,
+		},
+		{
+			Name:   "Input garbage",
+			Input:  "%23dslkjd",
+			Expect: false,
+		},
+	}
+	for _, test := range tests {
+		fmt.Printf("Testing '%s'\n", test.Name)
+		result := isAffirmative(test.Input)
+		if result != test.Expect {
+			t.Errorf("Failed '%s': expected %t, got %t", test.Name, test.Expect, result)
+		}
+	}
+}
+
+// generateClusterObjectForTesting creates a non-functional cluster object solely for testing purposes
+func generateClusterObjectForTesting(name string, id string, privateLink bool, private bool) clustersmgmtv1.Cluster {
+	var listen clustersmgmtv1.ListeningMethod
+	if private {
+		listen = clustersmgmtv1.ListeningMethodInternal
+	} else {
+		listen = clustersmgmtv1.ListeningMethodExternal
+	}
+	cluster, err := clustersmgmtv1.NewCluster().
+		Name(name).
+		ID(id).
+		AWS(clustersmgmtv1.NewAWS().PrivateLink(privateLink)).
+		API(clustersmgmtv1.NewClusterAPI().Listening(listen)).
+		Build()
+
+	if err != nil {
+		panic(fmt.Sprintf("Failed to build cluster: %v", err))
+	}
+	return *cluster
+}
+
+// generateKubeconfigSecretObjectForTesting creates a Secret containing a kubeconfig file for testing purposes
+func generateKubeconfigSecretObjectForTesting(name, namespace, key, serverURL string) (corev1.Secret, clientcmdapiv1.Config) {
+	kubeconfig := clientcmdapiv1.Config{
+		Clusters: []clientcmdapiv1.NamedCluster{
+			{
+				Cluster: clientcmdapiv1.Cluster{
+					Server: serverURL,
+				},
+			},
+		},
+	}
+	rawKubeconfig, err := json.Marshal(kubeconfig)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to marshal kubeconfig: %v", err))
+	}
+
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{key: rawKubeconfig},
+	}
+	return secret, kubeconfig
+}

--- a/cmd/cluster/access/cleanup.go
+++ b/cmd/cluster/access/cleanup.go
@@ -1,0 +1,221 @@
+package access
+
+import (
+	"context"
+	"fmt"
+	"os"
+	fpath "path/filepath"
+	"strings"
+
+	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/osdctl/pkg/k8s"
+	osdctlutil "github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newCmdCleanup(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	cleanupCmd := &cobra.Command{
+		Use:               "cleanup <cluster identifier>",
+		Short:             "Drop emergency access to a cluster",
+		Long:              "Relinquish emergency access from the given cluster. If the cluster is PrivateLink, it deletes\nall jump pods in the cluster's namespace (because of this, you must be logged into the hive shard\nwhen dropping access for PrivateLink clusters). For non-PrivateLink clusters, the $KUBECONFIG\nenvironment variable is unset, if applicable.",
+		Args:              cobra.ExactArgs(1),
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(cleanupCmdComplete(cmd, args))
+			cmdutil.CheckErr(verifyPermissions(streams, flags))
+			client := k8s.NewClient(flags)
+			cleanupAccess := newCleanupAccessOptions(client, streams, flags)
+			cmdutil.CheckErr(cleanupAccess.Run(cmd, args))
+		},
+	}
+	return cleanupCmd
+}
+
+func cleanupCmdComplete(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return cmdutil.UsageErrorf(cmd, "Exactly one cluster identifier was expected")
+	}
+	return osdctlutil.IsValidClusterKey(args[0])
+}
+
+// cleanupAccessOptions contains the objects and information required to drop access to a cluster
+type cleanupAccessOptions struct {
+	*genericclioptions.ConfigFlags
+	genericclioptions.IOStreams
+	kclient.Client
+}
+
+// newCleanupAccessOptions creates a cleanupAccessOptions object
+func newCleanupAccessOptions(client kclient.Client, streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) cleanupAccessOptions {
+	c := cleanupAccessOptions{
+		IOStreams:   streams,
+		ConfigFlags: flags,
+		Client:      client,
+	}
+	return c
+}
+
+// Println appends a newline then prints the given msg using the cleanupAccessOptions' IOStreams
+func (c *cleanupAccessOptions) Println(msg string) {
+	osdctlutil.StreamPrintln(c.IOStreams, msg)
+}
+
+// Println prints the given msg using the cleanupAccessOptions' IOStreams
+func (c *cleanupAccessOptions) Print(msg string) {
+	osdctlutil.StreamPrint(c.IOStreams, msg)
+}
+
+// Println appends a newline then prints the given error msg using the cleanupAccessOptions' IOStreams
+func (c *cleanupAccessOptions) Errorln(msg string) {
+	osdctlutil.StreamErrorln(c.IOStreams, msg)
+}
+
+// Readln reads a single line of user input using the cleanupAccessOptions' IOStreams. User input is returned with all
+// proceeding and following whitespace trimmed
+func (c *cleanupAccessOptions) Readln() (string, error) {
+	in, err := osdctlutil.StreamRead(c.IOStreams, '\n')
+	return strings.TrimSpace(in), err
+}
+
+// Run executes the 'cleanup' access subcommand
+func (c *cleanupAccessOptions) Run(cmd *cobra.Command, args []string) error {
+	clusteridentifier := args[0]
+
+	conn := osdctlutil.CreateConnection()
+	defer func() {
+		cmdutil.CheckErr(conn.Close())
+	}()
+
+	cluster, err := osdctlutil.GetCluster(conn, clusteridentifier)
+	if err != nil {
+		return err
+	}
+	c.Println(fmt.Sprintf("Dropping access to cluster '%s'", cluster.Name()))
+	if cluster.AWS().PrivateLink() {
+		return c.dropPrivateLinkAccess(cluster)
+	} else {
+		return c.dropLocalAccess(cluster)
+	}
+}
+
+// dropPrivateLinkAccess removes access to a PrivateLink cluster.
+// This primarily consists of deleting any jump pods found to be running against the cluster in hive.
+func (c *cleanupAccessOptions) dropPrivateLinkAccess(cluster *clustersmgmtv1.Cluster) error {
+	c.Println("Cluster is PrivateLink - removing jump pods in the cluster's namespace.")
+	ns, err := getClusterNamespace(c.Client, cluster.ID())
+	if err != nil {
+		c.Errorln("Failed to retrieve cluster namespace")
+		return err
+	}
+
+	// Generate label selector to only target pods w/ matching jump pod label
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{jumpPodLabelKey: cluster.ID()}}
+	selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
+	if err != nil {
+		c.Errorln("Failed to convert labelSelector to selector")
+		return err
+	}
+
+	listOpts := kclient.ListOptions{Namespace: ns.Name, LabelSelector: selector}
+	pods := corev1.PodList{}
+	err = c.Client.List(context.TODO(), &pods, &listOpts)
+	if err != nil {
+		c.Errorln(fmt.Sprintf("Failed to list pods in cluster namespace '%s'", ns.Name))
+		return err
+	}
+
+	numPods := len(pods.Items)
+	if numPods == 0 {
+		c.Println(fmt.Sprintf("No jump pods found running in namespace '%s'.", ns.Name))
+		c.Println("Access has been dropped.")
+		return nil
+	}
+
+	c.Println("")
+	c.Println(fmt.Sprintf("This will delete %d pods in the namespace '%s'", numPods, ns.Name))
+	for _, pod := range pods.Items {
+		c.Println(fmt.Sprintf("- %s", pod.Name))
+	}
+	c.Println("")
+	c.Print("Continue? [y/N] ")
+	input, err := c.Readln()
+	if err != nil {
+		c.Errorln("Failed to read user input")
+		return err
+	}
+	if isAffirmative(input) {
+		pod := corev1.Pod{}
+		err = c.Client.DeleteAllOf(context.TODO(), &pod, &kclient.DeleteAllOfOptions{ListOptions: listOpts})
+		if err != nil {
+			c.Errorln("Failed to delete pod(s)")
+			return err
+		}
+
+		c.Println(fmt.Sprintf("Waiting for %d pod(s) to terminate", numPods))
+		err = wait.PollImmediate(jumpPodPollInterval, jumpPodPollTimeout, func() (done bool, err error) {
+			// For some reason, we have to recreate the podList after deleting the pods, otherwise the listOpts don't filter properly,
+			// and we end up waiting for irrelevant pods. I've tried reproducing this bug in other places, but I haven't been able to
+			// figure it out. If someone does, please fix it.
+			pods := corev1.PodList{}
+			err = c.Client.List(context.TODO(), &pods, &listOpts)
+			if err != nil || len(pods.Items) != 0 {
+				return false, err
+			}
+			return true, nil
+		})
+		if err != nil {
+			c.Errorln("Error while waiting for pods to terminate")
+			return err
+		}
+		c.Println("Access has been dropped.")
+	} else {
+		c.Println("Access has not been dropped.")
+	}
+	return nil
+}
+
+// dropLocalAccess removes access to a non-PrivateLink cluster.
+// Basically it just unsets KUBECONFIG if it appears to be set to the given cluster, since we can't make assumptions
+// around local files.
+func (c *cleanupAccessOptions) dropLocalAccess(cluster *clustersmgmtv1.Cluster) error {
+	c.Println("Unsetting $KUBECONFIG for cluster")
+	kubeconfigPath, found := os.LookupEnv("KUBECONFIG")
+	if !found {
+		c.Errorln("'KUBECONFIG' unset. Access appears to have already been dropped.")
+		return nil
+	}
+
+	kubeconfigFileName := fpath.Base(kubeconfigPath)
+	if !strings.Contains(kubeconfigFileName, cluster.Name()) {
+		c.Errorln(fmt.Sprintf("'KUBECONFIG' set to '%s', which does not seem to be the kubeconfig for '%s'. Access assumed to have already been dropped.", kubeconfigFileName, cluster.Name()))
+		c.Errorln("(If you think this is a mistake, you can still manually drop access by running `unset KUBECONFIG` in the affected terminals)")
+		return nil
+	}
+
+	c.Print(fmt.Sprintf("$KUBECONFIG set to '%s'. Unset it? [y/N]", kubeconfigPath))
+	input, err := c.Readln()
+	if err != nil {
+		c.Errorln("Failed to read user input")
+		return err
+	}
+
+	if isAffirmative(input) {
+		c.Println("Unsetting $KUBECONFIG")
+		err = os.Unsetenv("KUBECONFIG")
+		if err != nil {
+			c.Errorln("Failed to unset $KUBECONFIG")
+			return err
+		}
+		c.Println("Successfully unset $KUBECONFIG.")
+	}
+
+	c.Println("Access has been dropped.")
+	return nil
+}

--- a/cmd/cluster/access/cleanup_test.go
+++ b/cmd/cluster/access/cleanup_test.go
@@ -1,0 +1,134 @@
+package access
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	osdctlutil "github.com/openshift/osdctl/pkg/utils"
+)
+
+func TestCleanupAccessOptions_dropPrivateLinkAccess(t *testing.T) {
+	const (
+		clusterid = "fake-cluster-uuid-12345"
+	)
+
+	tests := []struct {
+		Name              string
+		Pods              []metav1.ObjectMeta
+		ExpectedPodsAfter []string
+	}{
+		{
+			Name: "Single Jump Pod",
+			Pods: []metav1.ObjectMeta{
+				{
+					Name:   "jump",
+					Labels: map[string]string{jumpPodLabelKey: clusterid},
+				},
+			},
+			ExpectedPodsAfter: []string{},
+		},
+		{
+			Name:              "No pods",
+			Pods:              []metav1.ObjectMeta{},
+			ExpectedPodsAfter: []string{},
+		},
+		{
+			Name: "Mixed use pods",
+			Pods: []metav1.ObjectMeta{
+				{
+					Name:        "jump",
+					Labels:      map[string]string{jumpPodLabelKey: clusterid},
+					Annotations: map[string]string{"test-annotation": "test-annotation"},
+				},
+				{
+					Name:   "provision",
+					Labels: map[string]string{"a-provisioning-pod-label": "testing"},
+				},
+			},
+			ExpectedPodsAfter: []string{"provision"},
+		},
+		{
+			Name: "Multiple jump pods",
+			Pods: []metav1.ObjectMeta{
+				{
+					Name:   "jump1",
+					Labels: map[string]string{jumpPodLabelKey: clusterid},
+				},
+				{
+					Name:   "jump2",
+					Labels: map[string]string{jumpPodLabelKey: clusterid},
+				},
+			},
+			ExpectedPodsAfter: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		fmt.Printf("Testing '%s'\n", test.Name)
+
+		// Generate test objects
+		objs := []runtime.Object{}
+		ns := corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   fmt.Sprintf("uhc-staging-%s", clusterid),
+				Labels: map[string]string{"api.openshift.com/id": clusterid},
+			},
+		}
+		objs = append(objs, &ns)
+
+		for _, objMeta := range test.Pods {
+			pod := corev1.Pod{
+				ObjectMeta: objMeta,
+			}
+			pod.Namespace = ns.Name
+			objs = append(objs, &pod)
+		}
+
+		// Setup Environment
+		scheme := runtime.NewScheme()
+		err := corev1.AddToScheme(scheme)
+		if err != nil {
+			t.Fatalf("Failed '%s': to add corev1 to scheme: %v", test.Name, err)
+		}
+		client := fake.NewFakeClientWithScheme(scheme, objs...)
+
+		streams := genericclioptions.IOStreams{In: strings.NewReader("y\n"), Out: os.Stdout, ErrOut: os.Stderr}
+		flags := genericclioptions.ConfigFlags{}
+		cleanupAccess := newCleanupAccessOptions(client, streams, &flags)
+
+		cluster := generateClusterObjectForTesting("fake-cluster", clusterid, true, false)
+
+		// Run test
+		err = cleanupAccess.dropPrivateLinkAccess(&cluster)
+
+		// Verify results
+		if err != nil {
+			t.Fatalf("Failed '%s': unexpected error encountered: %v", test.Name, err)
+		}
+
+		// Verify only expected pods remain
+		podsAfter := corev1.PodList{}
+		err = cleanupAccess.Client.List(context.TODO(), &podsAfter)
+		if err != nil {
+			t.Fatalf("Failed '%s': error while listing pods after testing: %v", test.Name, err)
+		}
+
+		if len(podsAfter.Items) != len(test.ExpectedPodsAfter) {
+			t.Errorf("Failed '%s': unexpected number of pods remain after test: expected %d, got %d", test.Name, len(test.ExpectedPodsAfter), len(podsAfter.Items))
+		}
+		for _, pod := range podsAfter.Items {
+			if !osdctlutil.Contains(test.ExpectedPodsAfter, pod.Name) {
+				t.Errorf("Failed '%s': unexpected pod remains after test: %s", test.Name, pod.Name)
+			}
+		}
+	}
+}

--- a/cmd/cluster/access/common.go
+++ b/cmd/cluster/access/common.go
@@ -1,0 +1,39 @@
+package access
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	hiveNSLabelKey = "api.openshift.com/id"
+)
+
+// isAffirmative returns true if the provided input indicates user agreement ("y" or "Y")
+func isAffirmative(input string) bool {
+	return input == "y" || input == "Y"
+}
+
+// getClusterNamespace returns the hive namespace for a cluster given it's internal ID
+func getClusterNamespace(client kclient.Client, clusterid string) (corev1.Namespace, error) {
+	nsList := corev1.NamespaceList{}
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{hiveNSLabelKey: clusterid}}
+	selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
+	if err != nil {
+		return corev1.Namespace{}, err
+	}
+
+	err = client.List(context.TODO(), &nsList, &kclient.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return corev1.Namespace{}, err
+	}
+	if len(nsList.Items) != 1 {
+		return corev1.Namespace{}, fmt.Errorf("expected list operation to return exactly 1 namespace, got %d", len(nsList.Items))
+	}
+
+	return nsList.Items[0], nil
+}

--- a/cmd/cluster/access/common_test.go
+++ b/cmd/cluster/access/common_test.go
@@ -1,0 +1,170 @@
+package access
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestIsAffirmative ensures the isAffirmative() function is operating as expected
+func TestIsAffirmative(t *testing.T) {
+	tests := []struct {
+		Name           string
+		Input          string
+		ExpectedResult bool
+	}{
+		{
+			Name:           "Y",
+			Input:          "Y",
+			ExpectedResult: true,
+		},
+		{
+			Name:           "y",
+			Input:          "y",
+			ExpectedResult: true,
+		},
+		{
+			Name:           "<blank>",
+			Input:          "",
+			ExpectedResult: false,
+		},
+		{
+			Name:           "n",
+			Input:          "n",
+			ExpectedResult: false,
+		},
+		{
+			Name:           "Garbage",
+			Input:          "lj32423%#36",
+			ExpectedResult: false,
+		},
+	}
+	for _, test := range tests {
+		fmt.Printf("Testing '%s'\n", test.Name)
+
+		// Run test
+		result := isAffirmative(test.Input)
+
+		// Verify results
+		if test.ExpectedResult != result {
+			t.Errorf("Failed '%s': expected result to be '%t', got '%t'", test.Name, test.ExpectedResult, result)
+		}
+	}
+}
+
+// TestGetClusterNamespaces tests that getClusterNamespaces() retrieves the expected ns from hive
+func TestGetClusterNamespaces(t *testing.T) {
+	validClusterid := "fakecluster-123456"
+	tests := []struct {
+		Name              string
+		Clusterid         string
+		Namespaces        []metav1.ObjectMeta
+		ExpectErr         bool
+		ExpectedNamespace string
+	}{
+		{
+			Name:      "Single valid namespace",
+			Clusterid: validClusterid,
+			Namespaces: []metav1.ObjectMeta{
+				{
+					Name:   "fake-namespace",
+					Labels: map[string]string{hiveNSLabelKey: validClusterid},
+				},
+			},
+			ExpectErr:         false,
+			ExpectedNamespace: "fake-namespace",
+		},
+		{
+			Name:       "No namespaces",
+			Clusterid:  validClusterid,
+			Namespaces: []metav1.ObjectMeta{},
+			ExpectErr:  true,
+		},
+		{
+			Name:      "No valid namespaces",
+			Clusterid: validClusterid,
+			Namespaces: []metav1.ObjectMeta{
+				{
+					Name:   "fake-namespace",
+					Labels: map[string]string{hiveNSLabelKey: "invalid-cluster-id"},
+				},
+			},
+			ExpectErr: true,
+		},
+		{
+			Name:      "Multiple valid namespaces",
+			Clusterid: validClusterid,
+			Namespaces: []metav1.ObjectMeta{
+				{
+					Name:   "fake-namespace1",
+					Labels: map[string]string{hiveNSLabelKey: validClusterid},
+				},
+				{
+					Name:   "fake-namespace2",
+					Labels: map[string]string{hiveNSLabelKey: validClusterid},
+				},
+			},
+			ExpectErr: true,
+		},
+		{
+			Name:      "Multiple namespaces, 1 valid",
+			Clusterid: validClusterid,
+			Namespaces: []metav1.ObjectMeta{
+				{
+					Name:   "valid-namespace",
+					Labels: map[string]string{hiveNSLabelKey: validClusterid},
+				},
+				{
+					Name:   "invalid-namespace1",
+					Labels: map[string]string{hiveNSLabelKey: "invalid-cluster-id"},
+				},
+				{
+					Name:   "invalid-namespace2",
+					Labels: map[string]string{hiveNSLabelKey: "another-invalid-cluster-id"},
+				},
+			},
+			ExpectErr:         false,
+			ExpectedNamespace: "valid-namespace",
+		},
+	}
+	for _, test := range tests {
+		fmt.Printf("Testing '%s'\n", test.Name)
+		// Setup environment
+		objs := []runtime.Object{}
+		for _, nsMeta := range test.Namespaces {
+			ns := corev1.Namespace{
+				ObjectMeta: nsMeta,
+			}
+			objs = append(objs, &ns)
+		}
+
+		scheme := runtime.NewScheme()
+		err := corev1.AddToScheme(scheme)
+		if err != nil {
+			t.Fatalf("Failed '%s': could not add corev1 to scheme: %v", test.Name, err)
+		}
+		client := fake.NewFakeClientWithScheme(scheme, objs...)
+
+		// Run test
+		ns, err := getClusterNamespace(client, test.Clusterid)
+
+		// Verify results
+		if test.ExpectErr {
+			if err == nil {
+				t.Errorf("Failed '%s': expected error, got none.", test.Name)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Failed '%s': unexpected error encountered when running test: %v", test.Name, err)
+			}
+		}
+
+		if ns.Name != test.ExpectedNamespace {
+			t.Errorf("Failed '%s': incorrect Namespace returned. Expected '%s', got '%s'", test.Name, test.ExpectedNamespace, ns.Name)
+		}
+	}
+}

--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"fmt"
 
+	"github.com/openshift/osdctl/cmd/cluster/access"
 	"github.com/openshift/osdctl/cmd/cluster/support"
 	"github.com/openshift/osdctl/internal/utils/globalflags"
 	k8spkg "github.com/openshift/osdctl/pkg/k8s"
@@ -27,6 +28,7 @@ func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions
 	clusterCmd.AddCommand(support.NewCmdSupport(streams, flags, client, globalOpts))
 	clusterCmd.AddCommand(newCmdContext(streams, flags, globalOpts))
 	clusterCmd.AddCommand(newCmdTransferOwner(streams, flags, globalOpts))
+	clusterCmd.AddCommand(access.NewCmdAccess(streams, flags))
 
 	return clusterCmd
 }

--- a/docs/command/osdctl_cluster_break-glass.md
+++ b/docs/command/osdctl_cluster_break-glass.md
@@ -1,9 +1,10 @@
-## osdctl cluster
+## osdctl access
 
-Provides vitals of an AWS cluster
+Obtain emergency credentials to access the given cluster
+
 
 ```
-osdctl cluster [flags]
+osdctl cluster break-glass <cluster identifier> [flags]
 ```
 
 ### Options
@@ -33,6 +34,5 @@ osdctl cluster [flags]
 
 ### SEE ALSO
 
-* [osdctl](osdctl.md)	 - OSD CLI
-* [osdctl cluster health](osdctl_cluster_health.md)	 - Describes health of cluster nodes and provides other cluster vitals.
-* [osdctl cluster break-glass](osdctl_cluster_break-glass.md)    - Emergency access to a cluster
+* [osdctl cluster](osdctl_cluster.md)	 - Provides vitals of an AWS cluster
+* [osdctl cluster break-glass cleanup](osdctl_cluster_break-glass_cleanup.md)    - Drop emergency access to a cluster

--- a/docs/command/osdctl_cluster_break-glass_cleanup.md
+++ b/docs/command/osdctl_cluster_break-glass_cleanup.md
@@ -1,9 +1,9 @@
-## osdctl cluster
+## osdctl access
+Relinquish emergency access from the given cluster. If the cluster is PrivateLink, it deletes all jump pods in the cluster's namespace (because of this, you must be logged into the hive shard when dropping access for PrivateLink clusters). For non-PrivateLink clusters, the $KUBECONFIG environment variable is unset, if applicable.
 
-Provides vitals of an AWS cluster
 
 ```
-osdctl cluster [flags]
+osdctl cluster break-glass cleanup <cluster identifier> [flags]
 ```
 
 ### Options
@@ -33,6 +33,4 @@ osdctl cluster [flags]
 
 ### SEE ALSO
 
-* [osdctl](osdctl.md)	 - OSD CLI
-* [osdctl cluster health](osdctl_cluster_health.md)	 - Describes health of cluster nodes and provides other cluster vitals.
-* [osdctl cluster break-glass](osdctl_cluster_break-glass.md)    - Emergency access to a cluster
+* [osdctl cluster break-glass](osdctl_cluster_break-glass.md)	 - Request or obtain emergency break-glass access for a cluster

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.18.5
 	k8s.io/apimachinery v0.24.3
 	k8s.io/cli-runtime v0.18.5

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -12,6 +12,7 @@ import (
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	amv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 type lmtSprReasonItem struct {
@@ -261,4 +262,35 @@ func ConfirmSend() error {
 		log.Fatalf("Exiting...")
 	}
 	return nil
+}
+
+// streamPrintln appends a newline then prints the given msg using the provided IOStreams
+func StreamPrintln(stream genericclioptions.IOStreams, msg string) {
+	stream.Out.Write([]byte(fmt.Sprintln(msg)))
+}
+
+// streamPrint prints the given msg using the provided IOStreams
+func StreamPrint(stream genericclioptions.IOStreams, msg string) {
+	stream.Out.Write([]byte(msg))
+}
+
+// streamPrint prints the given error msg using the provided IOStreams
+func StreamErrorln(stream genericclioptions.IOStreams, msg string) {
+	stream.ErrOut.Write([]byte(fmt.Sprintln(msg)))
+}
+
+// StreamRead retrieves input from the provided IOStreams up to (and including) the delimiter given
+func StreamRead(stream genericclioptions.IOStreams, delim byte) (string, error) {
+	reader := bufio.NewReader(stream.In)
+	return reader.ReadString(delim)
+}
+
+// Contains returns true if the given key is present in the provided list
+func Contains(list []string, key string) bool {
+	for _, item := range list {
+		if item == key {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Completes: https://issues.redhat.com/browse/OSD-12757

---

Adds `break-glass` and `break-glass cleanup` subcommands to the `osdctl cluster` command.

- `break-glass` takes a single cluster-identifier argument, which is used to evaluate the cluster type and execute the appropriate procedure to grant the user emergency access to the cluster. Users must be logged onto the cluster's hive shard for this command to function properly. 

  For PrivateLink clusters, a temporary pod is spun up in the cluster's namespace on hive. These pods are configured to expire after 8 hours, however they can be terminated immediately using the `break-glass cleanup` subcommand.

  For non-PrivateLink clusters, the Kubeconfig is retrieved from hive, saved to the local tmp filesystem, and the user is prompted as to whether they would like to spawn a new terminal using the Kubeconfig. It is the responsibility of the SRE calling this command to delete the Kubeconfig file when finished. 

  In all cases, the user is prompted to elevate permissions if they have not impersonated the correct user using the global `--as` flag.

- `break-glass cleanup` takes a single cluster-identifier argument, which is used to evaluate the type of cluster who's access is being dropped, and execute the appropriate procedure to do so. For PrivateLink clusters, users must be logged into the cluster's hive shard for this command to function properly. For non-PrivateLink clusters, this command acts as a glorified `unset KUBECONFIG`.