### PR TITLE
add hypershift support to egress validations

### DIFF
--- a/cmd/network/verification.go
+++ b/cmd/network/verification.go
@@ -316,6 +316,9 @@ func (e *egressVerification) getSubnetId(ctx context.Context) (string, error) {
 		if len(instance.Reservations[0].Instances[0].NetworkInterfaces) == 0 {
 			return "", fmt.Errorf("found 0 network interfaces of the worker node: %s, consider the --subnet-id flag", *instance.Reservations[0].Instances[0].InstanceId)
 		}
+		if len(instance.Reservations[0].Instances[0].NetworkInterfaces) > 1 {
+			return "", fmt.Errorf("more than one interface found on the worker node: %s, consider the --subnet-id flag", *instance.Reservations[0].Instances[0].InstanceId)
+		}
 
 		e.log.Info(ctx, "detected BYOVPC Hypershift cluster, using the subnets of the worker nodes(private): %s", *instance.Reservations[0].Instances[0].NetworkInterfaces[0].SubnetId)
 		return *instance.Reservations[0].Instances[0].NetworkInterfaces[0].SubnetId, nil

--- a/cmd/network/verification.go
+++ b/cmd/network/verification.go
@@ -302,6 +302,10 @@ func (e *egressVerification) getSubnetId(ctx context.Context) (string, error) {
 					Name:   aws.String("tag:red-hat-managed"),
 					Values: []string{"true"},
 				},
+				{
+					Name:   aws.String("instance-state-name"),
+					Values: []string{"running", "pending"},
+				},
 			},
 		})
 		if err != nil {
@@ -311,7 +315,7 @@ func (e *egressVerification) getSubnetId(ctx context.Context) (string, error) {
 			return "", fmt.Errorf("found 0 instances with kubernetes.io/cluster/%s=owned and red-hat-managed, consider the --subnet-id flag", e.clusterId)
 		}
 		if len(instance.Reservations[0].Instances) == 0 {
-			return "", fmt.Errorf("found 0 instances with kubernetes.io/cluster/%s=owned and red-hat-managed, consider the --subnet-id flag", e.clusterId)
+			return "", fmt.Errorf("found 0 instances with kubernetes.io/cluster/%s=owned and red-hat-managed as running/pending, consider the --subnet-id flag", e.clusterId)
 		}
 		if len(instance.Reservations[0].Instances[0].NetworkInterfaces) == 0 {
 			return "", fmt.Errorf("found 0 network interfaces of the worker node: %s, consider the --subnet-id flag", *instance.Reservations[0].Instances[0].InstanceId)

--- a/cmd/network/verification_test.go
+++ b/cmd/network/verification_test.go
@@ -35,8 +35,13 @@ func newTestCluster(t *testing.T, cb *cmv1.ClusterBuilder) *cmv1.Cluster {
 }
 
 type mockEgressVerificationAWSClient struct {
+	describeInstancesResp      *ec2.DescribeInstancesOutput
 	describeSecurityGroupsResp *ec2.DescribeSecurityGroupsOutput
 	describeSubnetsResp        *ec2.DescribeSubnetsOutput
+}
+
+func (m mockEgressVerificationAWSClient) DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(options *ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	return m.describeInstancesResp, nil
 }
 
 func (m mockEgressVerificationAWSClient) DescribeSubnets(ctx context.Context, params *ec2.DescribeSubnetsInput, optFns ...func(options *ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {


### PR DESCRIPTION
This PR provides credential support for cases if a given cluster is hypershift (including stage and int)
This allows us to execute some of the osd checks against hypershift  such as egress:
(I haven't checked other functionalities, they may depend on additional resources that need to be fetched, too)

Test:
```shell
./ocm-login stage
ocm describe cluster HCP_CLUSTER_ID  | grep Management
Management Cluster:     hs-mc-8c6cdrxxx

dist/osdctl_darwin_arm64/osdctl network verify-egress --cluster-id HCP_CLUSTER_ID
2023/01/20 19:32:46 getting AWS credentials from backplane-api
2023/01/20 19:32:48 detected BYOVPC Hypershift cluster, using the subnets of the worker nodes(private): subnet-0dabcd1b9cb382df6
2023/01/20 19:32:48 searching for security group by tags: api.openshift.com/id=HCP_CLUSTER_ID
2023/01/20 19:32:49 using security-group-id: sg-0037647435c5c4f8c
2023/01/20 19:32:49 running with config: &{Timeout:2s Ctx:context.TODO SubnetID:subnet-0e3a4046c1c2f1078 CloudImageID:ami-03ab344882b539e44 InstanceType:t3.micro Proxy:{HttpProxy: HttpsProxy: Cacert: NoTls:false} Tags:map[Name:osd-network-verifier osd-network-verifier:owned red-hat-managed:true] AWS:{KmsKeyID: SecurityGroupId:sg-0037647435c5c4f8c} GCP:{Region: Zone: ProjectID: VpcName:}}
2023/01/20 19:32:51 Created instance with ID: i-0176573e578fc0abf
Summary:
All tests pass!
2023/01/20 19:34:53 All tests pass
```

Ref: https://gitlab.cee.redhat.com/service/backplane-cli/-/merge_requests/234 