### PR TITLE
Increase client timeout to 10s

### DIFF
--- a/pkg/utils/version.go
+++ b/pkg/utils/version.go
@@ -35,7 +35,7 @@ type gitHubResponse struct {
 // tags with a suffix like *-rc.1 are not returned. We will always show the latest stable on master branch.
 func GetLatestVersion() (latest string, err error) {
 	client := http.Client{
-		Timeout: time.Second * 2,
+		Timeout: time.Second * 10,
 	}
 
 	req, err := http.NewRequest(http.MethodGet, VersionAPIEndpoint, nil)


### PR DESCRIPTION
Increasing client timeout because the timeout includes connection time, any redirects, and reading the response body.
With 2s timeout we have seen frequent timeout message with `osdctl` commands 

- Get "https://api.github.com/repos/openshift/osdctl/releases/latest": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
