### PR TITLE
Better handling of edge cases around default routes

### DIFF
--- a/cmd/cluster/cpd.go
+++ b/cmd/cluster/cpd.go
@@ -87,8 +87,7 @@ func (o *cpdOptions) run() error {
 	fmt.Println("Checking if cluster is GCP")
 	// If the cluster is GCP, give instructions on how to get console access
 	if cluster.CloudProvider().ID() == "gcp" {
-		fmt.Printf("This command doesn't support GCP yet. Needs manual investigation\n Get the project ID from this command on hive: oc getprojectclaim -n uhc-production-$CLUSTER_INT_ID\nThen use this URL to access the GCP console: https://console.cloud.google.com/home/dashboard?project=${GCP_PROJECT_ID}\n")
-		return nil
+		return fmt.Errorf("this command doesn't support GCP yet. Needs manual investigation:\nocm backplane cloud console -b %s", o.clusterID)
 	}
 
 	fmt.Println("Generating AWS credentials for cluster")

--- a/cmd/cluster/cpd.go
+++ b/cmd/cluster/cpd.go
@@ -48,34 +48,31 @@ func newCmdCpd() *cobra.Command {
 			cmdutil.CheckErr(ops.run())
 		},
 	}
-	cpdCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", ops.clusterID, "The internal (OCM) Cluster ID")
+	cpdCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", ops.clusterID, "The internal/external (OCM) Cluster ID")
 	cpdCmd.Flags().StringVarP(&ops.awsProfile, "profile", "p", ops.awsProfile, "AWS profile name")
 
 	return cpdCmd
 }
 
 func (o *cpdOptions) run() error {
-
 	// Get the cluster info
 	ocmClient := utils.CreateConnection()
+	defer ocmClient.Close()
 
-	// TODO: This currently only supports the internal OCM ID
-	resp, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(o.clusterID).Get().Send()
+	cluster, err := utils.GetClusterAnyStatus(ocmClient, o.clusterID)
 	if err != nil {
 		return err
 	}
 
-	clusterInfo := resp.Body()
-
 	fmt.Println("Checking if cluster has become ready")
-	if clusterInfo.Status().State() == "ready" {
+	if cluster.Status().State() == "ready" {
 		fmt.Printf("This cluster is in a ready state and already provisioned")
 		return nil
 	}
 
 	fmt.Println("Checking if cluster DNS is ready")
 	// Check if DNS is ready, exit out if not
-	if !clusterInfo.Status().DNSReady() {
+	if !cluster.Status().DNSReady() {
 		fmt.Println("DNS not ready. Investigate reasons using the dnszones CR in the cluster namespace:")
 		fmt.Printf("oc get dnszones -n uhc-production-%s -o yaml --as backplane-cluster-admin\n", o.clusterID)
 		return nil
@@ -83,13 +80,13 @@ func (o *cpdOptions) run() error {
 
 	fmt.Println("Checking if OCM error code is already known")
 	// Check if the OCM Error code is a known error
-	if clusterInfo.Status().ProvisionErrorCode() != unknownProvisionCode {
-		fmt.Printf("Error code %s is known, customer already received Service Log\n", clusterInfo.Status().ProvisionErrorCode())
+	if cluster.Status().ProvisionErrorCode() != unknownProvisionCode {
+		fmt.Printf("Error code %s is known, customer already received Service Log\n", cluster.Status().ProvisionErrorCode())
 	}
 
 	fmt.Println("Checking if cluster is GCP")
 	// If the cluster is GCP, give instructions on how to get console access
-	if clusterInfo.CloudProvider().ID() == "gcp" {
+	if cluster.CloudProvider().ID() == "gcp" {
 		fmt.Printf("This command doesn't support GCP yet. Needs manual investigation\n Get the project ID from this command on hive: oc getprojectclaim -n uhc-production-$CLUSTER_INT_ID\nThen use this URL to access the GCP console: https://console.cloud.google.com/home/dashboard?project=${GCP_PROJECT_ID}\n")
 		return nil
 	}
@@ -105,17 +102,15 @@ func (o *cpdOptions) run() error {
 
 	// If the cluster is BYOVPC, check the route tables
 	// This check is copied from ocm-cli
-	if clusterInfo.AWS().SubnetIDs() != nil && len(clusterInfo.AWS().SubnetIDs()) > 0 {
+	if cluster.AWS().SubnetIDs() != nil && len(cluster.AWS().SubnetIDs()) > 0 {
 		fmt.Println("Checking BYOVPC to ensure subnets have valid routing")
-		for _, subnet := range clusterInfo.AWS().SubnetIDs() {
+		for _, subnet := range cluster.AWS().SubnetIDs() {
 			isValid, err := isSubnetRouteValid(awsClient, subnet)
 			if err != nil {
 				return err
 			}
 			if !isValid {
-				err := fmt.Errorf("subnet %v does not have valid routing. ", subnet)
-				fmt.Printf("%v\n Run the following to send a SerivceLog:\n osdctl servicelog post ${CLUSTER_EXT_ID} -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_NoRouteToInternet.json", err)
-				return err
+				return fmt.Errorf("subnet %s does not have a default route to 0.0.0.0/0\n Run the following to send a SerivceLog:\n osdctl servicelog post %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_NoRouteToInternet.json", subnet, o.clusterID)
 			}
 		}
 		fmt.Println("Next step: run the verifier egress test: osdctl network verify-egress --region ${CLUSTER_REGION} --subnet-id ${SUBNET_ID} --security-group ${SECURITY_GROUP_ID}")
@@ -128,10 +123,9 @@ func (o *cpdOptions) run() error {
 }
 
 func isSubnetRouteValid(awsClient aws.Client, subnetID string) (bool, error) {
-
 	var routeTable string
 
-	// Try and find a RouteTable with an association for the given subnet
+	// Try and find a Route Table associated with the given subnet
 	describeRouteTablesOutput, err := awsClient.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
 		Filters: []*ec2.Filter{
 			{
@@ -141,7 +135,7 @@ func isSubnetRouteValid(awsClient aws.Client, subnetID string) (bool, error) {
 		},
 	})
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to describe route tables associated to subnet %s: %w", subnetID, err)
 	}
 
 	// If there are no associated RouteTables, then the subnet uses the default RoutTable for the VPC
@@ -159,13 +153,13 @@ func isSubnetRouteValid(awsClient aws.Client, subnetID string) (bool, error) {
 
 		vpcID := *describeSubnetOutput.Subnets[0].VpcId
 
-		// Set the routetable to the default for the VPC
+		// Set the route table to the default for the VPC
 		routeTable, err = findDefaultRouteTableForVPC(awsClient, vpcID)
 		if err != nil {
 			return false, err
 		}
 	} else {
-		// Set the routetable to the one asscoiated with the subnet
+		// Set the route table to the one associated with the subnet
 		routeTable = *describeRouteTablesOutput.RouteTables[0].RouteTableId
 	}
 
@@ -178,25 +172,23 @@ func isSubnetRouteValid(awsClient aws.Client, subnetID string) (bool, error) {
 	}
 
 	if len(describeRouteTablesOutput.RouteTables) == 0 {
-		return false, fmt.Errorf("no routetables found for routetable id %v", routeTable)
+		// Shouldn't happen
+		return false, fmt.Errorf("no route tables found for route table id %v", routeTable)
 	}
 
 	for _, route := range describeRouteTablesOutput.RouteTables[0].Routes {
 		// Some routes don't use CIDR blocks as targets, so this needs to be checked
-		if route.DestinationCidrBlock != nil {
-			if *route.DestinationCidrBlock == "0.0.0.0/0" {
-				return true, nil
-			}
+		if route.DestinationCidrBlock != nil && *route.DestinationCidrBlock == "0.0.0.0/0" {
+			return true, nil
 		}
-
 	}
 
-	return false, fmt.Errorf("no default route exists to the internet in subnet %v", subnetID)
+	// We haven't found a default route to the internet, so this subnet has an invalid route table
+	return false, nil
 }
 
+// findDefaultRouteTableForVPC returns the AWS Route Table ID of the VPC's default Route Table
 func findDefaultRouteTableForVPC(awsClient aws.Client, vpcID string) (string, error) {
-
-	// Get all subnets in the VPC
 	describeRouteTablesOutput, err := awsClient.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
 		Filters: []*ec2.Filter{
 			{
@@ -206,7 +198,7 @@ func findDefaultRouteTableForVPC(awsClient aws.Client, vpcID string) (string, er
 		},
 	})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to describe route tables associated with vpc %s: %w", vpcID, err)
 	}
 
 	for _, rt := range describeRouteTablesOutput.RouteTables {
@@ -217,5 +209,5 @@ func findDefaultRouteTableForVPC(awsClient aws.Client, vpcID string) (string, er
 		}
 	}
 
-	return "", fmt.Errorf("no default routetable found for vpc %v", vpcID)
+	return "", fmt.Errorf("no default route table found for vpc: %s", vpcID)
 }

--- a/cmd/cluster/support/delete.go
+++ b/cmd/cluster/support/delete.go
@@ -130,8 +130,8 @@ func (o *deleteOptions) run() error {
 }
 
 // createDeleteRequest sets the delete API and returns a request
-//SDKConnection is an interface that is satisfied by the sdk.Connection and by our mock connection
-//this facilitates unit test and allow us to mock Post() and Delete() api calls
+// SDKConnection is an interface that is satisfied by the sdk.Connection and by our mock connection
+// this facilitates unit test and allow us to mock Post() and Delete() api calls
 func createDeleteRequest(ocmClient SDKConnection, cluster *v1.Cluster, reasonID string) (request *sdk.Request, err error) {
 
 	targetAPIPath := "/api/clusters_mgmt/v1/clusters/" + cluster.ID() + "/limited_support_reasons/" + reasonID

--- a/cmd/cluster/support/post.go
+++ b/cmd/cluster/support/post.go
@@ -162,8 +162,8 @@ func (o *postOptions) run() error {
 
 // createPostRequest create and populates the limited support post call
 // swagger code gen: https://api.openshift.com/?urls.primaryName=Clusters%20management%20service#/default/post_api_clusters_mgmt_v1_clusters__cluster_id__limited_support_reasons
-//SDKConnection is an interface that is satisfied by the sdk.Connection and by our mock connection
-//this facilitates unit test and allow us to mock Post() and Delete() api calls
+// SDKConnection is an interface that is satisfied by the sdk.Connection and by our mock connection
+// this facilitates unit test and allow us to mock Post() and Delete() api calls
 func createPostRequest(ocmClient SDKConnection, cluster *v1.Cluster) (request *sdk.Request, err error) {
 
 	targetAPIPath := "/api/clusters_mgmt/v1/clusters/" + cluster.ID() + "/limited_support_reasons"

--- a/cmd/cluster/support/sdkmock.go
+++ b/cmd/cluster/support/sdkmock.go
@@ -11,17 +11,17 @@ var (
 	Client SDKConnection
 )
 
-//sdk client structure
+// sdk client structure
 type MockClient struct {
 	//empty structure to satisfy interface
 }
 
-//Mock POST request to the API for unit tests
+// Mock POST request to the API for unit tests
 func (m *MockClient) Post() *sdk.Request {
 	return &sdk.Request{}
 }
 
-//Mock Delete request to the API for unit tests
+// Mock Delete request to the API for unit tests
 func (m *MockClient) Delete() *sdk.Request {
 	return &sdk.Request{}
 }

--- a/cmd/cluster/transferowner.go
+++ b/cmd/cluster/transferowner.go
@@ -363,7 +363,7 @@ type RegisterCluster struct {
 // fix is tracked in https://issues.redhat.com/browse/SDA-6652
 // after ocm-sdk is fixed this function can be cleaned up
 
-//re-register the cluster with CS with the new organization id
+// re-register the cluster with CS with the new organization id
 func createNewRegisterClusterRequest(ocm *sdk.Connection, externalClusterID string, subscriptionID string, organizationID string, consoleURL string, displayName string) (*sdk.Request, error) {
 
 	targetAPIPath := "/api/clusters_mgmt/v1/register_cluster"

--- a/cmd/cost/cost.go
+++ b/cmd/cost/cost.go
@@ -58,7 +58,7 @@ func newCostOptions(streams genericclioptions.IOStreams) *costOptions {
 	}
 }
 
-//Initiate AWS clients for Organizations and Cost Explorer services using, if given, credentials in flags, else, credentials in the environment
+// Initiate AWS clients for Organizations and Cost Explorer services using, if given, credentials in flags, else, credentials in the environment
 func (opsCost *costOptions) initAWSClients() (awsprovider.Client, error) {
 	//Initialize AWS clients
 	var (
@@ -82,7 +82,7 @@ func (opsCost *costOptions) initAWSClients() (awsprovider.Client, error) {
 	return awsClient, err
 }
 
-//Gets information regarding Organizational Unit
+// Gets information regarding Organizational Unit
 func getOU(org awsprovider.Client, OUid string) *organizations.OrganizationalUnit {
 	result, err := org.DescribeOrganizationalUnit(&organizations.DescribeOrganizationalUnitInput{
 		OrganizationalUnitId: aws.String(OUid),

--- a/cmd/cost/create.go
+++ b/cmd/cost/create.go
@@ -46,13 +46,13 @@ func newCmdCreate(streams genericclioptions.IOStreams) *cobra.Command {
 	return createCmd
 }
 
-//Store flag options for create command
+// Store flag options for create command
 type createOptions struct {
 	ou string
 	genericclioptions.IOStreams
 }
 
-//Create Cost Category for OU given as argument for -ou flag
+// Create Cost Category for OU given as argument for -ou flag
 func createCostCategory(OUid *string, OU *organizations.OrganizationalUnit, awsClient awsprovider.Client) error {
 	//Gets all (not only immediate) accounts under the given OU
 	accounts, err := getAccountsRecursive(OU, awsClient)

--- a/cmd/cost/get.go
+++ b/cmd/cost/get.go
@@ -68,7 +68,7 @@ func (o *getOptions) checkArgs(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-//Store flag options for get command
+// Store flag options for get command
 type getOptions struct {
 	ou        string
 	recursive bool
@@ -133,7 +133,7 @@ func (o *getOptions) run() error {
 	return nil
 }
 
-//Get account IDs of immediate accounts under given OU
+// Get account IDs of immediate accounts under given OU
 func getAccounts(OU *organizations.OrganizationalUnit, awsClient awsprovider.Client) ([]*string, error) {
 	var accountSlice []*string
 	var nextToken *string
@@ -161,7 +161,7 @@ func getAccounts(OU *organizations.OrganizationalUnit, awsClient awsprovider.Cli
 	return accountSlice, nil
 }
 
-//Get the account IDs of all (not only immediate) accounts under OU
+// Get the account IDs of all (not only immediate) accounts under OU
 func getAccountsRecursive(OU *organizations.OrganizationalUnit, awsClient awsprovider.Client) ([]*string, error) {
 	var accountsIDs []*string
 
@@ -185,7 +185,7 @@ func getAccountsRecursive(OU *organizations.OrganizationalUnit, awsClient awspro
 	return append(accountsIDs, accountsIDsOU...), nil
 }
 
-//Get immediate OUs (child nodes) directly under given OU
+// Get immediate OUs (child nodes) directly under given OU
 func getOUs(OU *organizations.OrganizationalUnit, awsClient awsprovider.Client) ([]*organizations.OrganizationalUnit, error) {
 	var OUSlice []*organizations.OrganizationalUnit
 	var nextToken *string
@@ -214,7 +214,7 @@ func getOUs(OU *organizations.OrganizationalUnit, awsClient awsprovider.Client) 
 	return OUSlice, nil
 }
 
-//Get the account IDs of all (not only immediate) accounts under OU
+// Get the account IDs of all (not only immediate) accounts under OU
 func getOUsRecursive(OU *organizations.OrganizationalUnit, awsClient awsprovider.Client) ([]*organizations.OrganizationalUnit, error) {
 	var OUs []*organizations.OrganizationalUnit
 
@@ -235,7 +235,7 @@ func getOUsRecursive(OU *organizations.OrganizationalUnit, awsClient awsprovider
 	return OUs, nil
 }
 
-//Get cost of given account
+// Get cost of given account
 func (o *getOptions) getAccountCost(accountID *string, unit *string, awsClient awsprovider.Client, cost *decimal.Decimal) error {
 
 	var start, end, granularity string
@@ -290,7 +290,7 @@ func (o *getOptions) getAccountCost(accountID *string, unit *string, awsClient a
 	return nil
 }
 
-//Get cost of given OU by aggregating costs of only immediate accounts under given OU
+// Get cost of given OU by aggregating costs of only immediate accounts under given OU
 func (o *getOptions) getOUCost(cost *decimal.Decimal, unit *string, OU *organizations.OrganizationalUnit, awsClient awsprovider.Client) error {
 	//Populate accounts
 	accounts, err := getAccounts(OU, awsClient)
@@ -308,7 +308,7 @@ func (o *getOptions) getOUCost(cost *decimal.Decimal, unit *string, OU *organiza
 	return nil
 }
 
-//Get cost of given OU by aggregating costs of all (including immediate) accounts under OU
+// Get cost of given OU by aggregating costs of all (including immediate) accounts under OU
 func (o *getOptions) getOUCostRecursive(cost *decimal.Decimal, unit *string, OU *organizations.OrganizationalUnit, awsClient awsprovider.Client) error {
 	//Populate OUs
 	OUs, err := getOUs(OU, awsClient)
@@ -331,7 +331,7 @@ func (o *getOptions) getOUCostRecursive(cost *decimal.Decimal, unit *string, OU 
 	return nil
 }
 
-//Get time period based on time flag
+// Get time period based on time flag
 func getTimePeriod(timePtr *string) (string, string) {
 
 	t := time.Now()

--- a/cmd/cost/list.go
+++ b/cmd/cost/list.go
@@ -66,7 +66,7 @@ func (o *listOptions) checkArgs(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-//Store flag options for get command
+// Store flag options for get command
 type listOptions struct {
 	ou     []string
 	time   string
@@ -159,7 +159,7 @@ func printHeader(ops *listOptions) {
 	}
 }
 
-//List the cost of each OU under given OU
+// List the cost of each OU under given OU
 func listCostsUnderOU(OU *organizations.OrganizationalUnit, awsClient awsprovider.Client, ops *listOptions) error {
 	OUs, err := getOUsRecursive(OU, awsClient)
 	if err != nil {

--- a/cmd/cost/reconcile.go
+++ b/cmd/cost/reconcile.go
@@ -44,7 +44,7 @@ func newCmdReconcile(streams genericclioptions.IOStreams) *cobra.Command {
 	return reconcileCmd
 }
 
-//Checks if there's a cost category for every OU. If not, creates the missing cost category. This should be ran every 24 hours.
+// Checks if there's a cost category for every OU. If not, creates the missing cost category. This should be ran every 24 hours.
 func reconcileCostCategories(OU *organizations.OrganizationalUnit, awsClient awsprovider.Client) error {
 	costCategoryCreated := false
 	costCategoriesSet := mapset.NewSet()


### PR DESCRIPTION
The older commit was the result of running `go fmt ./...`

Summary of the changes in the second commit:
- We weren't closing our OCM client connection
- Support of external ID (it's a minor thing since PagerDuty generally provides the internal ID for CPD)
- A bit more context on some of the errors
- Suggest `ocm backplane cloud console` for GCP clusters
- Return `false, nil` instead of `false, err` https://github.com/openshift/osdctl/pull/291/files#diff-8d546d74a081da0204b85af938301169de6c745e6df0e76c9d25397747e96edfL194-R186 when we finish validation of subnet route tables successfully, but determine that a configuration is invalid
- Fill in the cluster id when suggesting to send a service log. TODO it should just try to send on its own and ask for confirmation like normal.

Previously this would just return the contents of an error if no default route was found:
```
error: no default route exists to the internet in subnet subnet-057ae41a68a4924c6
```

Now it returns the intended message
```bash
❯ ./osdctl cluster cpd -C b9b236d4-7505-42b3-b221-f4bba6732013 --profile rhcontrol
Checking if cluster has become ready
Checking if cluster DNS is ready
Checking if OCM error code is already known
Checking if cluster is GCP
Generating AWS credentials for cluster
Checking BYOVPC to ensure subnets have valid routing
error: subnet subnet-057ae41a68a4924c6 does not have a default route to 0.0.0.0/0
 Run the following to send a SerivceLog:
 osdctl servicelog post b9b236d4-7505-42b3-b221-f4bba6732013 -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_NoRouteToInternet.json
```