### PR TITLE
Elevate for performing control plane node drain

### DIFF
--- a/cmd/cluster/resizecontrolplanenode.go
+++ b/cmd/cluster/resizecontrolplanenode.go
@@ -234,7 +234,7 @@ func drainNode(nodeID string) error {
 	printer.PrintlnGreen("Draining node", nodeID)
 
 	// TODO: replace subprocess call with API call
-	cmd := fmt.Sprintf("oc adm drain %s --ignore-daemonsets --delete-emptydir-data", nodeID)
+	cmd := fmt.Sprintf("oc adm drain %s --ignore-daemonsets --delete-emptydir-data --as backplane-cluster-admin", nodeID)
 	output, err := exec.Command("bash", "-c", cmd).CombinedOutput()
 
 	if err != nil {


### PR DESCRIPTION
# What is being changed

- Elevate to `backplane-cluster-admin` for the first (non-forceful) attempt at a control plane node drain.

# Why

The control plane node drain resize command presently results in an error because it can't list pods in all namespaces, therefore always directing the SRE towards a skip/force/cancel path which is not necessarily needed.
