### PR TITLE
Make OHSS cards in `cluster context` easier to scan

### DIFF
--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -506,7 +506,7 @@ func (o *contextOptions) printJIRAOHSS(jiraClient *jira.Client) error {
 	jql := fmt.Sprintf(
 		`(project = "OpenShift Hosted SRE Support" AND "Cluster ID" ~ "%s") 
 		OR (project = "OpenShift Hosted SRE Support" AND "Cluster ID" ~ "%s") 
-		ORDER BY priority DESC, Status DESC`,
+		ORDER BY created DESC`,
 		o.externalClusterID,
 		o.clusterID,
 	)
@@ -523,7 +523,8 @@ func (o *contextOptions) printJIRAOHSS(jiraClient *jira.Client) error {
 	fmt.Println("============================================================")
 
 	for _, i := range issues {
-		fmt.Printf("[%s](%s/%s): %+v [Status: %s]\n", i.Key, i.Fields.Type.Name, i.Fields.Priority.Name, i.Fields.Summary, i.Fields.Status.Name)
+		fmt.Printf("[%s](%s/%s): %+v\n", i.Key, i.Fields.Type.Name, i.Fields.Priority.Name, i.Fields.Summary)
+		fmt.Printf("- Created: %s\tStatus: %s\n", time.Time(i.Fields.Created).Format("2006-01-02 15:04"), i.Fields.Status.Name)
 		fmt.Printf("- Link: https://issues.redhat.com/browse/%s\n\n", i.Key)
 	}
 


### PR DESCRIPTION
Adds more information in the OHSS card listing (creation times) and orders them chronologically, so it's easier to make a call on the recent history of a given cluster by scanning that card list.

When comparing the output from before this change and with this change, it's clear on the latter (even with card names obscured) that the most recent OHSS ticket is likely the only one worth attention when troubleshooting a new issue.

Resolves #345

The new output for `osdctl cluster context` would be:

```
============================================================
Cluster OHSS Cards
============================================================
[OHSS-20085](Task/Medium): Quasi architecto beatae vitae dicta sunt explicabo
- Created: 2023-03-27 12:39     Status: In Progress
- Link: https://issues.redhat.com/browse/OHSS-20085

[OHSS-15792](Task/Medium): Modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem
- Created: 2022-10-10 13:31     Status: Resolved
- Link: https://issues.redhat.com/browse/OHSS-15792

[OHSS-14415](Task/Medium): Consequuntur magni dolores eos qui ratione
- Created: 2022-08-09 16:09     Status: Resolved
- Link: https://issues.redhat.com/browse/OHSS-14415

[OHSS-14176](Incident/High):  Lorem ipsum dolor
- Created: 2022-07-31 10:06     Status: Resolved
- Link: https://issues.redhat.com/browse/OHSS-14176

[OHSS-13559](Task/High): Exercitation ullamco laboris nisi ut aliquip ex ea commodo
- Created: 2022-07-05 11:40     Status: Resolved
- Link: https://issues.redhat.com/browse/OHSS-13559

[OHSS-10723](Task/High): Quis nostrud exercitation ullamco laboris nisi
- Created: 2022-03-11 12:57     Status: Resolved
- Link: https://issues.redhat.com/browse/OHSS-10723

[OHSS-8852](Task/Medium): Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet
- Created: 2021-12-28 08:43     Status: Resolved
- Link: https://issues.redhat.com/browse/OHSS-8852

[OHSS-8825](Task/Medium): Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis
- Created: 2021-12-23 14:58     Status: Resolved
- Link: https://issues.redhat.com/browse/OHSS-8825

[OHSS-4152](Task/Medium): Quis autem vel eum iure reprehenderit qui in
- Created: 2021-05-11 09:02     Status: Resolved
- Link: https://issues.redhat.com/browse/OHSS-4152
```


Changed from this:

```
============================================================
Cluster OHSS Cards
============================================================
[OHSS-14176](Incident/High): Lorem ipsum dolor [Status: Resolved]
- Link: https://issues.redhat.com/browse/OHSS-14176

[OHSS-10723](Task/High): Quis nostrud exercitation ullamco laboris nisi  [Status: Resolved]
- Link: https://issues.redhat.com/browse/OHSS-10723

[OHSS-13559](Task/High): Exercitation ullamco laboris nisi ut aliquip ex ea commodo  [Status: Resolved]
- Link: https://issues.redhat.com/browse/OHSS-13559

[OHSS-20085](Task/Medium): Quasi architecto beatae vitae dicta sunt explicabo [Status: In Progress]
- Link: https://issues.redhat.com/browse/OHSS-20085

[OHSS-14415](Task/Medium): Consequuntur magni dolores eos qui ratione  [Status: Resolved]
- Link: https://issues.redhat.com/browse/OHSS-14415

[OHSS-15792](Task/Medium): Modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem [Status: Resolved]
- Link: https://issues.redhat.com/browse/OHSS-15792

[OHSS-8825](Task/Medium): Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis [Status: Resolved]
- Link: https://issues.redhat.com/browse/OHSS-8825

[OHSS-4152](Task/Medium): Quis autem vel eum iure reprehenderit qui in [Status: Resolved]
- Link: https://issues.redhat.com/browse/OHSS-4152

[OHSS-8852](Task/Medium): Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet [Status: Resolved]
- Link: https://issues.redhat.com/browse/OHSS-8852
```