### PR TITLE
Update verifier deps to pull latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/openshift/gcp-project-operator v0.0.0-20220920194256-df38e31387a7
 	github.com/openshift/hive v1.1.17-0.20220921183516-849ebe80fa61
 	github.com/openshift/hive/apis v0.0.0
-	github.com/openshift/osd-network-verifier v0.0.0-20221004143407-ffba9f3c9174
+	github.com/openshift/osd-network-verifier v0.0.0-20221013153547-6e1f127c37ee
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1431,8 +1431,8 @@ github.com/openshift/machine-api-operator v0.2.1-0.20220331125846-eb5fce743ada/g
 github.com/openshift/machine-api-operator v0.2.1-0.20220601192856-d7fb6b5b87ef/go.mod h1:FBgKM8rkLjF2V6ZfvvscpUSFsdXzEOFAiKccqjkxgBg=
 github.com/openshift/machine-api-provider-gcp v0.0.0/go.mod h1:lgTHPL+8qZt/bvkrkxYXroErVmFy4gXn/BhidMI6FQs=
 github.com/openshift/machine-config-operator v0.0.0/go.mod h1:4IzikyGmUVQwlohScKeaAr5n2YzcWXkZvTMGGxDcU2Q=
-github.com/openshift/osd-network-verifier v0.0.0-20221004143407-ffba9f3c9174 h1:qOFmw8e7tMfcSqd34N8+TEPMzJknIE5qdD7ELljE6CU=
-github.com/openshift/osd-network-verifier v0.0.0-20221004143407-ffba9f3c9174/go.mod h1:5oWqXBqQO4+Y1/9EdM/dIaH5sx8SdOtK2cXMIIGUmwc=
+github.com/openshift/osd-network-verifier v0.0.0-20221013153547-6e1f127c37ee h1:WWKPHHCer7cyBrkrxpSmfQr7Mvo6HRrnFG+Iyf+rOXA=
+github.com/openshift/osd-network-verifier v0.0.0-20221013153547-6e1f127c37ee/go.mod h1:5oWqXBqQO4+Y1/9EdM/dIaH5sx8SdOtK2cXMIIGUmwc=
 github.com/openshift/rosa v1.2.5/go.mod h1:4cCAxzdFLlOMRAELN//oWG75iPwoPowg5NzekCYqNVU=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=


### PR DESCRIPTION
This version of the verifier removes the use of Public IP addresses on EC2 instances. Note, this will cause failures on the verifier if ran in a public subnet. This is know and expected, so the guidance is to only run the verifier on the private subnet. This should still allow for verification of egress for clusters since all instances in a cluster run in the private subnets. 