### PR TITLE
Use aws_proxy_url for awsClient if it's set in the osdctl config

### DIFF
--- a/cmd/account/console.go
+++ b/cmd/account/console.go
@@ -102,7 +102,7 @@ func (o *consoleOptions) run() error {
 		}
 	}
 
-	// Build the base AWS client using the provide credentials (profile or env vars)
+	// Build the base AWS client using the provided credentials (profile or env vars)
 	awsClient, err := aws.NewAwsClient(o.awsProfile, o.region, "")
 	if err != nil {
 		fmt.Printf("Could not build AWS Client: %s\n", err)

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -5,6 +5,9 @@ package aws
 
 import (
 	"fmt"
+	"github.com/spf13/viper"
+	"net/http"
+	"net/url"
 	"path/filepath"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -30,6 +33,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 )
+
+const awsProxyUrlKey = "aws_proxy_url"
 
 // AwsClientInput input for new aws client
 type AwsClientInput struct {
@@ -141,6 +146,16 @@ func NewAwsSession(profile, region, configFile string) (*session.Session, error)
 			Region: aws.String(region),
 		},
 		Profile: profile,
+	}
+
+	if awsProxyUrl := viper.GetString(awsProxyUrlKey); awsProxyUrl != "" {
+		opt.Config.HTTPClient = &http.Client{
+			Transport: &http.Transport{
+				Proxy: func(*http.Request) (*url.URL, error) {
+					return url.Parse(awsProxyUrl)
+				},
+			},
+		}
 	}
 
 	// only set config file if it is not empty


### PR DESCRIPTION
This work comes as a result of [SDE-2305](https://issues.redhat.com/browse/SDE-2305) in preparation of future work.

When creating the the AWS Client - and by extension the Session - used for communication with AWS services, osdctl will check to see if "aws_proxy_url" is defined in `~/.config/osdctl` and use the defined value as a proxy for requests.