### PR TITLE
Improve documentation and helptext around osdctl cluster cpd

### DIFF
--- a/pkg/osdCloud/aws.go
+++ b/pkg/osdCloud/aws.go
@@ -305,6 +305,9 @@ func GenerateNonCCSClusterAWSClient(ocmClient *sdk.Connection, awsClient aws.Cli
 	return awsClientNonCCS, nil
 }
 
+// GenerateAWSClientForCluster generates an AWS client given an OCM cluster id and AWS profile name.
+// If an AWS profile name is not specified, this function will also read the AWS_PROFILE environment
+// variable or use the default AWS profile.
 func GenerateAWSClientForCluster(awsProfile string, clusterID string) (aws.Client, error) {
 
 	ocmClient := utils.CreateConnection()


### PR DESCRIPTION
The help now looks like this (omitted global flags for brevity):

```
❯ osdctl cluster cpd -h

Helps investigate OSD/ROSA cluster provisioning delays (CPD) or failures

  This command only supports AWS at the moment and will:
	
  * Check the cluster's dnszone.hive.openshift.io custom resource
  * Check whether a known OCM error code and message has been shared with the customer already
  * Check that the cluster's VPC and/or subnet route table(s) contain a route for 0.0.0.0/0 if it's BYOVPC

Usage:
  osdctl cluster cpd [flags]

Examples:

  # Investigate a CPD for a cluster using an AWS profile named "rhcontrol"
  osdctl cluster cpd --cluster-id 1kfmyclusteristhebesteverp8m --profile rhcontrol


Flags:
  -C, --cluster-id string   The internal (OCM) Cluster ID
  -h, --help                help for cpd
  -p, --profile string      AWS profile name
```

Added an escape hatch when a cluster's already provisioned:

```
❯ osdctl cluster cpd -C ${some already provisioned cluster} --profile rhcontrol
This cluster is in a ready state and already provisioned

# Old behavior (ProvisionErrorCode is "")
❯ osdctl cluster cpd -C ${some already provisioned cluster} --profile rhcontrol
Error code  is known, customer already received Service Log
Next step: check the AWS reources manually, run ocm backplane cloud console
```