### PR TITLE
Remove k8sclusterresourcefactory from account console and cli

### DIFF
--- a/cmd/account/cli.go
+++ b/cmd/account/cli.go
@@ -3,19 +3,17 @@ package account
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/openshift/osdctl/internal/utils/globalflags"
-	k8spkg "github.com/openshift/osdctl/pkg/k8s"
-	awsprovider "github.com/openshift/osdctl/pkg/provider/aws"
+	"github.com/aws/aws-sdk-go/service/sts"
+	osdCloud "github.com/openshift/osdctl/pkg/osdCloud"
+	"github.com/openshift/osdctl/pkg/provider/aws"
+	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/klog/v2"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 // newCmdCli implements the Cli command which generates temporary STS cli credentials for the specified account cr
-func newCmdCli(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
-	ops := newCliOptions(streams, flags, globalOpts)
+func newCmdCli() *cobra.Command {
+	ops := &cliOptions{}
 	cliCmd := &cobra.Command{
 		Use:               "cli",
 		Short:             "Generate temporary AWS CLI credentials on demand",
@@ -27,99 +25,131 @@ func newCmdCli(streams genericclioptions.IOStreams, flags *genericclioptions.Con
 		},
 	}
 
-	ops.k8sclusterresourcefactory.AttachCobraCliFlags(cliCmd)
-
 	cliCmd.Flags().BoolVarP(&ops.verbose, "verbose", "", false, "Verbose output")
+	cliCmd.Flags().StringVarP(&ops.awsAccountID, "accountId", "i", "", "AWS Account ID")
+	cliCmd.Flags().StringVarP(&ops.awsProfile, "profile", "p", "", "AWS Profile")
+	cliCmd.Flags().StringVarP(&ops.output, "output", "o", "", "Output type")
+	cliCmd.Flags().StringVarP(&ops.region, "region", "r", "", "Region")
+	cliCmd.Flags().StringVarP(&ops.clusterID, "clusterID", "C", "", "Cluster ID")
 
 	return cliCmd
 }
 
 // cliOptions defines the struct for running the cli command
 type cliOptions struct {
-	k8sclusterresourcefactory k8spkg.ClusterResourceFactoryOptions
-
 	output  string
 	verbose bool
 
-	genericclioptions.IOStreams
-	GlobalOptions *globalflags.GlobalOptions
-}
-
-func newCliOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cliOptions {
-	return &cliOptions{
-		k8sclusterresourcefactory: k8spkg.ClusterResourceFactoryOptions{
-			Flags: flags,
-		},
-		IOStreams:     streams,
-		GlobalOptions: globalOpts,
-	}
+	awsAccountID string
+	awsProfile   string
+	region       string
+	clusterID    string
 }
 
 func (o *cliOptions) complete(cmd *cobra.Command) error {
-	k8svalid, err := o.k8sclusterresourcefactory.ValidateIdentifiers()
-	if !k8svalid {
+
+	var err error
+
+	ocmClient := utils.CreateConnection()
+
+	if o.awsAccountID == "" && o.clusterID == "" {
+		return fmt.Errorf("please specify -i or -C")
+	}
+
+	if o.awsAccountID != "" && o.clusterID != "" {
+		return fmt.Errorf("-i and -c are mutually exclusive, please only specify one")
+	}
+
+	if o.clusterID != "" {
+		o.awsAccountID, err = utils.GetAWSAccountIdForCluster(ocmClient, o.clusterID)
 		if err != nil {
 			return err
 		}
 	}
 
-	awsvalid, err := o.k8sclusterresourcefactory.Awscloudfactory.ValidateIdentifiers()
-	if !awsvalid {
-		if err != nil {
-			return err
-		}
+	if o.region == "" {
+		o.region = "us-east-1"
 	}
-
-	o.output = o.GlobalOptions.Output
 
 	return nil
 }
 
 func (o *cliOptions) run() error {
-	awsClient, err := o.k8sclusterresourcefactory.GetCloudProvider(o.verbose)
-	if err != nil {
-		return err
-	}
 
-	partition, err := awsprovider.GetAwsPartition(awsClient)
-	if err != nil {
-		return err
-	}
+	var err error
+	isCCS := false
 
-	creds := o.k8sclusterresourcefactory.Awscloudfactory.Credentials
+	ocmClient := utils.CreateConnection()
 
-	if o.k8sclusterresourcefactory.Awscloudfactory.RoleName != "OrganizationAccountAccessRole" {
-		creds, err = awsprovider.GetAssumeRoleCredentials(
-			awsClient,
-			&o.k8sclusterresourcefactory.Awscloudfactory.ConsoleDuration,
-			aws.String(o.k8sclusterresourcefactory.Awscloudfactory.SessionName),
-			aws.String(fmt.Sprintf("arn:%s:iam::%s:role/%s", partition, o.k8sclusterresourcefactory.AccountID, o.k8sclusterresourcefactory.Awscloudfactory.RoleName)),
-		)
+	// If a cluster ID was provided, determine if the cluster is CCS
+	if o.clusterID != "" {
+		isCCS, err = utils.IsClusterCCS(ocmClient, o.clusterID)
 		if err != nil {
-			klog.Error("Failed to assume ManagedOpenShiftSupport role. Customer either deleted role or denied SREP access")
 			return err
 		}
 	}
 
-	if o.output == "" {
-		fmt.Println("Temporary AWS Credentials:")
+	// Build the base AWS client using the provide credentials (profile or env vars)
+	awsClient, err := aws.NewAwsClient(o.awsProfile, o.region, "")
+	if err != nil {
+		fmt.Printf("Could not build AWS Client: %s\n", err)
+		return err
 	}
 
-	if o.output == "env" || o.output == "" {
-		fmt.Fprintf(o.IOStreams.Out, "AWS_ACCESS_KEY_ID=%s \nAWS_SECRET_ACCESS_KEY=%s \nAWS_SESSION_TOKEN=%s \nAWS_DEFAULT_REGION=%s\n",
-			*creds.AccessKeyId,
-			*creds.SecretAccessKey,
-			*creds.SessionToken,
-			o.k8sclusterresourcefactory.Awscloudfactory.Region,
-		)
+	// Generate a session name using the SRE's kerberos ID
+	sessionName, err := osdCloud.GenerateRoleSessionName(awsClient)
+	if err != nil {
+		fmt.Printf("Could not generate Session Name: %s\n", err)
+		return err
+	}
+
+	var assumedRoleCreds *sts.Credentials
+	if isCCS {
+		// If the cluster is CCS, the target role needs to be determined, and the jump role chain needs to be executed
+
+		// Determine the right jump role
+		targetRole, err := utils.GetSupportRoleArnForCluster(ocmClient, o.clusterID)
+		if err != nil {
+			return err
+		}
+
+		// Start the jump role chain. Result should be credentials for the ManagedOpenShift Support role for the target cluster
+		assumedRoleCreds, err = osdCloud.GenerateSupportRoleCredentials(awsClient, o.awsAccountID, o.region, sessionName, targetRole)
+		if err != nil {
+			return err
+		}
+
+	} else {
+
+		// If the cluster is non-CCS, or an AWS Account ID was provided with -i, try and use OrganizationAccountAccessRole
+		assumedRoleCreds, err = osdCloud.GenerateOrganizationAccountAccessCredentials(awsClient, o.awsAccountID, sessionName)
+		if err != nil {
+			fmt.Printf("Could not build AWS Client for OrganizationAccountAccessRole: %s\n", err)
+			return err
+		}
+	}
+
+	// Output section
+	if o.output == "" {
+		fmt.Printf("Temporary AWS Credentials:\n%s\n", assumedRoleCreds)
 	}
 
 	if o.output == "json" {
-		fmt.Fprintf(o.IOStreams.Out, "{\n\"AccessKeyId\": %q, \n\"Expiration\": %q, \n\"SecretAccessKey\": %q, \n\"SessionToken\": %q\n}",
-			*creds.AccessKeyId,
-			*creds.Expiration,
-			*creds.SecretAccessKey,
-			*creds.SessionToken,
+		fmt.Printf("{\n\"AccessKeyId\": %q, \n\"Expiration\": %q, \n\"SecretAccessKey\": %q, \n\"SessionToken\": %q, \n\"Region\": %s\n}",
+			*assumedRoleCreds.AccessKeyId,
+			*assumedRoleCreds.Expiration,
+			*assumedRoleCreds.SecretAccessKey,
+			*assumedRoleCreds.SessionToken,
+			o.region,
+		)
+	}
+
+	if o.output == "env" {
+		fmt.Printf("AWS_ACCESS_KEY_ID=%s \nAWS_SECRET_ACCESS_KEY=%s \nAWS_SESSION_TOKEN=%s \nAWS_DEFAULT_REGION=%s\n",
+			*assumedRoleCreds.AccessKeyId,
+			*assumedRoleCreds.SecretAccessKey,
+			*assumedRoleCreds.SessionToken,
+			o.region,
 		)
 	}
 

--- a/cmd/account/cmd.go
+++ b/cmd/account/cmd.go
@@ -2,6 +2,7 @@ package account
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,8 +29,8 @@ func NewCmdAccount(streams genericclioptions.IOStreams, flags *genericclioptions
 	accountCmd.AddCommand(mgmt.NewCmdMgmt(streams, flags, globalOpts))
 	accountCmd.AddCommand(newCmdReset(streams, flags, client))
 	accountCmd.AddCommand(newCmdSet(streams, flags, client))
-	accountCmd.AddCommand(newCmdConsole(streams, flags))
-	accountCmd.AddCommand(newCmdCli(streams, flags, globalOpts))
+	accountCmd.AddCommand(newCmdConsole())
+	accountCmd.AddCommand(newCmdCli())
 	accountCmd.AddCommand(newCmdCleanVeleroSnapshots(streams))
 	accountCmd.AddCommand(newCmdVerifySecrets(streams, flags, client))
 	accountCmd.AddCommand(newCmdRotateSecret(streams, flags, client))

--- a/pkg/osdCloud/aws.go
+++ b/pkg/osdCloud/aws.go
@@ -1,0 +1,172 @@
+package osdCloud
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	awsSdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/openshift/osdctl/pkg/provider/aws"
+)
+
+const (
+	RhSreCcsAccessRolename        = "RH-SRE-CCS-Access"
+	RhTechnicalSupportAccess      = "RH-Technical-Support-Access"
+	OrganizationAccountAccessRole = "OrganizationAccountAccessRole"
+)
+
+// Creates a client for an assumed OrganizationAccountAccessRole
+func CreateOrganizationAccountAccessClient(client aws.Client, accountId, region, sessionName string) (aws.Client, error) {
+
+	assumeRoleCredentials, err := GenerateOrganizationAccountAccessCredentials(client, accountId, sessionName)
+	if err != nil {
+		return nil, err
+	}
+
+	organizationAccountAccessClient, err := aws.NewAwsClientWithInput(
+		&aws.AwsClientInput{
+			AccessKeyID:     *assumeRoleCredentials.AccessKeyId,
+			SecretAccessKey: *assumeRoleCredentials.SecretAccessKey,
+			SessionToken:    *assumeRoleCredentials.SessionToken,
+			Region:          *awsSdk.String(region),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return organizationAccountAccessClient, nil
+}
+
+// Uses the provided IAM Client to try and assume OrganizationAccountAccessRole for the given AWS Account
+// This only works when the provided client is a user from the root account of an organization and the AWS account provided is a linked accounts within that organization
+func GenerateOrganizationAccountAccessCredentials(client aws.Client, accountId, sessionName string) (*sts.Credentials, error) {
+
+	roleArn := aws.GenerateRoleARN(accountId, "OrganizationAccountAccessRole")
+	assumeRoleOutput, err := client.AssumeRole(
+		&sts.AssumeRoleInput{
+			RoleArn:         awsSdk.String(roleArn),
+			RoleSessionName: awsSdk.String(sessionName),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return assumeRoleOutput.Credentials, nil
+
+}
+
+// Uses the provided IAM Client to perform the Assume Role chain needed to get to a cluster's Support Role
+func GenerateSupportRoleCredentials(client aws.Client, awsAccountID, region, sessionName, targetRole string) (*sts.Credentials, error) {
+
+	// Perform the Assume Role chain to get the jump
+	jumpRoleCreds, err := GenerateJumpRoleCredentials(client, awsAccountID, region, sessionName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build client for jump role needed for the last step
+	jumpRoleClient, err := aws.NewAwsClientWithInput(
+		&aws.AwsClientInput{
+			AccessKeyID:     *jumpRoleCreds.AccessKeyId,
+			SecretAccessKey: *jumpRoleCreds.SecretAccessKey,
+			SessionToken:    *jumpRoleCreds.SessionToken,
+			Region:          *awsSdk.String(region),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Assume target ManagedOpenShift-Support role in the cluster's AWS Account
+	targetAssumeRoleOutput, err := jumpRoleClient.AssumeRole(
+		&sts.AssumeRoleInput{
+			RoleArn:         awsSdk.String(targetRole),
+			RoleSessionName: awsSdk.String(sessionName),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return targetAssumeRoleOutput.Credentials, nil
+}
+
+// Preforms the Assume Role chain from IAM User to the Jump role
+// This sequence stays within the Red Hat account boundary, so a failure here indicates an internal misconfiguration
+func GenerateJumpRoleCredentials(client aws.Client, awsAccountID, region, sessionName string) (*sts.Credentials, error) {
+
+	callerIdentityOutput, err := client.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	sreUserArn, err := arn.Parse(*callerIdentityOutput.Arn)
+	if err != nil {
+		return nil, err
+	}
+
+	// Assume RH-SRE-CCS-Access role
+	sreCcsAccessRoleArn := aws.GenerateRoleARN(sreUserArn.AccountID, RhSreCcsAccessRolename)
+	sreCcsAccessAssumeRoleOutput, err := client.AssumeRole(
+		&sts.AssumeRoleInput{
+			RoleArn:         awsSdk.String(sreCcsAccessRoleArn),
+			RoleSessionName: awsSdk.String(sessionName),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build client for RH-SRE-CCS-Access role
+	sreCcsAccessRoleClient, err := aws.NewAwsClientWithInput(
+		&aws.AwsClientInput{
+			AccessKeyID:     *sreCcsAccessAssumeRoleOutput.Credentials.AccessKeyId,
+			SecretAccessKey: *sreCcsAccessAssumeRoleOutput.Credentials.SecretAccessKey,
+			SessionToken:    *sreCcsAccessAssumeRoleOutput.Credentials.SessionToken,
+			Region:          *awsSdk.String(region),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Assume jump role
+	// This will be different between stage and prod. There's probably a better way to do this that isn't hardcoding
+	jumproleAccountID := os.Getenv("JUMPROLE_ACCOUNT_ID")
+	jumpRoleArn := aws.GenerateRoleARN(jumproleAccountID, RhTechnicalSupportAccess)
+	jumpAssumeRoleOutput, err := sreCcsAccessRoleClient.AssumeRole(
+		&sts.AssumeRoleInput{
+			RoleArn:         awsSdk.String(jumpRoleArn),
+			RoleSessionName: awsSdk.String(sessionName),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return jumpAssumeRoleOutput.Credentials, nil
+
+}
+
+// Uses the current IAM ARN to generate a role name. This should end up being RH-SRE-$kerberosID
+func GenerateRoleSessionName(client aws.Client) (string, error) {
+
+	callerIdentityOutput, err := client.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", err
+	}
+
+	roleArn, err := arn.Parse(awsSdk.StringValue(callerIdentityOutput.Arn))
+	if err != nil {
+		return "", err
+	}
+
+	splitArn := strings.Split(roleArn.Resource, "/")
+	username := splitArn[1]
+
+	return fmt.Sprintf("RH-SRE-%s", username), nil
+}

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -120,9 +120,6 @@ type AwsClient struct {
 }
 
 func NewAwsSession(profile, region, configFile string) (*session.Session, error) {
-	if profile == "" && configFile == "" {
-		fmt.Println("Config file and profile are not provided. Reading from env vars.")
-	}
 
 	opt := session.Options{
 		Config: aws.Config{

--- a/pkg/provider/aws/iam.go
+++ b/pkg/provider/aws/iam.go
@@ -207,3 +207,7 @@ func RefreshIAMPolicy(awsClient Client, federatedRole *awsv1alpha1.AWSFederatedR
 
 	return nil
 }
+
+func GenerateRoleARN(accountId, roleName string) string {
+	return fmt.Sprintf("arn:aws:iam::%s:role/%s", accountId, roleName)
+}

--- a/pkg/utils/ocm.go
+++ b/pkg/utils/ocm.go
@@ -1,10 +1,12 @@
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/openshift-online/ocm-cli/pkg/ocm"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -69,4 +71,58 @@ func CreateConnection() *sdk.Connection {
 		log.Fatalf("Failed to create OCM connection: %v", err)
 	}
 	return connection
+}
+
+func GetSupportRoleArnForCluster(ocmClient *sdk.Connection, clusterID string) (string, error) {
+	liveResponse, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(clusterID).Resources().Live().Get().Send()
+	if err != nil {
+		return "", err
+	}
+
+	respBody := liveResponse.Body().Resources()
+	if awsAccountClaim, ok := respBody["aws_account_claim"]; ok {
+
+		var claimJson map[string]interface{}
+		json.Unmarshal([]byte(awsAccountClaim), &claimJson)
+
+		if spec, ok := claimJson["spec"]; ok {
+
+			if supportRoleArn, ok := spec.(map[string]interface{})["supportRoleARN"]; ok {
+				return supportRoleArn.(string), nil
+			}
+		}
+
+		return "", fmt.Errorf("unable to get role arn from claim JSON")
+	}
+
+	return "", fmt.Errorf("cluster does not have AccountClaim")
+}
+
+func GetAWSAccountIdForCluster(ocmClient *sdk.Connection, clusterID string) (string, error) {
+
+	roleArn, err := GetSupportRoleArnForCluster(ocmClient, clusterID)
+	if err != nil {
+		return "", err
+	}
+
+	awsRoleArn, err := arn.Parse(roleArn)
+	if err != nil {
+		return "", err
+	}
+	return awsRoleArn.AccountID, nil
+}
+
+func IsClusterCCS(ocmClient *sdk.Connection, clusterID string) (bool, error) {
+
+	clusterResponse, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(clusterID).Get().Send()
+	if err != nil {
+		return false, err
+	}
+
+	cluster := clusterResponse.Body()
+	if cluster.CCS().Enabled() {
+		return true, nil
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
Removes k8sclusterresourcefactory usage from `osdctl account cli` and `osdctl account console`

With this change, both `-i` and `-C` are usable without requiring hive access. Only proper OCM and AWS credentials are required. To achieve this, some new utility functions are created for common SRE workflows. Specifically 
- Assuming the OrganizationAccountAccessRole
- Performing the Assume Role chain from IAM User -> RH Support Role -> Jump Role -> ManagedOpenShift-Support target role
- Getting a cluster's AWS Account ID from OCM
- Getting a cluster's Support Role ARN for OCM
- Generating the correct session name using an SRE's kerberos ID

This is the first step in a larger refactor to fully remove k8sclusterresourcefactory, and other commands that require logging into hive (`osdctl cluster health` for example) will be able to use these functions instead.

I'm convinced this pattern is the way forward for osdctl, and we should continue to support -C separate from the backplane path as long as it remains achievable through OCM. There's a host of functionality in osdctl it wouldn't make sense to migrate, and needs the same functionality as -C anyway.

The only thing I'm not confident about is how to set the Jump Role Account ID. In the code I'm simply reading from an env var for simplicity. However, this is error prone and potentially requires setting every time, as the Account ID is different between stage and prod. I'm against hard coding as 1) They're static IDs and I'm concerned about security and 2) osdctl should remain as flexible as possible and rely on account layout, not specific accounts. I think the best way forward here may be to create an `~/.osdctl.conf` file where one can set various configs, like `stage_jump_role_account_id` and `prod_jump_role_account_id`. Then in code, the logic could determine which OCM env is being used and select the right thing from the file. This has the benefit of remaining agnostic, and is a one time setting rather than an env var that needs to be set every time and correctly by an SRE (its just too much cognitive load). The downside is everyone using this tool will need to do an extra step, but given its a one time step I think this could be acceptable. Thoughts?