### PR TITLE
Add version protection when running a command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,7 @@ builds:
       # See also: https://pkg.go.dev/cmd/link
       - -s
       - -w
-      - -X github.com/openshift/osdctl/cmd.Version={{.Version}}
+      - -X github.com/openshift/osdctl/pkg/utils.Version={{.Version}}
       - "-extldflags=-zrelro" # binary hardening: For further explanation look here: https://www.redhat.com/en/blog/hardening-elf-binaries-using-relocation-read-only-relro
       - "-extldflags=-znow"
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-semver/semver"
+	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -29,12 +30,12 @@ func upgrade(cmd *cobra.Command, args []string) error {
 	// between releases :-)
 	rootName := cmd.Root().Name()
 
-	latest, err := getLatestVersion()
+	latest, err := utils.GetLatestVersion()
 	if err != nil {
 		return err
 	}
 	latestWithoutPrefix := strings.TrimPrefix(latest, "v")
-	currentSemVer := semver.New(Version)
+	currentSemVer := semver.New(utils.Version)
 	latestSemVer := semver.New(latestWithoutPrefix)
 	if !currentSemVer.LessThan(*latestSemVer) {
 		fmt.Println("Already up to date, nothing to do!")
@@ -45,7 +46,7 @@ func upgrade(cmd *cobra.Command, args []string) error {
 		Timeout: time.Second * 60,
 	}
 
-	addr := fmt.Sprintf(versionAddressTemplate,
+	addr := fmt.Sprintf(utils.VersionAddressTemplate,
 		latestWithoutPrefix,
 		latestWithoutPrefix,
 		parseGOOS(runtime.GOOS),

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,32 +3,12 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"runtime/debug"
 	"strings"
-	"time"
 
+	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
 )
-
-const (
-	versionAPIEndpoint     = "https://api.github.com/repos/openshift/osdctl/releases/latest"
-	versionAddressTemplate = "https://github.com/openshift/osdctl/releases/download/v%s/osdctl_%s_%s_%s.tar.gz" // version, version, GOOS, GOARCH
-)
-
-var (
-	// Version is the tag version from the environment
-	// Will be set during build process via GoReleaser
-	// See also: https://pkg.go.dev/cmd/link
-	Version string
-)
-
-// githubResponse is a necessary struct for the JSON unmarshalling that is happening
-// in the getLatestVersion().
-type gitHubResponse struct {
-	TagName string `json:"tag_name"`
-}
 
 // versionResponse is necessary for the JSON version response. It uses the three
 // variables that get set during the build.
@@ -59,10 +39,10 @@ func version(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	latest, _ := getLatestVersion() // let's ignore this error, just in case we have no internet access
+	latest, _ := utils.GetLatestVersion() // let's ignore this error, just in case we have no internet access
 	ver, err := json.MarshalIndent(&versionResponse{
 		Commit:  gitCommit,
-		Version: Version,
+		Version: utils.Version,
 		Latest:  strings.TrimPrefix(latest, "v"),
 	}, "", "  ")
 	if err != nil {
@@ -70,36 +50,4 @@ func version(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Println(string(ver))
 	return nil
-}
-
-// getLatestVersion connects to the GitHub API and returns the latest osdctl tag name
-// Interesting Note: GitHub only shows the latest "stable" tag. This means, that
-// tags with a suffix like *-rc.1 are not returned. We will always show the latest stable on master branch.
-func getLatestVersion() (latest string, err error) {
-	client := http.Client{
-		Timeout: time.Second * 2,
-	}
-
-	req, err := http.NewRequest(http.MethodGet, versionAPIEndpoint, nil)
-	if err != nil {
-		return latest, err
-	}
-
-	res, err := client.Do(req)
-	if err != nil {
-		return latest, err
-	}
-
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return latest, err
-	}
-
-	githubResp := gitHubResponse{}
-	err = json.Unmarshal(body, &githubResp)
-	if err != nil {
-		return latest, err
-	}
-
-	return githubResp.TagName, nil
 }

--- a/main.go
+++ b/main.go
@@ -4,9 +4,11 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/openshift/osdctl/cmd"
 	"github.com/openshift/osdctl/pkg/osdctlConfig"
+	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/pflag"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -18,6 +20,31 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 		return
+	}
+
+	latestVersion, err := utils.GetLatestVersion()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	if utils.Version != latestVersion {
+		fmt.Println("The current version is different than the latest version.")
+		fmt.Println("It is recommended that you update to the latest version to ensure that no known bugs or issues are hit.")
+		fmt.Println("Please confirm that you would like to continute with [y|n]")
+
+		var input string
+		for {
+			fmt.Scanln(&input)
+			if strings.ToLower(input) == "y" {
+				break
+			}
+			if strings.ToLower(input) == "n" {
+				fmt.Println("Exiting")
+				return
+			}
+			fmt.Println("Input not recognized. Please select [y|n]")
+		}
 	}
 
 	flags := pflag.NewFlagSet("osdctl", pflag.ExitOnError)

--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	VersionAPIEndpoint     = "https://api.github.com/repos/openshift/osdctl/releases/latest"
+	VersionAddressTemplate = "https://github.com/openshift/osdctl/releases/download/v%s/osdctl_%s_%s_%s.tar.gz" // version, version, GOOS, GOARCH
+)
+
+var (
+	// GitCommit is the short git commit hash from the environment
+	// Will be set during build process via GoReleaser
+	// See also: https://pkg.go.dev/cmd/link
+	GitCommit string
+
+	// Version is the tag version from the environment
+	// Will be set during build process via GoReleaser
+	// See also: https://pkg.go.dev/cmd/link
+	Version string
+)
+
+// githubResponse is a necessary struct for the JSON unmarshalling that is happening
+// in the getLatestVersion().
+type gitHubResponse struct {
+	TagName string `json:"tag_name"`
+}
+
+// getLatestVersion connects to the GitHub API and returns the latest osdctl tag name
+// Interesting Note: GitHub only shows the latest "stable" tag. This means, that
+// tags with a suffix like *-rc.1 are not returned. We will always show the latest stable on master branch.
+func GetLatestVersion() (latest string, err error) {
+	client := http.Client{
+		Timeout: time.Second * 2,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, VersionAPIEndpoint, nil)
+	if err != nil {
+		return latest, err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return latest, err
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return latest, err
+	}
+
+	githubResp := gitHubResponse{}
+	err = json.Unmarshal(body, &githubResp)
+	if err != nil {
+		return latest, err
+	}
+
+	return githubResp.TagName, nil
+}


### PR DESCRIPTION
To ensure that a user isn't accidentally running an outdated version of osdctl, this PR adds a check to compare the current version of the ran binary with the latest tagged version released on GitHub. If the versions don't match, then the user is prompted to check if they want to explicitly run the binary or not. This should help protect the user from accidentally running an outdated or development versions of osdctl commands. 

I added the WIP tag to allow for further discussion 