### PR TITLE
Skip version check if it fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,14 +24,17 @@ func main() {
 
 	latestVersion, err := utils.GetLatestVersion()
 	if err != nil {
+		fmt.Println("Warning: Unable to get osdctl version from GitHub:")
 		fmt.Println(err)
-		return
+
+		// Version query failed, so we just assume that the version didn't change
+		latestVersion = utils.Version
 	}
 
 	if utils.Version != latestVersion {
 		fmt.Println("The current version is different than the latest version.")
 		fmt.Println("It is recommended that you update to the latest version to ensure that no known bugs or issues are hit.")
-		fmt.Println("Please confirm that you would like to continute with [y|n]")
+		fmt.Println("Please confirm that you would like to continue with [y|n]")
 
 		var input string
 		for {

--- a/main.go
+++ b/main.go
@@ -24,9 +24,10 @@ func main() {
 
 	latestVersion, err := utils.GetLatestVersion()
 	if err != nil {
-		fmt.Println("Warning: Unable to get osdctl version from GitHub:")
+		fmt.Println("Warning: Unable to verify that osdctl is running under the latest version. Error trying to reach GitHub:")
 		fmt.Println(err)
-
+		fmt.Println("Please be aware that you are possibly running an outdated version.")
+		
 		// Version query failed, so we just assume that the version didn't change
 		latestVersion = utils.Version
 	}

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 		fmt.Println("Warning: Unable to verify that osdctl is running under the latest version. Error trying to reach GitHub:")
 		fmt.Println(err)
 		fmt.Println("Please be aware that you are possibly running an outdated version.")
-		
+
 		// Version query failed, so we just assume that the version didn't change
 		latestVersion = utils.Version
 	}


### PR DESCRIPTION
**What?**

Skip the version check and assume that the current version is the most recent if the version query from github fails. 

**Why?**

With the current implementation, our whole osdctl tool is broken if we can't reach github or if the github API changes. 
The tool can also not be used offline (not sure if that would ever be the case).

**Example:** 

1. block outbound/inbound traffic to github
2. run `osdctl --help` 
3. osdctl errors with
   ```./osdctl --help
   Get "https://api.github.com/repos/openshift/osdctl/releases/latest": dial tcp: lookup api.github.com on 127.0.0.53:53: 
   server misbehaving
