### PR TITLE
[OSD-15156] Create new client for AWS/GCP abstraction.

### DIFF
--- a/cmd/cluster/health.go
+++ b/cmd/cluster/health.go
@@ -7,12 +7,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/service/ec2"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/osdctl/pkg/osdCloud"
 	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
-	"google.golang.org/api/iterator"
 	"gopkg.in/yaml.v2"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
@@ -104,117 +102,64 @@ func (o *healthOptions) run() error {
 	totalStopped := 0
 	totalCluster := 0
 
+	var clusterHealthClient osdCloud.ClusterHealthClient
+	var ownedLabel string
+	infraID := cluster.InfraID()
 	if cluster.CloudProvider().ID() == "gcp" {
-		clusterResources, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(o.clusterID).Resources().Live().Get().Send()
+		clusterHealthClient, err = osdCloud.NewGcpCluster(ocmClient, o.clusterID)
 		if err != nil {
 			return err
 		}
-		projectClaimRaw, found := clusterResources.Body().Resources()["gcp_project_claim"]
-		if !found {
-			return fmt.Errorf("The gcp_project_claim was not found in the ocm resource")
-		}
-		projectClaim, err := osdCloud.ParseGcpProjectClaim(projectClaimRaw)
-		if err != nil {
-			log.Printf("Unmarshalling GCP projectClaim failed: %v\n", err)
-			return err
-		}
-		projectId := projectClaim.Spec.GcpProjectID
-		zones := cluster.Nodes().AvailabilityZones()
-		if projectId == "" || len(zones) == 0 {
-			return fmt.Errorf("ProjectID or Zones empty - aborting")
-		}
-		gcpClient, err := osdCloud.GenerateGCPComputeInstancesClient()
-		defer gcpClient.Close()
-		if err != nil {
-			return err
-		}
-		ownedLabel := "kubernetes-io-cluster-" + cluster.InfraID()
-		for _, zone := range zones {
-			instances := osdCloud.ListInstances(gcpClient, projectId, zone)
-			for {
-				instance, err := instances.Next()
-				if err == iterator.Done {
-					break
-				}
-				if err != nil {
-					return err
-				}
-				name := instance.GetName()
-				state := instance.GetStatus()
-				labels := instance.GetLabels()
-				belongsToCluster := false
-				for label := range labels {
-					if label == ownedLabel {
-						belongsToCluster = true
-					}
-				}
-				if !belongsToCluster {
-					log.Printf("Skipping a machine not belonging to the cluster: %s\n", name)
-					continue
-				}
-				totalCluster += 1
-				if state != "RUNNING" {
-					totalStopped += 1
-				} else {
-					if strings.HasPrefix(name, cluster.InfraID()) && strings.Contains(name, "master") {
-						runningMasters += 1
-					} else if strings.HasPrefix(name, cluster.InfraID()) && strings.Contains(name, "infra") {
-						runningInfra += 1
-					} else if strings.HasPrefix(name, cluster.InfraID()) && strings.Contains(name, "worker") {
-						runningWorkers += 1
-					}
-				}
-			}
-		}
+		ownedLabel = "kubernetes-io-cluster-" + infraID
+		defer clusterHealthClient.Close()
 	} else if cluster.CloudProvider().ID() == "aws" {
-		awsClient, err := osdCloud.GenerateAWSClientForCluster(o.awsProfile, o.clusterID)
+		clusterHealthClient, err = osdCloud.NewAwsCluster(ocmClient, o.clusterID, o.awsProfile)
 		if err != nil {
 			return err
 		}
-
-		instances, err := awsClient.DescribeInstances(&ec2.DescribeInstancesInput{})
-		if err != nil {
-			return err
-		}
-
-		//Here we count the number of customer's running worker, infra and master instances in the cluster in the given region. To decide if the instance belongs to the cluster we are checking the Name Tag on the instance.
-		for idx := range instances.Reservations {
-			for _, inst := range instances.Reservations[idx].Instances {
-				tags := inst.Tags
-				for _, t := range tags {
-					if *t.Key == "Name" {
-						if strings.HasPrefix(*t.Value, cluster.InfraID()) && strings.Contains(*t.Value, "master") {
-							totalCluster += 1
-							if *inst.State.Name == "running" {
-								runningMasters += 1
-							}
-							if *inst.State.Name == "stopped" {
-								totalStopped += 1
-							}
-
-						} else if strings.HasPrefix(*t.Value, cluster.InfraID()) && strings.Contains(*t.Value, "infra") {
-							totalCluster += 1
-							if *inst.State.Name == "running" {
-								runningInfra += 1
-							}
-							if *inst.State.Name == "stopped" {
-								totalStopped += 1
-							}
-						} else if strings.HasPrefix(*t.Value, cluster.InfraID()) && strings.Contains(*t.Value, "worker") {
-							totalCluster += 1
-							if *inst.State.Name == "running" {
-								runningWorkers += 1
-							}
-							if *inst.State.Name == "stopped" {
-								totalStopped += 1
-							}
-						}
-					}
-				}
-			}
-		}
+		ownedLabel = "kubernetes.io/cluster/" + infraID
+		defer clusterHealthClient.Close()
 	} else {
 		return errors.New(fmt.Sprintf("Unknown cloud provider found: %s", cluster.CloudProvider().ID()))
+	}
+	err = clusterHealthClient.Login()
+	if err != nil {
+		return err
+	}
+	for _, zone := range clusterHealthClient.GetAZs() {
+		instances, err := clusterHealthClient.GetAllVirtualMachines(zone)
+		if err != nil {
+			return err
+		}
+		for _, instance := range instances {
+			name := instance.Name
+			state := instance.State
+			labels := instance.Labels
+			belongsToCluster := false
+			for label := range labels {
+				if label == ownedLabel {
+					belongsToCluster = true
+				}
+			}
+			if !belongsToCluster {
+				if o.verbose {
+					log.Printf("Skipping a machine not belonging to the cluster: %s\n", name)
+				}
+				continue
+			}
+			totalCluster += 1
+			if state != "running" {
+				totalStopped += 1
+			} else {
+				if strings.HasPrefix(name, infraID) && strings.Contains(name, "master") {
+					runningMasters += 1
+				} else if strings.HasPrefix(name, infraID) && strings.Contains(name, "infra") {
+					runningInfra += 1
+				} else if strings.HasPrefix(name, infraID) && strings.Contains(name, "worker") {
+					runningWorkers += 1
+				}
+			}
+		}
 	}
 
 	healthObject.Actual.Stopped = totalStopped

--- a/pkg/osdCloud/gcp.go
+++ b/pkg/osdCloud/gcp.go
@@ -3,8 +3,13 @@ package osdCloud
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	"google.golang.org/api/iterator"
 	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
 
@@ -37,4 +42,87 @@ func ListInstances(client *compute.InstancesClient, projectID, zone string) *com
 		Zone:    zone,
 	}
 	return client.List(ctx, request)
