### PR TITLE
Working minimum POC that calls other commands

### DIFF
--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/osdctl/cmd/cluster/access"
+	"github.com/openshift/osdctl/cmd/cluster/jumphost"
 	"github.com/openshift/osdctl/cmd/cluster/support"
 	"github.com/openshift/osdctl/internal/utils/globalflags"
 	"github.com/spf13/cobra"
@@ -29,6 +30,7 @@ func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions
 	clusterCmd.AddCommand(access.NewCmdAccess(streams, flags))
 	clusterCmd.AddCommand(newCmdResizeControlPlaneNode(streams, flags, globalOpts))
 	clusterCmd.AddCommand(newCmdCpd())
+	clusterCmd.AddCommand(jumphost.NewCmdJumphost(streams, flags, client))
 	return clusterCmd
 }
 

--- a/cmd/cluster/jumphost/cmd.go
+++ b/cmd/cluster/jumphost/cmd.go
@@ -1,0 +1,21 @@
+package jumphost
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewCmdJumphost implements the cluster utility
+func NewCmdJumphost(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, kubeClient client.Client) *cobra.Command {
+	jumphostCmd := &cobra.Command{
+		Use:               "jumphost",
+		Short:             "Jumphost Creation/Deletion for a given cluster",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+	}
+
+	jumphostCmd.AddCommand(newCmdGenerateKey(streams, flags))
+	jumphostCmd.AddCommand(newCmdInit(streams, flags))
+	return jumphostCmd
+}

--- a/cmd/cluster/jumphost/generate-key.go
+++ b/cmd/cluster/jumphost/generate-key.go
@@ -5,39 +5,50 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 // newCmdGenerateKey builds a new Key Generation Command
 func newCmdGenerateKey(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
-	ops := GenerateKeyOptions{}
+	genKeyCmd := GenerateKeyCommand{}
 
-	keyGenCommand := &cobra.Command{
+	cobraCmd := &cobra.Command{
 		Use:               "generate-key",
 		Short:             "Generates a key in AWS for ssh'ing to a jumphost",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(ops.Run())
+			output, err := genKeyCmd.Run()
+			cmdUtil.CheckErr(err)
+			output.Print()
 		},
 	}
-	keyGenCommand.Flags().StringVarP(&ops.keyName, "key-name", "k", "$$USER$$-SRE-Jumphost", "Key Name")
-	return keyGenCommand
+	cobraCmd.Flags().StringVarP(&ops.keyName, "key-name", "k", "$$USER$$-SRE-Jumphost", "Key Name")
+	return cobraCmd
 }
 
