### PR TITLE
fail fast on STS accounts attempting to rotate credentials

### DIFF
--- a/cmd/account/generate-secret.go
+++ b/cmd/account/generate-secret.go
@@ -139,6 +139,10 @@ func (o *generateSecretOptions) run() error {
 		} else {
 			return fmt.Errorf("account CR is missing AWS Account ID")
 		}
+
+		if account.Spec.ManualSTSMode {
+			return fmt.Errorf("Account %s is STS - No IAM User Credentials to Rotate", o.accountName)
+		}
 	} else {
 		accountID = o.accountID
 	}

--- a/cmd/account/generate-secret.go
+++ b/cmd/account/generate-secret.go
@@ -28,7 +28,8 @@ func newCmdGenerateSecret(streams genericclioptions.IOStreams, flags *genericcli
 	ops := newGenerateSecretOptions(streams, flags, client)
 	generateSecretCmd := &cobra.Command{
 		Use:               "generate-secret <IAM User name>",
-		Short:             "Generate IAM credentials secret",
+		Short:             "Generates IAM credentials secret",
+		Long:              "When logged into a hive shard, this generates a new IAM credential secret for a given IAM user",
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(ops.complete(cmd, args))

--- a/cmd/account/rotate-secret.go
+++ b/cmd/account/rotate-secret.go
@@ -95,6 +95,9 @@ func (o *rotateSecretOptions) run() error {
 	if err != nil {
 		return err
 	}
+	if account.Spec.ManualSTSMode {
+		return fmt.Errorf("Account %s is STS - No IAM User Credentials to Rotate", o.accountCRName)
+	}
 
 	// Set the account ID
 	accountID = account.Spec.AwsAccountID

--- a/cmd/account/rotate-secret.go
+++ b/cmd/account/rotate-secret.go
@@ -30,8 +30,9 @@ import (
 func newCmdRotateSecret(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
 	ops := newRotateSecretOptions(streams, flags, client)
 	rotateSecretCmd := &cobra.Command{
-		Use:               "rotate-secret <IAM User name>",
+		Use:               "rotate-secret <aws-account-cr-name>",
 		Short:             "Rotate IAM credentials secret",
+		Long:              "When logged into a hive shard, this rotates IAM credential secrets for a given `account` CR.",
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(ops.complete(cmd, args))


### PR DESCRIPTION
This fails fast in order to prevent chasing red-herrings when attempting to rotate IAM user credentials on STS-based accounts.

Resolves [OSD-15115](https://issues.redhat.com//browse/OSD-15115)