### PR TITLE
Using Go 1.18's new and shiny features

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,13 +16,12 @@ builds:
       - amd64
       - arm64
     ldflags:
-      # the following line will inject the current git commit and git tag in the binary during the build process.
-      # .ShortCommit and .Version are template variables that will be set during the GoReleaser run
+      # the following line will inject the current git tag in the binary during the build process.
+      # .Version are template variables that will be set during the GoReleaser run
       # The "-X" go flag injects the strings into the two global variables GitCommit and Version
       # See also: https://pkg.go.dev/cmd/link
       - -s
       - -w
-      - -X github.com/openshift/osdctl/cmd.GitCommit={{.ShortCommit}}
       - -X github.com/openshift/osdctl/cmd.Version={{.Version}}
       - "-extldflags=-zrelro" # binary hardening: For further explanation look here: https://www.redhat.com/en/blog/hardening-elf-binaries-using-relocation-read-only-relro
       - "-extldflags=-znow"

--- a/cmd/account/generate-secret.go
+++ b/cmd/account/generate-secret.go
@@ -3,7 +3,7 @@ package account
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -209,7 +209,7 @@ func (o *generateSecretOptions) run() error {
 			return err
 		}
 		// set permission to 0600 to ensure, only owner has access
-		return ioutil.WriteFile(outputPath, []byte(secret), 0600)
+		return os.WriteFile(outputPath, []byte(secret), 0600)
 	}
 
 	return nil

--- a/cmd/cluster/support/post.go
+++ b/cmd/cluster/support/post.go
@@ -3,7 +3,6 @@ package support
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -206,7 +205,7 @@ func accessFile(filePath string) ([]byte, error) {
 
 	// when template is file on disk
 	if utils.FileExists(filePath) {
-		file, err := ioutil.ReadFile(filePath) //#nosec G304 -- filePath cannot be constant
+		file, err := os.ReadFile(filePath) //#nosec G304 -- filePath cannot be constant
 		if err != nil {
 			return file, fmt.Errorf("cannot read the file.\nError: %q", err)
 		}

--- a/cmd/env/env.go
+++ b/cmd/env/env.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -383,14 +382,14 @@ func (e *OcEnv) createBin(cmd, content string) {
 
 func (e *OcEnv) createKubeconfig() {
 	if e.Options.Kubeconfig != "" {
-		input, err := ioutil.ReadFile(e.Options.Kubeconfig)
+		input, err := os.ReadFile(e.Options.Kubeconfig)
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
 
 		path := filepath.Join(e.Path, "/kubeconfig.json")
-		err = ioutil.WriteFile(path, input, 0600)
+		err = os.WriteFile(path, input, 0600)
 		if err != nil {
 			panic(fmt.Errorf("error creating %s: %v", path, err))
 		}

--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -3,7 +3,6 @@ package servicelog
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"os/signal"
@@ -223,7 +222,7 @@ func accessFile(filePath string) ([]byte, error) {
 	filePath = filepath.Clean(filePath)
 	if utils.FileExists(filePath) {
 		// template is file on the disk
-		file, err := ioutil.ReadFile(filePath) //#nosec G304 -- Potential file inclusion via variable
+		file, err := os.ReadFile(filePath) //#nosec G304 -- Potential file inclusion via variable
 		if err != nil {
 			return file, fmt.Errorf("cannot read the file.\nError: %q", err)
 		}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -89,7 +88,7 @@ func upgrade(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		dir, err := ioutil.TempDir(homeDir, ".*")
+		dir, err := os.MkdirTemp(homeDir, ".*")
 		if err != nil {
 			return err
 		}

--- a/internal/utils/network.go
+++ b/internal/utils/network.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -52,7 +52,7 @@ func CurlThis(webpage string) (body []byte, err error) {
 		err = resp.Body.Close()
 	}()
 	if resp.StatusCode == http.StatusOK {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return body, err
 		}

--- a/pkg/envConfig/config.go
+++ b/pkg/envConfig/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -32,7 +31,7 @@ func LoadYaml(paramFilePath string) Config {
 		return config
 	}
 	// ignore linter error: filepath has to be static
-	yamlFile, err := ioutil.ReadFile(configFilePath) //#nosec G304 -- filepath cannot be constant
+	yamlFile, err := os.ReadFile(configFilePath) //#nosec G304 -- filepath cannot be constant
 	if err != nil {
 		log.Printf("Failed to read config yaml %s: %v ", configFilePath, err)
 	}
@@ -57,7 +56,7 @@ func LoadPDConfig(paramFilePath string) PDConfig {
 	}
 
 	// ignore linter error: filepath has to be static
-	jsonFile, err := ioutil.ReadFile(configFilePath) //#nosec G304 -- filepath cannot be constant
+	jsonFile, err := os.ReadFile(configFilePath) //#nosec G304 -- filepath cannot be constant
 	if err != nil {
 		log.Printf("Failed to read config json %s: %v ", configFilePath, err)
 	}

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -2,7 +2,7 @@ package printer
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -45,7 +45,7 @@ foo1                foo2                foo3
 			err := p.Flush()
 			g.Expect(err).ShouldNot(HaveOccurred())
 
-			data, err := ioutil.ReadAll(buf)
+			data, err := io.ReadAll(buf)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(string(data)).Should(Equal(tc.output))
 		})

--- a/pkg/provider/aws/sts.go
+++ b/pkg/provider/aws/sts.go
@@ -3,7 +3,7 @@ package aws
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -182,7 +182,7 @@ func requestSignedURL(baseUrl string, jsonCredentials []byte) (string, error) {
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		klog.Errorf("Failed to read response body %v", err)
 		return "", err


### PR DESCRIPTION
[OSD-14140](https://issues.redhat.com//browse/OSD-14140) - Updating osdctl to Go 1.18

- `io/ioutil` has been deprecated and its functionality moved into `io` and `os` mostly.
- `runtime/debug` lets us natively get the git commit hash instead of depending on goreleaser.

All the information available from `runtime/debug` if curious (only using `vcs.revision` in this PR):

```
[{-compiler gc}
{-ldflags -s -w -X github.com/openshift/osdctl/cmd.Version=0.13.4}
{CGO_ENABLED 0}
{GOARCH arm64}
{GOOS darwin}
{vcs git}
{vcs.revision 1c19ccee8807771fb43b3fdb70920c18440ea548}
{vcs.time 2022-11-30T21:12:10Z}
{vcs.modified true}]
```