### PR TITLE
Updated struct data type while unmarshal clusterkubeconfig operation

### DIFF
--- a/cmd/cluster/access/access.go
+++ b/cmd/cluster/access/access.go
@@ -70,7 +70,6 @@ func NewCmdAccess(streams genericclioptions.IOStreams, flags *genericclioptions.
 	return accessCmd
 }
 
-
 // clusterCmdComplete verifies the command's invocation, returning an error if the usage is invalid
 func accessCmdComplete(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {

--- a/cmd/cluster/access/access_test.go
+++ b/cmd/cluster/access/access_test.go
@@ -18,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	clientcmdapiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -295,7 +294,7 @@ func TestClusterAccessOptions_createLocalKubeconfigAccess(t *testing.T) {
 				}
 			} else {
 				// Since we don't expect the createLocalKubeconfigAccess func to throw an error in this test, we also expect the local file to be a valid kubeconfig
-				localKubeconfig := clientcmdapiv1.Config{}
+				localKubeconfig := clusterKubeConfig{}
 				err = yaml.Unmarshal(file, &localKubeconfig)
 				if err != nil {
 					t.Errorf("Failed '%s': could not unmarshal local file to Config: %v", test.Name, err)
@@ -468,11 +467,11 @@ func generateClusterObjectForTesting(name string, id string, privateLink bool, p
 }
 
 // generateKubeconfigSecretObjectForTesting creates a Secret containing a kubeconfig file for testing purposes
-func generateKubeconfigSecretObjectForTesting(name, namespace, key, serverURL string) (corev1.Secret, clientcmdapiv1.Config) {
-	kubeconfig := clientcmdapiv1.Config{
-		Clusters: []clientcmdapiv1.NamedCluster{
+func generateKubeconfigSecretObjectForTesting(name, namespace, key, serverURL string) (corev1.Secret, clusterKubeConfig) {
+	kubeconfig := clusterKubeConfig{
+		Clusters: []clusterConfig{
 			{
-				Cluster: clientcmdapiv1.Cluster{
+				Cluster: cluster{
 					Server: serverURL,
 				},
 			},

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.13.0
 	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
 	k8s.io/cli-runtime v0.24.3
@@ -39,6 +38,7 @@ require (
 	k8s.io/kubectl v0.24.3
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/controller-runtime v0.12.1
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -146,13 +146,13 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.24.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/kustomize/api v0.11.4 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 replace (


### PR DESCRIPTION
Related to - https://issues.redhat.com/browse/OSD-13939
 
Changes include:
1. Added "NewYAMLOrJSONDecoder" to use "json:" annotations while parsing yaml data. 
2. Marshal data to YAML while storing the local kubeconfig file.

Why: 
Currently client-go does not declare yaml go struct tags for the kubeconfig types(clientcmdapiv1.Config). 
In order to marshal the data object used a common method which supports both format yaml and json.     

