### PR TITLE
Adds osdctlCommand interfaces

### DIFF
--- a/pkg/osdctlCommand/command.go
+++ b/pkg/osdctlCommand/command.go
@@ -1,0 +1,11 @@
+package command
+
+type Command interface {
+	Init() error
+	Validate() error
+	Run() (Output, error)
+}
+
+type Output interface {
+	Print()
+}


### PR DESCRIPTION
Adds the initial Command and Output interfaces.  Output might need some work still, especially for outputs with a specific format requested.