### PR TITLE
Update to Go 1.19

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -16,22 +16,22 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0 # See: https://goreleaser.com/ci/actions/
 
       - name: Set up Go
-        uses: actions/setup-go@v3.3.1
+        uses: actions/setup-go@v3.5.0
         with:
-          go-version: 1.18.8
+          go-version: 1.19.5
         id: go
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4.2.0
         with:
           distribution: goreleaser
-          version: 'v1.13.1'
-          args: release --rm-dist
+          version: 'v1.15.0'
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/validate_goreleaser.yml
+++ b/.github/workflows/validate_goreleaser.yml
@@ -16,21 +16,21 @@ jobs:
 
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2.3.3
+        uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0 # See: https://goreleaser.com/ci/actions/
 
       - name: Set up Go
-        uses: actions/setup-go@v3.3.1
+        uses: actions/setup-go@v3.5.0
         with:
-          go-version: 1.18.8
+          go-version: 1.19.5
         id: go
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4.2.0
         with:
           distribution: goreleaser
-          version: 'v1.13.1'
+          version: 'v1.15.0'
           args: check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,14 +1,9 @@
 project_name: osdctl
-
-before:
-  hooks:
-    - go mod tidy
-
 builds:
   - env:
       - CGO_ENABLED=0
       - "GO111MODULE=on" # make sure to use go modules
-      - "GOFLAGS=-mod=readonly -trimpath" # trimpath helps with producing verificable binaries
+      - "GOFLAGS=-mod=readonly -trimpath" # trimpath helps with producing verifiable binaries
     goos:
       - linux
       - darwin
@@ -27,10 +22,13 @@ builds:
       - "-extldflags=-znow"
 
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      amd64: x86_64
+  # https://goreleaser.com/deprecations/#archivesreplacements
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end}}
 
 checksum:
   name_template: 'sha256sum.txt'

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ OS := $(shell go env GOOS | sed 's/[a-z]/\U&/')
 ARCH := $(shell go env GOARCH)
 .PHONY: download-goreleaser
 download-goreleaser:
-	GOBIN=${BASE_DIR}/bin/ go install github.com/goreleaser/goreleaser@v1.13.1
+	GOBIN=${BASE_DIR}/bin/ go install github.com/goreleaser/goreleaser@v1.15.0
 
 # CI build containers don't include goreleaser by default,
 # so they need to get it first, and then run the build
@@ -36,10 +36,10 @@ SINGLE_TARGET ?= false
 # Snapshot allows the build without validation of the
 # repository itself
 build:
-	goreleaser build --rm-dist --snapshot --single-target=${SINGLE_TARGET}
+	goreleaser build --clean --snapshot --single-target=${SINGLE_TARGET}
 
 release:
-	./bin/goreleaser release --rm-dist
+	./bin/goreleaser release --clean
 
 vet:
 	go vet ${BUILDFLAGS} ./...

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently, it mainly supports related work for AWS, especially [aws-account-oper
 
 #### Requirements
 
-- Go >= 1.13
+- Go >= 1.19
 - make
 - [goreleaser](https://github.com/goreleaser)
 - `GOPROXY` contains `proxy.golang.org`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/osdctl
 
-go 1.18
+go 1.19
 
 require (
 	github.com/PagerDuty/go-pagerduty v1.5.1


### PR DESCRIPTION
Updating the README too as it was a bit behind

GoReleaser Deprecations:
* https://goreleaser.com/deprecations/#-rm-dist `--rm-dist` deprecated in favor of `--clean`
* https://goreleaser.com/deprecations/#archivesreplacements `.archives.replacements` deprecated