### PR TITLE
Refactor servicelog post such that it can be called from other commands

### DIFF
--- a/cmd/cluster/checkbanneduser.go
+++ b/cmd/cluster/checkbanneduser.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+	"github.com/openshift/osdctl/cmd/servicelog"
 	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -63,8 +64,16 @@ func CheckBannedUser(clusterID string) error {
 			fmt.Println("User banned due to export control compliance.\nPlease follow the steps detailed here: https://github.com/openshift/ops-sop/blob/master/v4/alerts/UpgradeConfigSyncFailureOver4HrSRE.md#user-banneddisabled-due-to-export-control-compliance .")
 			return nil
 		}
-		fmt.Println("Recommend sending service log with:")
-		fmt.Printf("osdctl servicelog post -t https://raw.githubusercontent.com/openshift/managed-notifications/master/ocm/cluster_owner_disabled.json %v\n", clusterID)
+
+		fmt.Println("Sending service log.")
+		postCmd := servicelog.PostCmdOptions{
+			Template:  "https://raw.githubusercontent.com/openshift/managed-notifications/master/ocm/cluster_owner_disabled.json",
+			ClusterId: clusterID,
+		}
+		if err = postCmd.Run(); err != nil {
+			return err
+		}
+
 		return nil
 	}
 	fmt.Println("User allowed")

--- a/cmd/cluster/validatepullsecret_test.go
+++ b/cmd/cluster/validatepullsecret_test.go
@@ -37,7 +37,7 @@ func Test_getPullSecretEmail(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			email, err, done := getPullSecretEmail("abc123", tt.secret)
+			email, err, done := getPullSecretEmail("abc123", tt.secret, false)
 			if email != tt.expectedEmail {
 				t.Errorf("getPullSecretEmail() email = %v, expectedEmail %v", email, tt.expectedEmail)
 			}

--- a/cmd/servicelog/cmd.go
+++ b/cmd/servicelog/cmd.go
@@ -19,8 +19,8 @@ func NewCmdServiceLog() *cobra.Command {
 	}
 
 	// Add subcommands
-	servicelogCmd.AddCommand(listCmd) // servicelog list
-	servicelogCmd.AddCommand(postCmd) // servicelog post
+	servicelogCmd.AddCommand(listCmd)      // servicelog list
+	servicelogCmd.AddCommand(newPostCmd()) // servicelog post
 
 	return servicelogCmd
 }

--- a/cmd/servicelog/common.go
+++ b/cmd/servicelog/common.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	templateParams, userParameterNames, userParameterValues, filterParams []string
-	HTMLBody                                                              []byte
+	userParameterNames, userParameterValues, filterParams []string
+	HTMLBody                                              []byte
 )
 
 const (
@@ -25,25 +25,6 @@ func sendRequest(request *sdk.Request) (*sdk.Response, error) {
 		return nil, fmt.Errorf("cannot send request: %q", err)
 	}
 	return response, nil
-}
-
-func check(response *sdk.Response, clusterMessage servicelog.Message) {
-	body := response.Bytes()
-	if response.Status() < 400 {
-		_, err := validateGoodResponse(body, clusterMessage)
-		if err != nil {
-			failedClusters[clusterMessage.ClusterUUID] = err.Error()
-		} else {
-			successfulClusters[clusterMessage.ClusterUUID] = fmt.Sprintf("Message has been successfully sent to %s", clusterMessage.ClusterUUID)
-		}
-	} else {
-		badReply, err := validateBadResponse(body)
-		if err != nil {
-			failedClusters[clusterMessage.ClusterUUID] = err.Error()
-		} else {
-			failedClusters[clusterMessage.ClusterUUID] = badReply.Reason
-		}
-	}
 }
 
 func validateGoodResponse(body []byte, clusterMessage servicelog.Message) (goodReply *servicelog.GoodReply, err error) {


### PR DESCRIPTION
In some instances, the end result of an investigation performed by an osdctl command is to send a service log to the customer. This process is much more easily facilitated if the original command called automatically calls through to the `servicelog post` command. Two recent commands use this functionality (check-banned-user and validate-pull-secret).

The user will still be prompted to confirm before the service log is actually sent.

NOTE: this PR loosely attempts to follow the interface proposed in [336](https://github.com/openshift/osdctl/pull/336)