### PR TITLE
Fix latest version judgement

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -61,7 +61,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 					fmt.Println("Please be aware that you are possibly running an outdated or unreleased version.")
 				}
 
-				if utils.Version != strings.TrimPrefix(latestVersion, "v") {
+				if !strings.Contains(utils.Version, latestVersion) {
 					fmt.Println(fmt.Sprintf("The current version (%s) is different than the latest released version (%s).", utils.Version, latestVersion))
 					fmt.Println("It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.")
 					fmt.Println("Please confirm that you would like to continue with [y|n]")


### PR DESCRIPTION
I still got below error, and not sure whether it is related to MacOS:
```
The current version (v0.13.6-next) is different than the latest released version (v0.13.6).
It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.
Please confirm that you would like to continue with [y|n]
y
{
  "commit": "d8fb95807ff17a232ab602e183626c4929c7acdc",
  "version": "v0.13.6-next",
  "latest": "0.13.6"
}
```