### PR TITLE
Refactor osdctl cluster health

### DIFF
--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -22,7 +22,7 @@ func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions
 		DisableAutoGenTag: true,
 	}
 
-	clusterCmd.AddCommand(newCmdHealth(streams, flags, globalOpts))
+	clusterCmd.AddCommand(newCmdHealth())
 	clusterCmd.AddCommand(newCmdLoggingCheck(streams, flags, globalOpts))
 	clusterCmd.AddCommand(newCmdOwner(streams, flags, globalOpts))
 	clusterCmd.AddCommand(support.NewCmdSupport(streams, flags, client, globalOpts))

--- a/cmd/cluster/health.go
+++ b/cmd/cluster/health.go
@@ -3,21 +3,15 @@ package cluster
 import (
 	"fmt"
 	"log"
-	"os"
 	"strconv"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/osdctl/internal/utils/globalflags"
-	k8spkg "github.com/openshift/osdctl/pkg/k8s"
-	awsprovider "github.com/openshift/osdctl/pkg/provider/aws"
+	"github.com/openshift/osdctl/pkg/osdCloud"
 	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/klog/v2"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
@@ -25,20 +19,18 @@ import (
 // This command requires the ocm API Token https://cloud.redhat.com/openshift/token be available in the OCM_TOKEN env variable.
 
 type healthOptions struct {
-	k8sclusterresourcefactory k8spkg.ClusterResourceFactoryOptions
-	output                    string
-	verbose                   bool
-
-	genericclioptions.IOStreams
-	GlobalOptions *globalflags.GlobalOptions
+	clusterID  string
+	output     string
+	verbose    bool
+	awsProfile string
 }
 
 // newCmdHealth implements the health command to describe number of running instances in cluster and the expected number of nodes
-func newCmdHealth(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
-	ops := newHealthOptions(streams, flags, globalOpts)
+func newCmdHealth() *cobra.Command {
+	ops := newHealthOptions()
 	healthCmd := &cobra.Command{
 		Use:               "health",
-		Short:             "Describes health of cluster nodes and provides other cluster vitals. Requires being logged into the cluster's corresponding hive cluster.",
+		Short:             "Describes health of cluster nodes and provides other cluster vitals.",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -46,30 +38,19 @@ func newCmdHealth(streams genericclioptions.IOStreams, flags *genericclioptions.
 			cmdutil.CheckErr(ops.run())
 		},
 	}
-	ops.k8sclusterresourcefactory.AttachCobraCliFlags(healthCmd)
+
 	healthCmd.Flags().BoolVarP(&ops.verbose, "verbose", "", false, "Verbose output")
+	healthCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "Cluster ID")
+	healthCmd.Flags().StringVarP(&ops.awsProfile, "profile", "p", "", "AWS Profile")
 	healthCmd.MarkFlagRequired("cluster-id")
 	return healthCmd
 }
 
-func newHealthOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *healthOptions {
-	return &healthOptions{
-		k8sclusterresourcefactory: k8spkg.ClusterResourceFactoryOptions{
-			Flags: flags,
-		},
-		IOStreams:     streams,
-		GlobalOptions: globalOpts,
-	}
+func newHealthOptions() *healthOptions {
+	return &healthOptions{}
 }
 
 func (o *healthOptions) complete(cmd *cobra.Command, _ []string) error {
-
-	err := CompleteValidation(&o.k8sclusterresourcefactory, o.IOStreams)
-	if err != nil {
-		return err
-	}
-
-	o.output = o.GlobalOptions.Output
 
 	return nil
 }
@@ -93,13 +74,18 @@ type ClusterHealthCondensedObject struct {
 	} `yaml:"Actual nodes"`
 }
 
-var healthObject = ClusterHealthCondensedObject{}
-
 func (o *healthOptions) run() error {
 
-	// This call gets the availability zone of the cluster, as well as the expected number of nodes.
-	//az, clusterName, compute, infra, master, ascMin, ascMax, err := ocmDescribe(o.k8sclusterresourcefactory.ClusterID)
-	cluster, err := ocmDescribe(o.k8sclusterresourcefactory.ClusterID)
+	ocmClient := utils.CreateConnection()
+	defer ocmClient.Close()
+
+	clusterResp, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(o.clusterID).Get().Send()
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	cluster := clusterResp.Body()
+	healthObject := createHealthObject(cluster)
 
 	if cluster.Nodes().AvailabilityZones() != nil {
 
@@ -117,40 +103,12 @@ func (o *healthOptions) run() error {
 		return err
 	}
 
-	// This aws client connects to an OpenShift AWS account and we use it here to get credentials to access a customer's account.
-	awsClient, err := o.k8sclusterresourcefactory.GetCloudProvider(o.verbose)
+	awsClient, err := osdCloud.GenerateAWSClientForCluster(o.awsProfile, o.clusterID)
 	if err != nil {
 		return err
 	}
 
-	creds := o.k8sclusterresourcefactory.Awscloudfactory.Credentials
-
-	if o.k8sclusterresourcefactory.Awscloudfactory.RoleName != "OrganizationAccountAccessRole" {
-		creds, err = awsprovider.GetAssumeRoleCredentials(awsClient,
-			&o.k8sclusterresourcefactory.Awscloudfactory.ConsoleDuration, aws.String(o.k8sclusterresourcefactory.Awscloudfactory.SessionName),
-			aws.String(fmt.Sprintf("arn:aws:iam::%s:role/%s",
-				o.k8sclusterresourcefactory.AccountID,
-				o.k8sclusterresourcefactory.Awscloudfactory.RoleName)))
-		if err != nil {
-			klog.Error("Failed to assume ManagedOpenShiftSupport role. Customer either deleted role or denied SREP access.")
-			return err
-		}
-	}
-
-	reg := cluster.Region().ID()
-
-	//This call creates a client that is connected to the customer's account and we will use it to get the information on customer's running instances etc.
-	awsJumpClient, err := awsprovider.NewAwsClientWithInput(&awsprovider.AwsClientInput{
-		AccessKeyID:     *creds.AccessKeyId,
-		SecretAccessKey: *creds.SecretAccessKey,
-		SessionToken:    *creds.SessionToken,
-		Region:          reg,
-	})
-	if err != nil {
-		return err
-	}
-
-	instances, err := awsJumpClient.DescribeInstances(&ec2.DescribeInstancesInput{})
+	instances, err := awsClient.DescribeInstances(&ec2.DescribeInstancesInput{})
 	runningMasters := 0
 	runningInfra := 0
 	runningWorkers := 0
@@ -160,7 +118,7 @@ func (o *healthOptions) run() error {
 	//Here we count the number of customer's running worker, infra and master instances in the cluster in the given region. To decide if the instance belongs to the cluster we are checking the Name Tag on the instance.
 	for idx := range instances.Reservations {
 		for _, inst := range instances.Reservations[idx].Instances {
-			tags := GetTags(inst)
+			tags := inst.Tags
 			for _, t := range tags {
 				if *t.Key == "Name" {
 					if strings.HasPrefix(*t.Value, cluster.Name()) && strings.Contains(*t.Value, "master") {
@@ -212,32 +170,16 @@ func (o *healthOptions) run() error {
 	if err != nil {
 		log.Fatalf("error: %v", err)
 	}
-	fmt.Fprintf(o.IOStreams.Out, "\n \n")
-	fmt.Printf(string(healthOutput))
+	fmt.Printf("\n \n")
+	fmt.Println(string(healthOutput))
 
 	return nil
 }
 
-//This command implements the ocm describe clsuter call via ocm-sdk.
-//This call requires the ocm API Token https://cloud.redhat.com/openshift/token be available in the OCM_TOKEN env variable.
-//Example: export OCM_TOKEN=$(jq -r .refresh_token ~/.ocm.json)
-func ocmDescribe(clusterID string) (*v1.Cluster, error) {
-	connection := utils.CreateConnection()
-	defer connection.Close()
+func createHealthObject(cluster *v1.Cluster) *ClusterHealthCondensedObject {
 
-	// Get the client for the resource that manages the collection of clusters:
-	collection := connection.ClustersMgmt().V1().Clusters()
-	resource := collection.Cluster(clusterID)
+	var healthObject ClusterHealthCondensedObject
 
-	// Send the request to retrieve the cluster:
-	response, err := resource.Get().Send()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Can't retrieve cluster: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Print the result:
-	cluster := response.Body()
 	cloudProvider := cluster.CloudProvider().ID()
 	cloudProviderMessage := strings.ToUpper(cloudProvider)
 
@@ -248,15 +190,5 @@ func ocmDescribe(clusterID string) (*v1.Cluster, error) {
 	healthObject.Expected.Infra = cluster.Nodes().Infra()
 	healthObject.Expected.Master = cluster.Nodes().Master()
 
-	if cloudProvider != "aws" {
-		return cluster, fmt.Errorf("This command is only supported for AWS clusters. The command is not supported for %s clusters.", cloudProviderMessage)
-	}
-	return cluster, err
-}
-
-func GetTags(instance *ec2.Instance) []*ec2.Tag {
-
-	tags := instance.Tags
-	//fmt.Printf("\n%v ", tags)
-	return tags
+	return &healthObject
 }

--- a/pkg/osdCloud/aws.go
+++ b/pkg/osdCloud/aws.go
@@ -23,29 +23,6 @@ const (
 	OrganizationAccountAccessRole = "OrganizationAccountAccessRole"
 )
 
-// Creates a client for an assumed OrganizationAccountAccessRole
-func CreateOrganizationAccountAccessClient(client aws.Client, accountId, region, sessionName, partiton string) (aws.Client, error) {
-
-	assumeRoleCredentials, err := GenerateOrganizationAccountAccessCredentials(client, accountId, sessionName, partiton)
-	if err != nil {
-		return nil, err
-	}
-
-	organizationAccountAccessClient, err := aws.NewAwsClientWithInput(
-		&aws.AwsClientInput{
-			AccessKeyID:     *assumeRoleCredentials.AccessKeyId,
-			SecretAccessKey: *assumeRoleCredentials.SecretAccessKey,
-			SessionToken:    *assumeRoleCredentials.SessionToken,
-			Region:          *awsSdk.String(region),
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return organizationAccountAccessClient, nil
-}
-
 // Uses the provided IAM Client to try and assume OrganizationAccountAccessRole for the given AWS Account
 // This only works when the provided client is a user from the root account of an organization and the AWS account provided is a linked accounts within that organization
 func GenerateOrganizationAccountAccessCredentials(client aws.Client, accountId, sessionName, partition string) (*sts.Credentials, error) {


### PR DESCRIPTION
Refactors `osdctl cluster health` to remove dependence on k8sclusterresourcefactory