### PR TITLE
Fix for the case when error is empty.

### DIFF
--- a/cmd/cluster/cpd.go
+++ b/cmd/cluster/cpd.go
@@ -80,8 +80,8 @@ func (o *cpdOptions) run() error {
 
 	fmt.Println("Checking if OCM error code is already known")
 	// Check if the OCM Error code is a known error
-	if cluster.Status().ProvisionErrorCode() != unknownProvisionCode {
-		fmt.Printf("Error code %s is known, customer already received Service Log\n", cluster.Status().ProvisionErrorCode())
+	if len(cluster.Status().ProvisionErrorCode()) > 0 && cluster.Status().ProvisionErrorCode() != unknownProvisionCode {
+		fmt.Printf("Error code '%s' is known, customer already received Service Log\n", cluster.Status().ProvisionErrorCode())
 	}
 
 	fmt.Println("Checking if cluster is GCP")


### PR DESCRIPTION
The CPD command shows "SL already sent" even when the error field isn't populated.

This fix removes a confusing output.