### PR TITLE
Fixes segfault when a route isn't using a CIDR block as its target

### DIFF
--- a/cmd/cluster/cpd.go
+++ b/cmd/cluster/cpd.go
@@ -182,9 +182,13 @@ func isSubnetRouteValid(awsClient aws.Client, subnetID string) (bool, error) {
 	}
 
 	for _, route := range describeRouteTablesOutput.RouteTables[0].Routes {
-		if *route.DestinationCidrBlock == "0.0.0.0/0" {
-			return true, nil
+		// Some routes don't use CIDR blocks as targets, so this needs to be checked
+		if route.DestinationCidrBlock != nil {
+			if *route.DestinationCidrBlock == "0.0.0.0/0" {
+				return true, nil
+			}
 		}
+
 	}
 
 	return false, fmt.Errorf("no default route exists to the internet in subnet %v", subnetID)


### PR DESCRIPTION
Some routes don't use a CIDR block as its target, which causes the current code to segfault as it assumes the field is present for each route. This code fixes the issue by checking that the field is non nil before accessing it. 