### PR TITLE
Fix latest version judgement

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 		latestVersion = utils.Version
 	}
 
-	if utils.Version != latestVersion {
+	if !strings.Contains(utils.Version, latestVersion) {
 		fmt.Println("The current version is different than the latest version.")
 		fmt.Println("It is recommended that you update to the latest version to ensure that no known bugs or issues are hit.")
 		fmt.Println("Please confirm that you would like to continue with [y|n]")


### PR DESCRIPTION
From my latest build. I got this:
```
The current version is different from the latest version.
It is recommended that you update to the latest version to ensure that no known bugs or issues are hit.
Please confirm that you would like to continue with [y|n]
y
{
  "commit": "5f9affad5e4ef7f1278bdb540019a5237bf4b9eb",
  "version": "v0.13.4-next",
  "latest": "0.13.4"
}
```
Not sure where did the `-next` come from, but I think I had the latest one already.