+}
+
+// Concrete struct with fields required only for interacting with the GCP cloud.
+type GcpCluster struct {
+	*BaseClient
+	ComputeClient *compute.InstancesClient
+	ProjectId     string
+	Zones         []string
+}
+
+func NewGcpCluster(ocmClient *sdk.Connection, clusterId string) (ClusterHealthClient, error) {
+	clusterResp, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(clusterId).Get().Send()
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+	cluster := clusterResp.Body()
+	return &GcpCluster{
+		BaseClient: &BaseClient{
+			ClusterId: clusterId,
+			OcmClient: ocmClient,
+			Cluster:   cluster,
+		},
+	}, nil
+}
+
+func (g *GcpCluster) Login() error {
+	clusterResources, err := g.OcmClient.ClustersMgmt().V1().Clusters().Cluster(g.ClusterId).Resources().Live().Get().Send()
+	if err != nil {
+		return err
+	}
+	projectClaimRaw, found := clusterResources.Body().Resources()["gcp_project_claim"]
+	if !found {
+		return fmt.Errorf("The gcp_project_claim was not found in the ocm resource")
+	}
+	projectClaim, err := ParseGcpProjectClaim(projectClaimRaw)
+	if err != nil {
+		log.Printf("Unmarshalling GCP projectClaim failed: %v\n", err)
+		return err
+	}
+	g.ProjectId = projectClaim.Spec.GcpProjectID
+	g.Zones = g.Cluster.Nodes().AvailabilityZones()
+	if g.ProjectId == "" || len(g.Zones) == 0 {
+		return fmt.Errorf("ProjectID or Zones empty - aborting")
+	}
+	g.ComputeClient, err = GenerateGCPComputeInstancesClient()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (g *GcpCluster) Close() {
+	if g.ComputeClient != nil {
+		g.ComputeClient.Close()
+	}
+}
+
+func (g *GcpCluster) GetAZs() []string {
+	return g.Zones
+}
+
+func (g *GcpCluster) GetAllVirtualMachines(region string) ([]VirtualMachine, error) {
+	vms := make([]VirtualMachine, 5)
+	instances := ListInstances(g.ComputeClient, g.ProjectId, region)
+	for {
+		instance, err := instances.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		vm := VirtualMachine{
+			Original: instance,
+			Name:     instance.GetName(),
+			Size:     instance.GetMachineType(),
+			State:    strings.ToLower(instance.GetStatus()),
+			Labels:   instance.GetLabels(),
+		}
+		vms = append(vms, vm)
+	}
+	return vms, nil
 }

--- a/pkg/osdCloud/interfaces.go
+++ b/pkg/osdCloud/interfaces.go
@@ -1,0 +1,40 @@
+package osdCloud
+
+import (
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	ocmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+// This client is used to interface with AWS & GCP and provide common
+// abstractions that are generated from the cloud-specific resources.
+// Right now the client is only used by the `osdctl cluster health` command and only
+// provides functions used in that command.
+// It can and should be extended as seen fit if it seems useful.
+type ClusterHealthClient interface {
+	Login() error
+	GetCluster() *ocmv1.Cluster
+	GetAZs() []string
+	GetAllVirtualMachines(region string) ([]VirtualMachine, error)
+	Close()
+}
+
+// A common struct used to not repeat fields used in the sub'classes' for AWS and GCP.
+type BaseClient struct {
+	ClusterId string
+	OcmClient *sdk.Connection
+	Cluster   *ocmv1.Cluster
+}
+
+func (b *BaseClient) GetCluster() *ocmv1.Cluster {
+	return b.Cluster
+}
+
+// Abstract the AWS instances and GCP instances into a common type.
+// The Original field should store the data returned by the cloud directly, so it can be accessed via casting if needed.
+type VirtualMachine struct {
+	Original interface{}
+	Name     string
+	Size     string
+	State    string
+	Labels   map[string]string
+}


### PR DESCRIPTION
Currently the client is only used for the health command and abstracts GCP & AWS into a common client.