### PR TITLE
Resovle issue for finding config path of Mac

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.17
 
 require (
 	github.com/PagerDuty/go-pagerduty v1.5.1
-	github.com/adrg/xdg v0.4.0
 	github.com/aws/aws-sdk-go v1.44.66
 	github.com/coreos/go-semver v0.3.0
 	github.com/deckarep/golang-set v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,6 @@ github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
-github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
-github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -2205,7 +2203,6 @@ golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/osdctlConfig/osdctlConfig.go
+++ b/pkg/osdctlConfig/osdctlConfig.go
@@ -2,32 +2,22 @@ package osdctlConfig
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
-	"github.com/adrg/xdg"
 	"github.com/spf13/viper"
 )
 
 const (
 	ConfigFileName = "osdctl"
-	ConfifFilePath = "~/.config"
 )
 
-// Generates the config file path for osdctl config
-func generateConfigFilePath() (string, error) {
-	configFilePath, err := xdg.ConfigFile(ConfigFileName)
-	if err != nil {
-		return "", err
-	}
-	return configFilePath, nil
-}
-
 func EnsureConfigFile() error {
-	configFilePath, err := generateConfigFilePath()
+	configPath, err := os.UserHomeDir()
 	if err != nil {
 		return err
 	}
-
+	configFilePath := configPath + "/.config/" + ConfigFileName
 	if _, err := os.Stat(configFilePath); errors.Is(err, os.ErrNotExist) {
 		_, err = os.Create(configFilePath)
 		if err != nil {
@@ -40,7 +30,8 @@ func EnsureConfigFile() error {
 
 	if err := viper.ReadInConfig(); err != nil {
 		return err
+	} else {
+		fmt.Println("Reading config file from " + configFilePath)
 	}
-
-	return err
+	return nil
 }

--- a/pkg/osdctlConfig/osdctlConfig.go
+++ b/pkg/osdctlConfig/osdctlConfig.go
@@ -2,7 +2,6 @@ package osdctlConfig
 
 import (
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/spf13/viper"
@@ -13,11 +12,11 @@ const (
 )
 
 func EnsureConfigFile() error {
-	configPath, err := os.UserHomeDir()
+	configHomePath, err := os.UserHomeDir()
 	if err != nil {
 		return err
 	}
-	configFilePath := configPath + "/.config/" + ConfigFileName
+	configFilePath := configHomePath + "/.config/" + ConfigFileName
 	if _, err := os.Stat(configFilePath); errors.Is(err, os.ErrNotExist) {
 		_, err = os.Create(configFilePath)
 		if err != nil {
@@ -30,8 +29,6 @@ func EnsureConfigFile() error {
 
 	if err := viper.ReadInConfig(); err != nil {
 		return err
-	} else {
-		fmt.Println("Reading config file from " + configFilePath)
 	}
 	return nil
 }


### PR DESCRIPTION
Keeps getting the error of finding the config file while already put into `~/.config/osdctl`. After reading the [xdg](https://github.com/OpenPeeDeeP/xdg#locations-per-os) doc, the path for `xdg.ConfigFile` would be different for Linux and macOS.
Provide a fix so that it will support all os types.