### PR TITLE
Add lint step to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export PATH:=$(BASE_DIR)/bin:$(PATH)
 SHELL := env PATH=$(PATH) /bin/bash
 
 
-all: format mod build test
+all: format mod build test lint
 
 format: vet mod fmt mockgen ci-build docs
 
@@ -59,3 +59,6 @@ ensure-mockgen:
 
 test:
 	go test ${BUILDFLAGS} ./... -covermode=atomic -coverpkg=./...
+
+lint:
+	golangci-lint run


### PR DESCRIPTION
**Why?:** Linting is essential to keep up code quality, with this PR linting is added to the `make all` target.

**What?:** Add a lint target to the makefile