-type GenerateKeyOptions struct {
+type GenerateKeyCommand struct {
 	keyName string
 }
 
-func (o *GenerateKeyOptions) Validate() error {
-	if o.keyName == "" {
+type GenerateKeyOutput struct {
+	keyArn  string
+	keyName string
+}
+
+func (o *GenerateKeyOutput) Print() {
+	fmt.Println("Key Generated:")
+	fmt.Printf("  Name: %s\n  Arn: %s\n", o.keyName, o.keyArn)
+}
+
+func (c *GenerateKeyCommand) Validate() error {
+	if c.keyName == "" {
 		return fmt.Errorf("Key name must be specified")
 	}
 	return nil
 }
 
-func (o *GenerateKeyOptions) Run() error {
-	err := o.Validate()
+func (c *GenerateKeyOptions) Run() (*GenerateKeyOutput, error) {
+	err := c.Validate()
 	if err != nil {
 		return err
 	}

--- a/cmd/cluster/jumphost/generate-key.go
+++ b/cmd/cluster/jumphost/generate-key.go
@@ -1,0 +1,48 @@
+package jumphost
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+// newCmdGenerateKey builds a new Key Generation Command
+func newCmdGenerateKey(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	ops := GenerateKeyOptions{}
+
+	keyGenCommand := &cobra.Command{
+		Use:               "generate-key",
+		Short:             "Generates a key in AWS for ssh'ing to a jumphost",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.Run())
+		},
+	}
+	keyGenCommand.Flags().StringVarP(&ops.keyName, "key-name", "k", "$$USER$$-SRE-Jumphost", "Key Name")
+	return keyGenCommand
+}
+
+type GenerateKeyOptions struct {
+	keyName string
+}
+
+func (o *GenerateKeyOptions) Validate() error {
+	if o.keyName == "" {
+		return fmt.Errorf("Key name must be specified")
+	}
+	return nil
+}
+
+func (o *GenerateKeyOptions) Run() error {
+	err := o.Validate()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Generating Key")
+
+	return nil
+}

--- a/cmd/cluster/jumphost/init.go
+++ b/cmd/cluster/jumphost/init.go
@@ -1,0 +1,72 @@
+package jumphost
+
+import (
+	"fmt"
+
+	osdctlCommand "github.com/openshift/osdctl/pkg/osdctlCommand"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+// newCmdInit builds a new Jumphost from start to finish
+func newCmdInit(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	ops := &InitOptions{}
+
+	initCmd := &cobra.Command{
+		Use:               "init",
+		Short:             "Initializes a jumphost in a cluster",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.Run())
+		},
+	}
+
+	initCmd.Flags().StringVarP(&ops.keyName, "key-name", "k", "$$USER$$-SRE-Jumphost", "Key Name")
+	return initCmd
+}
+
+type InitOptions struct {
+	keyName string
+
+	generateKeyOpts osdctlCommand.Command
+}
+
+func (o *InitOptions) Init() error {
+	if o.generateKeyOpts == nil {
+		o.generateKeyOpts = &GenerateKeyOptions{
+			keyName: o.keyName,
+		}
+	}
+
+	return nil
+}
+
+func (o *InitOptions) Validate() error {
+	if o.keyName == "" {
+		return fmt.Errorf("Key name must be specified")
+	}
+	return nil
+}
+
+func (o *InitOptions) Run() error {
+	err := o.Validate()
+	if err != nil {
+		return err
+	}
+
+	err = o.Init()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Initializing Jumphost")
+
+	err = o.generateKeyOpts.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/cluster/jumphost/init.go
+++ b/cmd/cluster/jumphost/init.go
@@ -43,6 +43,10 @@ func (o *InitOptions) Init() error {
 	return nil
 }
 
+// Validate validates the options that are passed to the command. These are generally
+// populated by flags, but in the cases where we would be calling a command from another
+// command these would be manually populated, so it would be a good idea to have a separate
+// set of validation in that case.
 func (o *InitOptions) Validate() error {
 	if o.keyName == "" {
 		return fmt.Errorf("Key name must be specified")
@@ -50,6 +54,10 @@ func (o *InitOptions) Validate() error {
 	return nil
 }
 
+// This should be the entire functionality of the command, from start to end. There's
+// nothing saying that we can't break out into smaller functions here.  Printing output is
+// also something that we should consider how to do effectively, as we might not always
+// want to _print_ the output after running, but we might want to just _use_ the output.
 func (o *InitOptions) Run() error {
 	err := o.Validate()
 	if err != nil {

--- a/pkg/osdctlCommand/command.go
+++ b/pkg/osdctlCommand/command.go
@@ -4,3 +4,7 @@ type Command interface {
 	Validate() error
 	Run() error
 }
+
+type Output interface {
+	Print()
+}

--- a/pkg/osdctlCommand/command.go
+++ b/pkg/osdctlCommand/command.go
@@ -1,0 +1,6 @@
+package command
+
+type Command interface {
+	Validate() error
+	Run() error
+}


### PR DESCRIPTION
This is a demo of a working minimum POC that allows us to call other commands (and subsequently mock them out) by adhering to an interface.

Old commands would need to be retrofit into the new paradigm, so I figured I'd start with a quick little PoC.

It's not _terribly_ different from what we're doing, but we'd want to standardize on it and so I figured I'd open the floor for feedback as early as possible on this.

One thing I would do is create some kind of template file that we could initialize new command files with, so that new commands all use the same template.