### PR TITLE
If .config dir doesn't exist, create it

### DIFF
--- a/pkg/osdctlConfig/osdctlConfig.go
+++ b/pkg/osdctlConfig/osdctlConfig.go
@@ -16,8 +16,13 @@ func EnsureConfigFile() error {
 	if err != nil {
 		return err
 	}
-	configFilePath := configHomePath + "/.config/" + ConfigFileName
+	configFileDir := configHomePath + "/.config/"
+	configFilePath := configFileDir + ConfigFileName
 	if _, err := os.Stat(configFilePath); errors.Is(err, os.ErrNotExist) {
+		err = os.MkdirAll(configFileDir, 0755)
+		if err != nil {
+			return err
+		}
 		_, err = os.Create(configFilePath)
 		if err != nil {
 			return err


### PR DESCRIPTION
The requirement that this directory exist was causing issues in certain environments. This handles creating if it doesn't exist.