### PR TITLE
[OSD-15150] osdctl network verify-egress should have a way to specify all subnets

### DIFF
--- a/cmd/network/verification.go
+++ b/cmd/network/verification.go
@@ -127,7 +127,7 @@ func (e *EgressVerification) Run(ctx context.Context) {
 		log.Fatal(err)
 	}
 
-	for i, _ := range inputs {
+	for i := range inputs {
 		e.log.Info(ctx, "running with config: %+v", inputs[i])
 		e.log.Info(ctx, "running network verifier for subnet  %+v, security group %+v", inputs[i].SubnetID, inputs[i].AWS.SecurityGroupId)
 		out := onv.ValidateEgress(c, *inputs[i])
@@ -260,7 +260,7 @@ func (e *EgressVerification) generateAWSValidateEgressInput(ctx context.Context,
 
 	//Creating a slice of input values to run in a for loop in the network-verifier
 	inputs := make([]*onv.ValidateEgressInput, len(subnetId))
-	for i, _ := range subnetId {
+	for i := range subnetId {
 		inputs[i] = input
 		inputs[i].SubnetID = subnetId[i]
 
@@ -277,7 +277,7 @@ func (e *EgressVerification) getSubnetId(ctx context.Context) ([]string, error) 
 		e.log.Info(ctx, "using manually specified subnet-id: %s", e.SubnetId)
 		return e.SubnetId, nil
 	}
-	//If the --all-subnets flag is specified, and the cluster is privatelink, the network verifier will be run on all the subnets listed in ocm
+	//If the --all-subnets flag is specified, and the cluster is Privatelink, the network verifier will be run on all the subnets listed in ocm
 	if e.AllSubnets {
 
 		if e.cluster.AWS().SubnetIDs() != nil && e.cluster.AWS().PrivateLink() {

--- a/cmd/network/verification_test.go
+++ b/cmd/network/verification_test.go
@@ -64,7 +64,7 @@ func Test_egressVerificationSetup(t *testing.T) {
 			name: "ClusterId optional",
 			e: &EgressVerification{
 				ClusterId:       "",
-				SubnetId:        "subnet-a",
+				SubnetId:        []string{"subnet-a"},
 				SecurityGroupId: "sg-b",
 			},
 			expectErr: false,
@@ -169,8 +169,10 @@ func Test_egressVerificationGenerateAWSValidateEgressInput(t *testing.T) {
 				if test.expectErr {
 					t.Errorf("expected err, got none")
 				}
-				if !compareValidateEgressInput(test.expected, actual) {
-					t.Errorf("expected %v, got %v", test.expected, actual)
+				for i, _ := range actual {
+					if !compareValidateEgressInput(test.expected, actual[i]) {
+						t.Errorf("expected %v, got %v", test.expected, actual[i])
+					}
 				}
 			}
 		})
@@ -263,7 +265,7 @@ func Test_egressVerificationGetSubnetId(t *testing.T) {
 			name: "manual override",
 			e: &EgressVerification{
 				log:      newTestLogger(t),
-				SubnetId: "override",
+				SubnetId: []string{"override"},
 			},
 			expected:  "override",
 			expectErr: false,
@@ -326,11 +328,14 @@ func Test_egressVerificationGetSubnetId(t *testing.T) {
 					t.Errorf("expected no err, got %s", err)
 				}
 			} else {
-				if test.expectErr {
-					t.Errorf("expected err, got none")
-				}
-				if actual != test.expected {
-					t.Errorf("expected subnet-id %s, got %s", test.expected, actual)
+				for i, _ := range actual {
+
+					if test.expectErr {
+						t.Errorf("expected err, got none")
+					}
+					if actual[i] != test.expected {
+						t.Errorf("expected subnet-id %s, got %s", test.expected, actual[i])
+					}
 				}
 			}
 		})

--- a/cmd/network/verification_test.go
+++ b/cmd/network/verification_test.go
@@ -169,7 +169,7 @@ func Test_egressVerificationGenerateAWSValidateEgressInput(t *testing.T) {
 				if test.expectErr {
 					t.Errorf("expected err, got none")
 				}
-				for i, _ := range actual {
+				for i := range actual {
 					if !compareValidateEgressInput(test.expected, actual[i]) {
 						t.Errorf("expected %v, got %v", test.expected, actual[i])
 					}
@@ -328,7 +328,7 @@ func Test_egressVerificationGetSubnetId(t *testing.T) {
 					t.Errorf("expected no err, got %s", err)
 				}
 			} else {
-				for i, _ := range actual {
+				for i := range actual {
 
 					if test.expectErr {
 						t.Errorf("expected err, got none")

--- a/cmd/network/verification_test.go
+++ b/cmd/network/verification_test.go
@@ -435,7 +435,7 @@ func Test_egressVerificationGetSubnetIdAllSubnetsFlag(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "non-BYOVPC clusters get subnets from AWS, with --all-subnets flag",
+			name: "non-BYOVPC clusters get subnets from AWS",
 			e: &EgressVerification{
 				awsClient: mockEgressVerificationAWSClient{
 					describeSubnetsResp: &ec2.DescribeSubnetsOutput{
@@ -451,6 +451,31 @@ func Test_egressVerificationGetSubnetIdAllSubnetsFlag(t *testing.T) {
 				AllSubnets: true,
 			},
 			expected:  []string{"subnet-abcd"},
+			expectErr: false,
+		},
+		{
+			name: "non-BYOVPC clusters get subnets from AWS, all-subnets flag enabled",
+			e: &EgressVerification{
+				awsClient: mockEgressVerificationAWSClient{
+					describeSubnetsResp: &ec2.DescribeSubnetsOutput{
+						Subnets: []types.Subnet{
+							{
+								SubnetId: aws.String("subnet-abcd"),
+							},
+							{
+								SubnetId: aws.String("subnet-1234"),
+							},
+							{
+								SubnetId: aws.String("subnet-1267"),
+							},
+						},
+					},
+				},
+				cluster:    newTestCluster(t, cmv1.NewCluster()),
+				log:        newTestLogger(t),
+				AllSubnets: true,
+			},
+			expected:  []string{"subnet-abcd", "subnet-1234", "subnet-1267"},
 			expectErr: false,
 		},
 	}


### PR DESCRIPTION
In this commit, I added an --all-networks option to osdctl network verify-egress commands. When this option is specified, the cluster will run the network verifier against all subnets listed by ocm if the cluster is Privatelink. If the cluster is not private link, and non-BYOVPC the --all-networks option will run the network verifier against all private subnets found by tags, and the command will run as it would without the --all-networks flag for all other cases.

https://issues.redhat.com/browse/OSD-15150