### PR TITLE
Unit tests for osdctl network verify-egress

### DIFF
--- a/cmd/network/verification_test.go
+++ b/cmd/network/verification_test.go
@@ -7,7 +7,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift-online/ocm-sdk-go/logging"
+	"github.com/openshift/osd-network-verifier/pkg/proxy"
+	onv "github.com/openshift/osd-network-verifier/pkg/verifier"
 )
 
 func newTestLogger(t *testing.T) logging.Logger {
@@ -19,6 +22,16 @@ func newTestLogger(t *testing.T) logging.Logger {
 	}
 
 	return logger
+}
+
+// newTestCluster assembles a *cmv1.Cluster while handling the error to help out with inline test-case generation
+func newTestCluster(t *testing.T, cb *cmv1.ClusterBuilder) *cmv1.Cluster {
+	cluster, err := cb.Build()
+	if err != nil {
+		t.Fatalf("failed to build cluster: %s", err)
+	}
+
+	return cluster
 }
 
 type mockEgressVerificationAWSClient struct {
@@ -68,6 +81,96 @@ func Test_egressVerificationSetup(t *testing.T) {
 			} else {
 				if test.expectErr {
 					t.Errorf("expected err, got none")
+				}
+			}
+		})
+	}
+}
+
+func Test_egressVerificationGenerateAWSValidateEgressInput(t *testing.T) {
+	tests := []struct {
+		name      string
+		e         *egressVerification
+		region    string
+		expected  *onv.ValidateEgressInput
+		expectErr bool
+	}{
+		{
+			name: "GCP Unsupported",
+			e: &egressVerification{
+				cluster: newTestCluster(t, cmv1.NewCluster().CloudProvider(cmv1.NewCloudProvider().ID("gcp"))),
+				log:     newTestLogger(t),
+			},
+			expectErr: true,
+		},
+		{
+			name: "Cluster-wide proxy requires cacert when there is an additional trust bundle",
+			e: &egressVerification{
+				cluster: newTestCluster(t, cmv1.NewCluster().
+					CloudProvider(cmv1.NewCloudProvider().ID("aws")).
+					Product(cmv1.NewProduct().ID("rosa")).
+					AdditionalTrustBundle("REDACTED").
+					Proxy(cmv1.NewProxy().HTTPProxy("http://my.proxy:80").HTTPSProxy("https://my.proxy:443")),
+				),
+				log: newTestLogger(t),
+			},
+			region:    "us-east-2",
+			expectErr: true,
+		},
+		{
+			name: "Transparent cluster-wide proxy",
+			e: &egressVerification{
+				awsClient: mockEgressVerificationAWSClient{
+					describeSecurityGroupsResp: &ec2.DescribeSecurityGroupsOutput{
+						SecurityGroups: []types.SecurityGroup{
+							{
+								GroupId: aws.String("sg-abcd"),
+							},
+						},
+					},
+					describeSubnetsResp: &ec2.DescribeSubnetsOutput{
+						Subnets: []types.Subnet{
+							{
+								SubnetId: aws.String("subnet-abcd"),
+							},
+						},
+					},
+				},
+				cluster: newTestCluster(t, cmv1.NewCluster().
+					CloudProvider(cmv1.NewCloudProvider().ID("aws")).
+					Product(cmv1.NewProduct().ID("rosa")).
+					Proxy(cmv1.NewProxy().HTTPProxy("http://my.proxy:80").HTTPSProxy("https://my.proxy:443")),
+				),
+				log: newTestLogger(t),
+			},
+			region: "us-east-2",
+			expected: &onv.ValidateEgressInput{
+				SubnetID: "subnet-abcd",
+				Proxy: proxy.ProxyConfig{
+					HttpProxy:  "http://my.proxy:80",
+					HttpsProxy: "https://my.proxy:443",
+				},
+				AWS: onv.AwsEgressConfig{
+					SecurityGroupId: "sg-abcd",
+				},
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := test.e.generateAWSValidateEgressInput(context.TODO(), test.region)
+			if err != nil {
+				if !test.expectErr {
+					t.Errorf("expected no err, got %s", err)
+				}
+			} else {
+				if test.expectErr {
+					t.Errorf("expected err, got none")
+				}
+				if !compareValidateEgressInput(test.expected, actual) {
+					t.Errorf("expected %v, got %v", test.expected, actual)
 				}
 			}
 		})
@@ -165,6 +268,54 @@ func Test_egressVerificationGetSubnetId(t *testing.T) {
 			expected:  "override",
 			expectErr: false,
 		},
+		{
+			name: "non-PrivateLink + BYOVPC unsupported",
+			e: &egressVerification{
+				cluster: newTestCluster(t, cmv1.NewCluster().AWS(cmv1.NewAWS().PrivateLink(false).SubnetIDs("subnet-abcd"))),
+				log:     newTestLogger(t),
+			},
+			expectErr: true,
+		},
+		{
+			name: "PrivateLink + BYOVPC picks the first subnet",
+			e: &egressVerification{
+				cluster: newTestCluster(t, cmv1.NewCluster().AWS(cmv1.NewAWS().PrivateLink(true).SubnetIDs("subnet-abcd"))),
+				log:     newTestLogger(t),
+			},
+			expected:  "subnet-abcd",
+			expectErr: false,
+		},
+		{
+			name: "non-BYOVPC clusters get subnets from AWS",
+			e: &egressVerification{
+				awsClient: mockEgressVerificationAWSClient{
+					describeSubnetsResp: &ec2.DescribeSubnetsOutput{
+						Subnets: []types.Subnet{
+							{
+								SubnetId: aws.String("subnet-abcd"),
+							},
+						},
+					},
+				},
+				cluster: newTestCluster(t, cmv1.NewCluster()),
+				log:     newTestLogger(t),
+			},
+			expected:  "subnet-abcd",
+			expectErr: false,
+		},
+		{
+			name: "non-BYOVPC clusters error if no subnets found in AWS",
+			e: &egressVerification{
+				awsClient: mockEgressVerificationAWSClient{
+					describeSubnetsResp: &ec2.DescribeSubnetsOutput{
+						Subnets: []types.Subnet{},
+					},
+				},
+				cluster: newTestCluster(t, cmv1.NewCluster()),
+				log:     newTestLogger(t),
+			},
+			expectErr: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -215,4 +366,27 @@ func TestDefaultValidateEgressInput(t *testing.T) {
 			}
 		})
 	}
+}
+
+// compareValidateEgressInput is a helper to compare selected fields of ValidateEgressInput that we care about during testing
+func compareValidateEgressInput(expected, actual *onv.ValidateEgressInput) bool {
+	if expected == nil && actual == nil {
+		return true
+	}
+
+	if (expected == nil && actual != nil) || (expected != nil && actual == nil) {
+		return false
+	}
+
+	if expected.SubnetID != actual.SubnetID ||
+		expected.AWS.SecurityGroupId != actual.AWS.SecurityGroupId {
+		return false
+	}
+
+	if expected.Proxy.HttpProxy != actual.Proxy.HttpProxy ||
+		expected.Proxy.HttpsProxy != actual.Proxy.HttpsProxy {
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
Unit tests!

I learned how to mock clusters in OCM with `cmv1.NewCluster().Build()`, so we can pretty much unit test all of the logic this tool does around auto-selection and when it makes SREs supply parameters