### PR TITLE
recommend the correct command for the network verifier

### DIFF
--- a/cmd/cluster/cpd.go
+++ b/cmd/cluster/cpd.go
@@ -118,7 +118,7 @@ func (o *cpdOptions) run() error {
 				return err
 			}
 		}
-		fmt.Println("Next step: run the verifier egress test: osd-network-verifier egress --region ${CLUSTER_REGION} --subnet-id ${SUBNET_ID} --security-group ${SECURITY_GROUP_ID}")
+		fmt.Println("Next step: run the verifier egress test: osdctl network verify-egress --region ${CLUSTER_REGION} --subnet-id ${SUBNET_ID} --security-group ${SECURITY_GROUP_ID}")
 		return nil
 	}
 


### PR DESCRIPTION
since the network verifier is part of osdctl, the output of `osdctl cluster cpd` should give the command to run it from here instead of the standalone command