### PR TITLE
Add commands to check if cluster owner is a banned user, and to verify that their pull secret matches the cluster's

### DIFF
--- a/cmd/cluster/checkbanneduser.go
+++ b/cmd/cluster/checkbanneduser.go
@@ -1,0 +1,72 @@
+package cluster
+
+import (
+	"fmt"
+	"github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+const BanCodeExportControlCompliance = "export_control_compliance"
+
+func newCmdCheckBannedUser() *cobra.Command {
+	return &cobra.Command{
+		Use:               "check-banned-user [CLUSTER_ID]",
+		Short:             "Checks if the cluster owner is a banned user.",
+		Args:              cobra.ExactArgs(1),
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(CheckBannedUser(args[0]))
+		},
+	}
+}
+
+func CheckBannedUser(clusterID string) error {
+	ocm := utils.CreateConnection()
+	defer func() {
+		if ocmCloseErr := ocm.Close(); ocmCloseErr != nil {
+			fmt.Printf("Cannot close the ocm (possible memory leak): %q", ocmCloseErr)
+		}
+	}()
+
+	fmt.Print("Finding subscription account: ")
+	subscription, err := utils.GetSubscription(ocm, clusterID)
+	if err != nil {
+		return err
+	}
+
+	if status := subscription.Status(); status != "Active" {
+		return fmt.Errorf("Expecting status 'Active' found %v\n", status)
+	}
+
+	fmt.Printf("Account %v - %v - %v\n", subscription.SupportLevel(), subscription.Creator().HREF(), subscription.Status())
+
+	fmt.Print("Finding account owner: ")
+	creator, err := utils.GetAccount(ocm, subscription.Creator().ID())
+	if err != nil {
+		return err
+	}
+
+	userEmail := creator.Email()
+	userBanned := creator.Banned()
+	userBanCode := creator.BanCode()
+	userBanDescription := creator.BanDescription()
+	lastUpdate := creator.UpdatedAt()
+
+	fmt.Printf("%v\n-------------------\nLast Update : %v\n", userEmail, lastUpdate)
+
+	if userBanned {
+		fmt.Println("User is banned")
+		fmt.Printf("Ban code = %v\n", userBanCode)
+		fmt.Printf("Ban description = %v\n", userBanDescription)
+		if userBanCode == BanCodeExportControlCompliance {
+			fmt.Println("User banned due to export control compliance.\nPlease follow the steps detailed here: https://github.com/openshift/ops-sop/blob/master/v4/alerts/UpgradeConfigSyncFailureOver4HrSRE.md#user-banneddisabled-due-to-export-control-compliance .")
+			return nil
+		}
+		fmt.Println("Recommend sending service log with:")
+		fmt.Printf("osdctl servicelog post -t https://raw.githubusercontent.com/openshift/managed-notifications/master/ocm/cluster_owner_disabled.json %v\n", clusterID)
+		return nil
+	}
+	fmt.Println("User allowed")
+	return nil
+}

--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -29,6 +29,8 @@ func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions
 	clusterCmd.AddCommand(access.NewCmdAccess(streams, flags))
 	clusterCmd.AddCommand(newCmdResizeControlPlaneNode(streams, flags, globalOpts))
 	clusterCmd.AddCommand(newCmdCpd())
+	clusterCmd.AddCommand(newCmdCheckBannedUser())
+	clusterCmd.AddCommand(newCmdValidatePullSecret(client, flags))
 	return clusterCmd
 }
 

--- a/cmd/cluster/validatepullsecret_test.go
+++ b/cmd/cluster/validatepullsecret_test.go
@@ -1,0 +1,52 @@
+package cluster
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"reflect"
+	"testing"
+)
+
+func Test_getPullSecretEmail(t *testing.T) {
+	tests := []struct {
+		name          string
+		secret        *corev1.Secret
+		expectedEmail string
+		expectedError error
+		expectedDone  bool
+	}{
+		{
+			name:         "Missing dockerconfigjson",
+			secret:       &corev1.Secret{Data: map[string][]byte{}},
+			expectedDone: true,
+		},
+		{
+			name:         "Missing cloud.openshift.com auth",
+			secret:       &corev1.Secret{Data: map[string][]byte{".dockerconfigjson": []byte("{\"auths\":{}}")}},
+			expectedDone: true,
+		},
+		{
+			name:         "Missing email",
+			secret:       &corev1.Secret{Data: map[string][]byte{".dockerconfigjson": []byte("{\"auths\":{\"cloud.openshift.com\":{}}}")}},
+			expectedDone: true,
+		},
+		{
+			name:          "Valid pull secret",
+			secret:        &corev1.Secret{Data: map[string][]byte{".dockerconfigjson": []byte("{\"auths\":{\"cloud.openshift.com\":{\"email\":\"foo@bar.com\"}}}")}},
+			expectedEmail: "foo@bar.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			email, err, done := getPullSecretEmail("abc123", tt.secret)
+			if email != tt.expectedEmail {
+				t.Errorf("getPullSecretEmail() email = %v, expectedEmail %v", email, tt.expectedEmail)
+			}
+			if !reflect.DeepEqual(err, tt.expectedError) {
+				t.Errorf("getPullSecretEmail() err = %v, expectedEmail %v", err, tt.expectedError)
+			}
+			if done != tt.expectedDone {
+				t.Errorf("getPullSecretEmail() done = %v, expectedEmail %v", done, tt.expectedDone)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR migrates the functionality of our [check_banned_users](https://github.com/openshift/ops-sop/blob/master/v4/utils/check_banned_user.sh) script into osdctl. Because the original script really performs 2 operations, I have made them into two separate commands here.

The first command, `cluster check-banned-user`, will check whether or not the owner of a cluster is a banned user. If so, it will provide next-steps to follow.

The second command, `cluster validate-pull-secret`, will check if the cluster's pull secret email address matches the email address of the owner account. If not, it will provide next-steps to follow.

I'm open to renaming these commands, but wanted to get the functionality and logic up and reviewed. Renaming them would be trivial if desired.