### PR TITLE
Automatically run the network-verifier after running the CPD utility

### DIFF
--- a/cmd/cluster/cpd.go
+++ b/cmd/cluster/cpd.go
@@ -156,9 +156,19 @@ func (o *cpdOptions) run() error {
 			}
 
 			output := verifier.ValidateEgress(awsVerifier, vei)
-			_, _, errors := output.Parse()
-			for _, err := range errors {
-				return err
+			failures, exceptions, errors := output.Parse()
+			if len(failures) != 0 || len(exceptions) != 0 || len(errors) != 0 {
+				resultString := "Network verifier results:\n"
+				for _, failure := range failures {
+					resultString = resultString + failure.Error() + "\n"
+				}
+				for _, exception := range exceptions {
+					resultString = resultString + exception.Error() + "\n"
+				}
+				for _, err := range errors {
+					resultString = resultString + err.Error() + "\n"
+				}
+				return fmt.Errorf(resultString)
 			}
 		}
 		return nil

--- a/cmd/cluster/cpd.go
+++ b/cmd/cluster/cpd.go
@@ -71,7 +71,7 @@ func (o *cpdOptions) run() error {
 
 	fmt.Println("Checking if cluster has become ready")
 	if cluster.Status().State() == "ready" {
-		fmt.Printf("This cluster is in a ready state and already provisioned")
+		fmt.Println("This cluster is in a ready state and already provisioned")
 		return nil
 	}
 

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -82,6 +82,7 @@ type Client interface {
 	//ec2
 	DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
 	DescribeRouteTables(*ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error)
+	DescribeSecurityGroups(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error)
 	DescribeSubnets(*ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
 	DescribeVpcs(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
 	StopInstances(*ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error)
@@ -434,6 +435,10 @@ func (c *AwsClient) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.D
 
 func (c *AwsClient) DescribeRouteTables(input *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error) {
 	return c.ec2Client.DescribeRouteTables(input)
+}
+
+func (c *AwsClient) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+	return c.ec2Client.DescribeSecurityGroups(input)
 }
 
 func (c *AwsClient) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {

--- a/pkg/provider/aws/mock/client.go
+++ b/pkg/provider/aws/mock/client.go
@@ -372,6 +372,21 @@ func (mr *MockClientMockRecorder) DescribeRouteTables(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRouteTables", reflect.TypeOf((*MockClient)(nil).DescribeRouteTables), arg0)
 }
 
+// DescribeSecurityGroups mocks base method.
+func (m *MockClient) DescribeSecurityGroups(arg0 *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeSecurityGroups", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeSecurityGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeSecurityGroups indicates an expected call of DescribeSecurityGroups.
+func (mr *MockClientMockRecorder) DescribeSecurityGroups(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroups", reflect.TypeOf((*MockClient)(nil).DescribeSecurityGroups), arg0)
+}
+
 // DescribeSubnets mocks base method.
 func (m *MockClient) DescribeSubnets(arg0 *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Running the egress network-verifier is the next step after running the
Cluster Provisioning Delay subcommand, so we may as well have it run
automatically as part of the CPD subcommand.