### PR TITLE
Added PD alert summary to cluster context command

### DIFF
--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,6 +22,7 @@ import (
 	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/utils/strings/slices"
 )
 
 type contextOptions struct {
@@ -147,7 +150,7 @@ func (o *contextOptions) run() error {
 		fmt.Println("============================================================")
 		fmt.Println("CloudTrail events for the Cluster")
 		fmt.Println("============================================================")
-		println("Not polling cloudtrail logs, use --full flag to do so (must be logged into the correct hive to work).")
+		fmt.Println("Not polling cloudtrail logs, use --full flag to do so (must be logged into the correct hive to work).")
 	}
 	return nil
 }
@@ -244,36 +247,37 @@ func (o *contextOptions) printServiceLogs() error {
 	return nil
 }
 
-func (o *contextOptions) printPDAlerts() error {
-	var oauthtoken string
-	if o.oauthtoken != "" {
-		oauthtoken = o.oauthtoken
-	} else {
+func GetPagerdutyClient(oauthtoken string) (*pd.Client, error) {
+	if oauthtoken == "" {
 		pdConfig := config.LoadPDConfig("/.config/pagerduty-cli/config.json")
 		if len(pdConfig.MySubdomain) == 0 {
-			return fmt.Errorf("unable to parse PagerDuty config")
+			return nil, fmt.Errorf("unable to parse PagerDuty config")
 		}
 		if len(pdConfig.MySubdomain[0].AccessToken) == 0 {
-			return fmt.Errorf("unable to locate oauth accesstoken in PagerDuty config")
+			return nil, fmt.Errorf("unable to locate oauth accesstoken in PagerDuty config")
 		}
 		oauthtoken = pdConfig.MySubdomain[0].AccessToken
 	}
-	client := pd.NewOAuthClient(oauthtoken)
+	return pd.NewOAuthClient(oauthtoken), nil
+}
 
-	ctx := context.TODO()
-	lsResponse, err := client.ListServicesWithContext(ctx, pd.ListServiceOptions{Query: o.baseDomain})
+func getPDSeviceID(pdClient *pd.Client, ctx context.Context, baseDomain string) (string, error) {
+	lsResponse, err := pdClient.ListServicesWithContext(ctx, pd.ListServiceOptions{Query: baseDomain})
 
 	if err != nil {
 		fmt.Printf("Failed to ListServicesWithContext %q\n", err)
-		return err
+		return "", err
 	}
 
 	if len(lsResponse.Services) != 1 {
-		return fmt.Errorf("unexpected number of services matched input. Expected 1 got %d", len(lsResponse.Services))
+		return "", fmt.Errorf("unexpected number of services matched input. Expected 1 got %d", len(lsResponse.Services))
 	}
 
-	serviceID := lsResponse.Services[0].ID
-	liResponse, err := client.ListIncidentsWithContext(
+	return lsResponse.Services[0].ID, nil
+}
+
+func printCurrentPDAlerts(pdClient *pd.Client, ctx context.Context, serviceID string) error {
+	liResponse, err := pdClient.ListIncidentsWithContext(
 		ctx,
 		pd.ListIncidentsOptions{
 			ServiceIDs: []string{serviceID},
@@ -286,7 +290,7 @@ func (o *contextOptions) printPDAlerts() error {
 	}
 
 	fmt.Println("============================================================")
-	fmt.Println("Pagerduty alerts for the Cluster")
+	fmt.Println("Current Pagerduty Alerts for the Cluster")
 	fmt.Println("============================================================")
 	fmt.Printf("Link to PD Service: https://redhat.pagerduty.com/service-directory/%s\n", serviceID)
 	table := printer.NewTablePrinter(os.Stdout, 20, 1, 3, ' ')
@@ -301,8 +305,117 @@ func (o *contextOptions) printPDAlerts() error {
 		fmt.Println("error while flushing table: ", err.Error())
 		return err
 	}
+	return nil
+}
 
-	return err
+func printHistoricalPDAlertSummary(pdClient *pd.Client, ctx context.Context, serviceID string) error {
+
+	fmt.Println()
+	fmt.Println("============================================================")
+	fmt.Println("Historical Pagerduty Alert Summary")
+	fmt.Println("============================================================")
+	fmt.Printf("Link to PD Service: https://redhat.pagerduty.com/service-directory/%s\n", serviceID)
+
+	var currentOffset uint
+	var limit uint = 100
+	var incidents []pd.Incident
+	print("\nPulling historical pd data")
+	for currentOffset = 0; true; currentOffset += limit {
+		print(".")
+		// pd defaults pulling the past month of data, which is enough for us to work with
+		liResponse, err := pdClient.ListIncidentsWithContext(
+			ctx,
+			pd.ListIncidentsOptions{
+				ServiceIDs: []string{serviceID},
+				Statuses:   []string{"resolved", "triggered", "acknowledged"},
+				Offset:     currentOffset,
+				Limit:      limit,
+				SortBy:     "created_at:desc",
+			},
+		)
+
+		if err != nil {
+			return err
+		}
+
+		if len(liResponse.Incidents) == 0 {
+			break
+		}
+
+		incidents = append(incidents, liResponse.Incidents...)
+	}
+	println()
+
+	incidentCounter := make(map[string]int)
+
+	table := printer.NewTablePrinter(os.Stdout, 20, 1, 3, ' ')
+	table.AddRow([]string{"Type", "Count"})
+
+	var incidentKeys []string
+	for _, incident := range incidents {
+		title := strings.Split(incident.Title, " ")[0]
+		incidentCounter[title]++
+		if !slices.Contains(incidentKeys, title) {
+			incidentKeys = append(incidentKeys, title)
+		}
+	}
+
+	sort.SliceStable(incidentKeys, func(i, j int) bool {
+		return incidentCounter[incidentKeys[i]] > incidentCounter[incidentKeys[j]]
+	})
+
+	for _, k := range incidentKeys {
+		table.AddRow([]string{k, strconv.Itoa(incidentCounter[k])})
+	}
+
+	// Add empty row for readability
+	table.AddRow([]string{})
+	err := table.Flush()
+	if err != nil {
+		fmt.Println("error while flushing table: ", err.Error())
+		return err
+	}
+
+	totalIncidents := len(incidents)
+	oldestIncidentTimestamp, err := time.Parse(time.RFC3339, incidents[totalIncidents-1].CreatedAt)
+	if err != nil {
+		fmt.Printf("Failed to parse time %q\n", err)
+		return err
+	}
+	oldestIncidentTimeInDays := int(time.Since(oldestIncidentTimestamp).Hours() / 24)
+	fmt.Println("Total number of incidents [", totalIncidents, "] in [", oldestIncidentTimeInDays, "] days")
+
+	return nil
+}
+
+func (o *contextOptions) printPDAlerts() error {
+
+	pdClient, err := GetPagerdutyClient(o.oauthtoken)
+	if err != nil {
+		fmt.Println("error getting pd client: ", err.Error())
+		return err
+	}
+
+	ctx := context.TODO()
+	serviceID, err := getPDSeviceID(pdClient, ctx, o.baseDomain)
+	if err != nil {
+		fmt.Println("error getting pd service id: ", err.Error())
+		return err
+	}
+
+	err = printCurrentPDAlerts(pdClient, ctx, serviceID)
+	if err != nil {
+		fmt.Println("error calling printCurrentPDAlerts: ", err.Error())
+		return err
+	}
+
+	err = printHistoricalPDAlertSummary(pdClient, ctx, serviceID)
+	if err != nil {
+		fmt.Println("error calling printHistoricalPDAlertSummary: ", err.Error())
+		return err
+	}
+
+	return nil
 }
 
 func (o *contextOptions) printOtherLinks() error {
@@ -329,7 +442,7 @@ func (o *contextOptions) printCloudTrailLogs() error {
 	foundEvents := []*cloudtrail.Event{}
 	var eventSearchInput = cloudtrail.LookupEventsInput{}
 
-	println("Pulling and filtering the past 40 pages of Cloudtrail data")
+	fmt.Println("Pulling and filtering the past 40 pages of Cloudtrail data")
 	for counter := 0; counter <= 40; counter++ {
 		print(".")
 		cloudTrailEvents, err := awsJumpClient.LookupEvents(&eventSearchInput)


### PR DESCRIPTION
Added PD Summary  to provide 'at a glance' overview of the types of alerts triggered by cluster in the past ~30 days
Example:
```
============================================================
Historical Pagerduty Alert Summary
============================================================
Link to PD Service: https://redhat.pagerduty.com/service-directory/ABC

Pulling historical pd data............
Type                                              Count               Last Occurrence
TargetDown                                        222                 2022-10-11T22:28:51Z
KubePodCrashLooping                               185                 2022-10-11T23:26:00Z
PrometheusMissingRuleEvaluations                  134                 2022-10-11T09:16:38Z
NodeProxyApplySlow                                103                 2022-10-11T20:39:14Z
KubeDeploymentReplicasMismatch                    75                  2022-10-11T22:28:48Z
KubeJobFailed                                     49                  2022-10-12T08:12:45Z
etcdGRPCRequestsSlow                              26                  2022-10-11T18:44:39Z
etcdMemberCommunicationSlow                       25                  2022-10-11T18:38:04Z
SDNPodNotReady                                    23                  2022-10-11T19:25:44Z
api-ErrorBudgetBurn                               20                  2022-10-11T19:57:44Z
ThanosRuleHighRuleEvaluationFailures              19                  2022-10-11T21:23:15Z
console-ErrorBudgetBurn                           16                  2022-10-11T19:57:22Z
KubeClientErrors                                  15                  2022-10-11T20:12:33Z
ClusterOperatorDown                               14                  2022-10-11T20:07:35Z
PodDisruptionBudgetLimit                          12                  2022-10-11T20:12:58Z
KubeletHealthState                                11                  2022-10-11T12:06:30Z
KubeStatefulSetReplicasMismatch                   10                  2022-10-11T20:15:29Z
etcdExcessiveDatabaseGrowth                       8                   2022-10-11T22:18:04Z
PrometheusOperatorNotReady                        8                   2022-10-11T20:02:09Z
KubePodNotReady                                   8                   2022-10-11T15:57:29Z
MNMOTooManyReconcileErrors15MinSRE                8                   2022-10-02T09:14:56Z
KubeJobCompletion                                 7                   2022-10-12T07:57:30Z
etcdNoLeader                                      7                   2022-10-11T18:36:04Z
PrometheusErrorSendingAlertsToSomeAlertmanagers   7                   2022-10-11T18:29:38Z
MachineNotYetDeleted                              6                   2022-10-11T19:57:31Z
KubeContainerWaiting                              6                   2022-10-11T15:42:30Z
etcdMembersDown                                   4                   2022-10-11T17:05:04Z
ClusterOperatorDegraded                           3                   2022-10-11T20:52:36Z
etcdHighCommitDurations                           3                   2022-10-11T18:45:34Z
KubeNodeUnschedulableSRE                          3                   2022-10-11T14:45:23Z
ThanosQueryHighDNSFailures                        2                   2022-10-11T18:27:47Z
ThanosQueryGrpcClientErrorRate                    2                   2022-10-08T11:17:45Z
PodDisruptionBudgetAtLimit                        2                   2022-10-08T11:07:28Z
etcdHighNumberOfFailedGRPCRequests                2                   2022-09-20T03:10:48Z
etcdInsufficientMembers                           1                   2022-10-11T17:04:48Z
KubeAPIErrorBudgetBurn                            1                   2022-10-09T01:29:56Z
CsvAbnormalFailedOver2Min                         1                   2022-10-09T01:01:14Z
CSRPendingLongDurationSRE                         1                   2022-09-20T18:40:51Z

Total number of incidents [ 1049 ] in [ 29 ] days
```