### PR TITLE
Trim v for version check

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -61,7 +61,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 					fmt.Println("Please be aware that you are possibly running an outdated or unreleased version.")
 				}
 
-				if utils.Version != latestVersion {
+				if utils.Version != strings.TrimPrefix(latestVersion, "v") {
 					fmt.Println(fmt.Sprintf("The current version (%s) is different than the latest released version (%s).", utils.Version, latestVersion))
 					fmt.Println("It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.")
 					fmt.Println("Please confirm that you would like to continue with [y|n]")


### PR DESCRIPTION
`utils.Version` is set when a new release is created via the `.goreleaser.yaml` config. However, the `v` in a version (for example v0.1.35) is getting trimmed. This causes a mismatch between what is set in `utils.Version` and what is being pulled from GitHub.

/hold

I'm not sure this is the way we should go. Ideally we should fix the `.goreleaser.yaml` path to set `utils.Version` correctly. In the case that's not possible, this PR can be merged. 