### PR TITLE
Remove duplicate code and fix cluster commands

### DIFF
--- a/cmd/cluster/loggingcheck.go
+++ b/cmd/cluster/loggingcheck.go
@@ -1,12 +1,9 @@
 package cluster
 
 import (
-	"context"
 	"fmt"
-	"log"
 	"os"
 
-	sdk "github.com/openshift-online/ocm-sdk-go"
 	"github.com/openshift/osdctl/internal/utils/globalflags"
 	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
@@ -82,25 +79,7 @@ func (o *loggingCheckOptions) complete(cmd *cobra.Command, args []string) error 
 
 func (o *loggingCheckOptions) run() error {
 
-	// Create a context:
-	ctx := context.Background()
-	//The ocm
-	token := os.Getenv("OCM_TOKEN")
-	if token == "" {
-		ocmToken, err := utils.GetOCMAccessToken()
-		if err != nil {
-			log.Fatalf("OCM token not set. Please configure it using the OCM_TOKEN evnironment variable or the ocm cli")
-			os.Exit(1)
-		}
-		token = *ocmToken
-	}
-	connection, err := sdk.NewConnectionBuilder().
-		Tokens(token).
-		Build()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't build connection: %v\n", err)
-		os.Exit(1)
-	}
+	connection := utils.CreateConnection()
 	defer connection.Close()
 
 	// Get the client for the resource that manages the collection of clusters:
@@ -108,7 +87,7 @@ func (o *loggingCheckOptions) run() error {
 	// Get the labels externally available for the cluster
 	resource := collection.Cluster(o.clusterID).ExternalConfiguration().Labels()
 	// Send the request to retrieve the list of external cluster labels:
-	response, err := resource.List().SendContext(ctx)
+	response, err := resource.List().Send()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Can't retrieve cluster labels: %v\n", err)
 		os.Exit(1)

--- a/cmd/cluster/owner.go
+++ b/cmd/cluster/owner.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"html/template"
 	"os"
-	"strings"
 
-	"github.com/openshift-online/ocm-cli/pkg/ocm"
-	sdk "github.com/openshift-online/ocm-sdk-go"
 	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	"github.com/openshift/osdctl/internal/utils/globalflags"
+	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
@@ -60,24 +58,8 @@ func (o *ownerOptions) complete(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func createConnection() (*sdk.Connection, error) {
-	connection, err := ocm.NewConnection().Build()
-	if err != nil {
-		baseErrString := "Failed to create OCM connection"
-		if strings.Contains(err.Error(), "Not logged in, run the") {
-			return nil, fmt.Errorf("%s: user is not logged in, please re-login and try again", baseErrString)
-		}
-
-		return nil, fmt.Errorf("%s: %w", baseErrString, err)
-	}
-	return connection, nil
-}
-
 func (o *ownerOptions) run() error {
-	connection, err := createConnection()
-	if err != nil {
-		return fmt.Errorf("could not createConnection: %w", err)
-	}
+	connection := utils.CreateConnection()
 
 	var (
 		accountName = o.userName

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -15,23 +14,10 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-type lmtSprReasonItem struct {
+type LimitedSupportReasonItem struct {
 	ID      string
 	Summary string
 	Details string
-}
-
-func GetOCMAccessToken() (*string, error) {
-	// Get ocm access token
-	ocmCmd := exec.Command("ocm", "token")
-	ocmCmd.Stderr = os.Stderr
-	ocmOutput, err := ocmCmd.Output()
-	if err != nil { // Throw error if ocm not in PATH, or ocm command exit non-zero.
-		return nil, fmt.Errorf("failed running ocm token: %v", err)
-	}
-	accessToken := strings.TrimSuffix(string(ocmOutput), "\n")
-
-	return &accessToken, nil
 }
 
 var clusterKeyRE = regexp.MustCompile(`^(\w|-)+$`)
@@ -51,7 +37,7 @@ func IsValidClusterKey(clusterKey string) (err error) {
 	return nil
 }
 
-//GetCluster Function allows to get a single cluster with any identifier (displayname, ID, or external ID)
+// GetCluster Function allows to get a single cluster with any identifier (displayname, ID, or external ID)
 func GetCluster(connection *sdk.Connection, key string) (cluster *cmv1.Cluster, err error) {
 	// Prepare the resources that we will be using:
 	subsResource := connection.AccountsMgmt().V1().Subscriptions()
@@ -143,7 +129,7 @@ func GetCluster(connection *sdk.Connection, key string) (cluster *cmv1.Cluster, 
 	return
 }
 
-func GetClusterLimitedSupportReasons(connection *sdk.Connection, clusterID string) ([]*lmtSprReasonItem, error) {
+func GetClusterLimitedSupportReasons(connection *sdk.Connection, clusterID string) ([]*LimitedSupportReasonItem, error) {
 
 	limitedSupportReasons, err := connection.ClustersMgmt().V1().
 		Clusters().
@@ -157,10 +143,10 @@ func GetClusterLimitedSupportReasons(connection *sdk.Connection, clusterID strin
 
 	lmtReason := limitedSupportReasons.Items().Slice()
 
-	var clusterLmtSprReasons []*lmtSprReasonItem
+	var clusterLmtSprReasons []*LimitedSupportReasonItem
 
 	for _, reason := range lmtReason {
-		clusterLmtSprReason := lmtSprReasonItem{
+		clusterLmtSprReason := LimitedSupportReasonItem{
 			ID:      reason.ID(),
 			Summary: reason.Summary(),
 			Details: reason.Details(),
@@ -171,7 +157,7 @@ func GetClusterLimitedSupportReasons(connection *sdk.Connection, clusterID strin
 	return clusterLmtSprReasons, nil
 }
 
-//GetSubscription Function allows to get a single subscription with any identifier (displayname, ID, internal or external ID)
+// GetSubscription Function allows to get a single subscription with any identifier (displayname, ID, internal or external ID)
 func GetSubscription(connection *sdk.Connection, key string) (subscription *amv1.Subscription, err error) {
 	// Prepare the resources that we will be using:
 	subsResource := connection.AccountsMgmt().V1().Subscriptions()
@@ -209,7 +195,7 @@ func GetSubscription(connection *sdk.Connection, key string) (subscription *amv1
 	return
 }
 
-//GetAccount Function allows to get a single account with any identifier (username, ID)
+// GetAccount Function allows to get a single account with any identifier (username, ID)
 func GetAccount(connection *sdk.Connection, key string) (account *amv1.Account, err error) {
 	// Prepare the resources that we will be using:
 	accsResource := connection.AccountsMgmt().V1().Accounts()


### PR DESCRIPTION
Refactored the following:
- removed the `sdk.NewConnectionBuilder` calls, which break the commands for stage, as this call uses the hardcoded production url `api.openshift.com`. Replaced those calls with the already existing `utils.CreateConnection`
- refactored `context.go` to use the same `utils.GetLimitedSupportReasons` as `status.go`
- fixed some formatting