### PR TITLE
Update the verifier dependency to use v0.1.0

### DIFF
--- a/cmd/network/verification.go
+++ b/cmd/network/verification.go
@@ -57,7 +57,7 @@ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (also AWS_SESSION_TOKEN for STS credent
 are set correctly before execution.
 
 # Verify that essential openshift domains are reachable from a given SUBNET_ID
-osdctl network verify-egress --subnet-id $(SUBNET_ID) --region $(AWS_REGION)`,
+osdctl network verify-egress --subnet-id $(SUBNET_ID) --security-group $(SECURITY_GROUP) --region $(AWS_REGION)`,
 		Run: func(cmd *cobra.Command, args []string) {
 			runEgressTest(config)
 		},
@@ -72,7 +72,7 @@ osdctl network verify-egress --subnet-id $(SUBNET_ID) --region $(AWS_REGION)`,
 	validateEgressCmd.Flags().DurationVar(&config.timeout, "timeout", 1*time.Second, "(optional) timeout for individual egress verification requests")
 	validateEgressCmd.Flags().StringVar(&config.kmsKeyID, "kms-key-id", "", "(optional) ID of KMS key used to encrypt root volumes of compute instances. Defaults to cloud account default key")
 	validateEgressCmd.Flags().StringVarP(&config.awsProfile, "profile", "p", "", "(optional) AWS Profile")
-	validateEgressCmd.Flags().StringVar(&config.securityGroupId, "security-group", "", "(optional) Security group to use for EC2 instance")
+	validateEgressCmd.Flags().StringVar(&config.securityGroupId, "security-group", "", "Security group to use for EC2 instance")
 	validateEgressCmd.Flags().StringVar(&config.httpProxy, "http-proxy", "", "(optional) http-proxy to be used upon http requests being made by verifier, format: http://user:pass@x.x.x.x:8978")
 	validateEgressCmd.Flags().StringVar(&config.httpsProxy, "https-proxy", "", "(optional) https-proxy to be used upon https requests being made by verifier, format: https://user:pass@x.x.x.x:8978")
 	validateEgressCmd.Flags().StringVar(&config.CaCert, "cacert", "", "(optional) path to cacert file to be used upon https requests being made by verifier")
@@ -80,7 +80,9 @@ osdctl network verify-egress --subnet-id $(SUBNET_ID) --region $(AWS_REGION)`,
 
 	if err := validateEgressCmd.MarkFlagRequired("subnet-id"); err != nil {
 		validateEgressCmd.PrintErr(err)
-		os.Exit(1)
+	}
+	if err := validateEgressCmd.MarkFlagRequired("security-group"); err != nil {
+		validateEgressCmd.PrintErr(err)
 	}
 
 	return validateEgressCmd

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/openshift/gcp-project-operator v0.0.0-20220920194256-df38e31387a7
 	github.com/openshift/hive v1.1.17-0.20220921183516-849ebe80fa61
 	github.com/openshift/hive/apis v0.0.0
-	github.com/openshift/osd-network-verifier v0.0.0-20221013153547-6e1f127c37ee
+	github.com/openshift/osd-network-verifier v0.1.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1431,8 +1431,8 @@ github.com/openshift/machine-api-operator v0.2.1-0.20220331125846-eb5fce743ada/g
 github.com/openshift/machine-api-operator v0.2.1-0.20220601192856-d7fb6b5b87ef/go.mod h1:FBgKM8rkLjF2V6ZfvvscpUSFsdXzEOFAiKccqjkxgBg=
 github.com/openshift/machine-api-provider-gcp v0.0.0/go.mod h1:lgTHPL+8qZt/bvkrkxYXroErVmFy4gXn/BhidMI6FQs=
 github.com/openshift/machine-config-operator v0.0.0/go.mod h1:4IzikyGmUVQwlohScKeaAr5n2YzcWXkZvTMGGxDcU2Q=
-github.com/openshift/osd-network-verifier v0.0.0-20221013153547-6e1f127c37ee h1:WWKPHHCer7cyBrkrxpSmfQr7Mvo6HRrnFG+Iyf+rOXA=
-github.com/openshift/osd-network-verifier v0.0.0-20221013153547-6e1f127c37ee/go.mod h1:5oWqXBqQO4+Y1/9EdM/dIaH5sx8SdOtK2cXMIIGUmwc=
+github.com/openshift/osd-network-verifier v0.1.0 h1:vwAFR7j/ZeGLn6rSCUJC7rCbcUm2JCRwMBkJ7qvRzKw=
+github.com/openshift/osd-network-verifier v0.1.0/go.mod h1:5oWqXBqQO4+Y1/9EdM/dIaH5sx8SdOtK2cXMIIGUmwc=
 github.com/openshift/rosa v1.2.5/go.mod h1:4cCAxzdFLlOMRAELN//oWG75iPwoPowg5NzekCYqNVU=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=


### PR DESCRIPTION
Updates the verifier to use the released version v0.1.0. With the current level of support permissions SRE have running this as a diagnostic tool, a security group is now required to run the verifier. In the short term, the SRE (or integration) running this command will need to find the ID of the security group that the installer creates for the worker nodes. Long term, I expect this to be refactored to try and find the right security group ID when none is provided. 