### PR TITLE
Make copy-pastable output the default behavior

### DIFF
--- a/cmd/account/cli.go
+++ b/cmd/account/cli.go
@@ -123,6 +123,5 @@ func (o *cliOptions) run() error {
 		)
 	}
 
-
 	return nil
 }

--- a/cmd/account/cli.go
+++ b/cmd/account/cli.go
@@ -102,7 +102,16 @@ func (o *cliOptions) run() error {
 	}
 
 	if o.output == "" {
-		fmt.Fprintf(o.IOStreams.Out, "Temporary AWS Credentials:\n%s\n", creds)
+		fmt.Println("Temporary AWS Credentials:")
+	}
+
+	if o.output == "env" || o.output == "" {
+		fmt.Fprintf(o.IOStreams.Out, "AWS_ACCESS_KEY_ID=%s \nAWS_SECRET_ACCESS_KEY=%s \nAWS_SESSION_TOKEN=%s \nAWS_DEFAULT_REGION=%s\n",
+			*creds.AccessKeyId,
+			*creds.SecretAccessKey,
+			*creds.SessionToken,
+			o.k8sclusterresourcefactory.Awscloudfactory.Region,
+		)
 	}
 
 	if o.output == "json" {
@@ -114,14 +123,6 @@ func (o *cliOptions) run() error {
 		)
 	}
 
-	if o.output == "env" {
-		fmt.Fprintf(o.IOStreams.Out, "AWS_ACCESS_KEY_ID=%s \nAWS_SECRET_ACCESS_KEY=%s \nAWS_SESSION_TOKEN=%s \nAWS_DEFAULT_REGION=%s\n",
-			*creds.AccessKeyId,
-			*creds.SecretAccessKey,
-			*creds.SessionToken,
-			o.k8sclusterresourcefactory.Awscloudfactory.Region,
-		)
-	}
 
 	return nil
 }


### PR DESCRIPTION
Change from go struct output to shell variable output when no -o is passed

jira: [OSD-13099](https://issues.redhat.com//browse/OSD-13099)