### PR TITLE
[OSD-14413] Add support exceptions to osdctl cluster context

### DIFF
--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -114,6 +114,7 @@ func (o *contextOptions) complete(cmd *cobra.Command, args []string) error {
 
 	orgID, err := utils.GetOrgfromClusterID(ocmClient, *cluster)
 	if err != nil {
+		fmt.Printf("Failed to get Org ID for cluster ID %s - err: %q", o.clusterID, err)
 		o.organizationID = ""
 	} else {
 		o.organizationID = orgID
@@ -493,7 +494,10 @@ func (o *contextOptions) printJiraCards() error {
 	jiraClient, _ := jira.NewClient(tp.Client(), "https://issues.redhat.com/")
 
 	o.printJIRAOHSS(jiraClient)
-	o.printJIRASupportExceptions(jiraClient)
+
+	if o.organizationID != "" {
+		o.printJIRASupportExceptions(jiraClient)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Added Support Exceptions to osdctl cluster context. 

**Example:**
```
============================================================
Cluster Org Support Exception
============================================================
[SUPPORTEX-1234](Story/Medium): Support OpenShiftSDN on 4.11 cluster on ROSA [Status: Approved]
- Link: https://issues.redhat.com/browse/SUPPORTEX-1234
```

Ticket Ref: [OSD-14413](https://issues.redhat.com/browse/OSD-14413)