### PR TITLE
Add public GOPROXY repository to build from source requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Currently, it mainly supports related work for AWS, especially [aws-account-oper
 - Go >= 1.13
 - make
 - [goreleaser](https://github.com/goreleaser)
+- `GOPROXY` contains `proxy.golang.org`
+  ```shell
+  # Google`s default proxy can be added globally:
+  go env -w GOPROXY="$(go env GOPROXY),https://proxy.golang.org"
+  ```
 
 ```shell
 # Goreleaser is required for builds,


### PR DESCRIPTION
**What:**
Add a requirement for `GOPROXY` to contain the public go proxy. 

**Why:**
The missing value in `GOPROXY` causes an error during the `go mod tidy` step of the `make build` command:

```bash
make build
goreleaser build --rm-dist --snapshot
   • building...      
   • loading config file       file=.goreleaser.yml
   • loading environment variables
   • getting and validating git state
      • ignoring errors because this is a snapshot error=git doesn't contain any tags. Either add a tag or use --snapshot
      • building...               commit=f7f108c94244102b804f300a4ab1a8e62ba37be1 latest tag=v0.0.0
      • pipe skipped              error=disabled during snapshot mode
   • parsing tag      
   • running before hooks
      • running                   hook=go mod tidy
   ⨯ build failed after 2.65s error=hook failed: go mod tidy: exit status 1; output: go: github.com/openshift/hive@v1.0.5 requires
	github.com/openshift/api@v3.9.1-0.20191111211345-a27ff30ebf09+incompatible: invalid pseudo-version: preceding tag (v3.9.0) not found
go: downloading github.com/openshift/api v0.0.0-20180801171038-322a19404e37
go: github.com/openshift/hive@v1.0.5 requires
	github.com/openshift/api@v3.9.1-0.20191111211345-a27ff30ebf09+incompatible: invalid pseudo-version: preceding tag (v3.9.0) not found

make: *** [Makefile:37: build] Error 1
```

This is occurs mostly for fedora users, as the fedora go fork [does not contain the default public](https://fedoraproject.org/wiki/Changes/golang1.13#Detailed_Description) `GOPROXY`.