### PR TITLE
Improve internal servicelog template summary

### DIFF
--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -253,7 +253,7 @@ func readTemplate() {
 		{
 			"severity": "Info",
 			"service_name": "SREManualAction",
-			"summary": "INTERNAL",
+			"summary": "INTERNAL ONLY, DO NOT SHARE WITH CUSTOMER",
 			"description": "${MESSAGE}",
 			"internal_only": true
 		}


### PR DESCRIPTION
Improving internal servicelog summary so that the message is not shared with the customer directly.

Built and tested on a cluster, works ok.