### PR TITLE
Allow `cluster cpd` to run `network verify-egress`

### DIFF
--- a/cmd/cluster/cpd.go
+++ b/cmd/cluster/cpd.go
@@ -1,10 +1,12 @@
 package cluster
 
 import (
+	"context"
 	"fmt"
 
 	awsSdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/openshift/osdctl/cmd/network"
 	"github.com/openshift/osdctl/pkg/osdCloud"
 	"github.com/openshift/osdctl/pkg/provider/aws"
 	"github.com/openshift/osdctl/pkg/utils"
@@ -112,7 +114,9 @@ func (o *cpdOptions) run() error {
 				return fmt.Errorf("subnet %s does not have a default route to 0.0.0.0/0\n Run the following to send a SerivceLog:\n osdctl servicelog post %s -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/aws/InstallFailed_NoRouteToInternet.json", subnet, o.clusterID)
 			}
 		}
-		fmt.Printf("Next step: run the verifier egress test: osdctl network verify-egress --cluster-id %s\n", o.clusterID)
+		fmt.Printf("Attempting to run: osdctl network verify-egress --cluster-id %s\n", o.clusterID)
+		ev := &network.EgressVerification{ClusterId: o.clusterID}
+		ev.Run(context.TODO())
 		return nil
 	}
 


### PR DESCRIPTION
[OSD-15018](https://issues.redhat.com//browse/OSD-15018)

* No functional changes to `osdctl network verify-egress`, just exporting its main struct and `Run` function so that other commands can call it when they want
* Configuring `cluster cpd` to call `network verify-egress` when it previously suggested SREs to run the command manually

Verified in stage:
```
❯ ~/git/openshift/osdctl/osdctl cluster cpd -C REDACTED --profile osd-staging-2
Checking if cluster has become ready
This cluster is in a ready state and already provisionedChecking if cluster DNS is ready
Checking if OCM error code is already known
Checking if cluster is GCP
Generating AWS credentials for cluster
Attempting to run: osdctl network verify-egress --cluster-id REDACTED
2023/02/08 23:02:31 getting AWS credentials from backplane-api
2023/02/08 23:02:32 searching for subnets by tags: kubernetes.io/cluster/REDACTED-zcd2v=owned and kubernetes.io/role/internal-elb=
2023/02/08 23:02:32 using subnet-id: subnet-036f5b0c13c06c88b
2023/02/08 23:02:32 searching for security group by tags: kubernetes.io/cluster/REDACTED-zcd2v=owned and Name=hivep01ue1-zcd2v-master-sg
2023/02/08 23:02:33 using security-group-id: sg-0fb3a3a84e87f51a8
2023/02/08 23:02:33 running with config: &{Timeout:2s Ctx:context.TODO SubnetID:subnet-036f5b0c13c06c88b CloudImageID:ami-091db60579967890f InstanceType:t3.micro Proxy:{HttpProxy: HttpsProxy: Cacert: NoTls:false} Tags:map[Name:osd-network-verifier osd-network-verifier:owned red-hat-managed:true] AWS:{KmsKeyID: SecurityGroupId:sg-0fb3a3a84e87f51a8} GCP:{Region: Zone: ProjectID: VpcName:}}
2023/02/08 23:02:35 Created instance with ID: i-0f64cac42621ebc14
Summary:
All tests pass!
2023/02/08 23:05:25 All tests pass
Next step: check the AWS resources manually, run ocm backplane cloud console
```