### PR TITLE
Fix README goproxy requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Currently, it mainly supports related work for AWS, especially [aws-account-oper
 - Go >= 1.13
 - make
 - [goreleaser](https://github.com/goreleaser)
-- `GOPROXY` contains `proxy.golang.org`
+- `GOPROXY` contains `proxy.golang.org` as highest priority
   ```shell
   # Google`s default proxy can be added globally:
-  go env -w GOPROXY="$(go env GOPROXY),https://proxy.golang.org"
+  go env -w GOPROXY="https://proxy.golang.org,$(go env GOPROXY)"
   ```
 
 ```shell


### PR DESCRIPTION
**Why?**
The proxy url needs to be the first priority in the `GOPROXY` env, otherwise `direct` might be used, and we run into the same error as when we don't configure the proxy.

`github.com/openshift/api@v3.9.1-0.20191111211345-a27ff30ebf09+incompatible: invalid pseudo-version: preceding tag (v3.9.0) not found`
