### PR TITLE
Make use of transferOwner and loggingCheck commands consistent

### DIFF
--- a/cmd/cluster/loggingcheck.go
+++ b/cmd/cluster/loggingcheck.go
@@ -30,7 +30,7 @@ type loggingCheckOptions struct {
 func newCmdLoggingCheck(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	ops := newloggingCheckOptions(streams, flags, globalOpts)
 	loggingCheckCmd := &cobra.Command{
-		Use:               "loggingCheck",
+		Use:               "logging-check",
 		Short:             "Shows the logging support status of a specified cluster",
 		Args:              cobra.ExactArgs(1),
 		DisableAutoGenTag: true,

--- a/cmd/cluster/transferowner.go
+++ b/cmd/cluster/transferowner.go
@@ -32,7 +32,7 @@ type transferOwnerOptions struct {
 func newCmdTransferOwner(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	ops := newTransferOwnerOptions(streams, flags, globalOpts)
 	transferOwnerCmd := &cobra.Command{
-		Use:               "transferOwner",
+		Use:               "transfer-owner",
 		Short:             "Transfer cluster ownership to a new user (to be done by Region Lead)",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,


### PR DESCRIPTION
Why? 
All commands in `osdctl` use kebab-case, transferOwner and loggingCheck are the only two commands using camelCase. Changed for consistency.

PR to reflect this in ops-sop is created and on hold until release:
https://github.com/openshift/ops-sop/pull/2203
