### PR TITLE
Add AWS_REGION env var

### DIFF
--- a/cmd/account/cli.go
+++ b/cmd/account/cli.go
@@ -159,10 +159,11 @@ func (o *cliOptions) run() error {
 	}
 
 	if o.output == "env" {
-		fmt.Printf("AWS_ACCESS_KEY_ID=%s \nAWS_SECRET_ACCESS_KEY=%s \nAWS_SESSION_TOKEN=%s \nAWS_DEFAULT_REGION=%s\n",
+		fmt.Printf("AWS_ACCESS_KEY_ID=%s\nAWS_SECRET_ACCESS_KEY=%s\nAWS_SESSION_TOKEN=%s\nAWS_DEFAULT_REGION=%s\nAWS_REGION=%s\n",
 			*assumedRoleCreds.AccessKeyId,
 			*assumedRoleCreds.SecretAccessKey,
 			*assumedRoleCreds.SessionToken,
+			o.region,
 			o.region,
 		)
 	}


### PR DESCRIPTION
When using `osdctl account cli -i ... -p ... -o env` to set local environment variables for `rosa`, I encountered an error where it needed the region set. Per https://docs.aws.amazon.com/sdkref/latest/guide/feature-region.html, AWS_REGION appears to be the more widely accepted variable, however AWS_DEFAULT_REGION appears to be used by AWS CLI v1 and boto3.