### PR TITLE
[WIP] Add reset accounts by legal entity functionality to aao command

### DIFF
--- a/cmd/aao/cmd.go
+++ b/cmd/aao/cmd.go
@@ -2,12 +2,14 @@ package aao
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewCmdAao implements the base aao command
-func NewCmdAao(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+func NewCmdAao(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
 	aaoCmd := &cobra.Command{
 		Use:               "aao",
 		Short:             "AWS Account Operator Debugging Utilities",
@@ -16,6 +18,7 @@ func NewCmdAao(streams genericclioptions.IOStreams, flags *genericclioptions.Con
 	}
 
 	aaoCmd.AddCommand(newCmdPool(streams, flags))
+	aaoCmd.AddCommand(newCmdReset(streams, flags, client))
 
 	return aaoCmd
 }

--- a/cmd/aao/reset.go
+++ b/cmd/aao/reset.go
@@ -1,0 +1,80 @@
+package aao
+
+import (
+	"context"
+	"fmt"
+
+	awsv1alpha1 "github.com/openshift/aws-account-operator/api/v1alpha1"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newCmdReset(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
+	ops := newResetOptions(streams, flags, client)
+	resetCmd := &cobra.Command{
+		Use:               "reset <legalEntityID>",
+		Short:             "Reset the unnused AWS Accounts for a specific Legal Entity ID",
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.complete(cmd, args))
+			cmdutil.CheckErr(ops.run())
+		},
+	}
+
+	resetCmd.Flags().StringVar(&ops.legalEntityID, "legalEntityID", "", "The legal entity ID you'd like to reset")
+	resetCmd.Flags().IntVar(&ops.count, "count", 10, "How many accounts you'd like to reset in this legal entity. Defaults to 10")
+
+	return resetCmd
+}
+
+// resetOptions defines the struct for running reset command
+type resetOptions struct {
+	legalEntityID string
+	count         int
+
+	flags *genericclioptions.ConfigFlags
+	genericclioptions.IOStreams
+	kubeCli client.Client
+}
+
+func newResetOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *resetOptions {
+	return &resetOptions{
+		flags:     flags,
+		IOStreams: streams,
+		kubeCli:   client,
+	}
+}
+
+func (o *resetOptions) complete(cmd *cobra.Command, args []string) error {
+	if o.legalEntityID == "" {
+		return cmdutil.UsageErrorf(cmd, "Legal Entity ID argument is required")
+	}
+	if o.count <= 0 {
+		return cmdutil.UsageErrorf(cmd, "Count must be greater than 0")
+	}
+	return nil
+}
+
+func (o *resetOptions) run() error {
+	ctx := context.TODO()
+	var accounts awsv1alpha1.AccountList
+	if err := o.kubeCli.List(ctx, &accounts, &client.ListOptions{
+		Namespace: "aws-account-operator",
+	}); err != nil {
+		return err
+	}
+
+	resetCount := 0
+	for _, account := range accounts.Items {
+		if resetCount < o.count {
+			if !account.Status.Claimed && account.Spec.LegalEntity.ID == o.legalEntityID && !account.Spec.BYOC {
+				fmt.Printf("%d. Resetting account %s\n", resetCount, account.Name)
+				// TODO refactor osdctl account reset to be called here
+				resetCount++
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -68,7 +68,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	kubeClient := k8s.NewClient(kubeFlags)
 
 	// add sub commands
-	rootCmd.AddCommand(aao.NewCmdAao(streams, kubeFlags))
+	rootCmd.AddCommand(aao.NewCmdAao(streams, kubeFlags, kubeClient))
 	rootCmd.AddCommand(account.NewCmdAccount(streams, kubeFlags, kubeClient, globalOpts))
 	rootCmd.AddCommand(cluster.NewCmdCluster(streams, kubeFlags, kubeClient, globalOpts))
 	rootCmd.AddCommand(clusterdeployment.NewCmdClusterDeployment(streams, kubeFlags, kubeClient))


### PR DESCRIPTION
Still todo:
- refactor osdctl account reset to be more easily callable by other packages 

Proposed output
```
osdctl aao reset --legalEntityID 1HfHhu0eGT7HtPtFtHByhuZqI85
0. Resetting account osd-creds-mgmt-226xcp
1. Resetting account osd-creds-mgmt-22gf87
2. Resetting account osd-creds-mgmt-28zjpw
3. Resetting account osd-creds-mgmt-2vdvxf
4. Resetting account osd-creds-mgmt-4nxnft
5. Resetting account osd-creds-mgmt-4zhtn9
6. Resetting account osd-creds-mgmt-5ghrww
7. Resetting account osd-creds-mgmt-5mdn5h
8. Resetting account osd-creds-mgmt-5zj2zk
9. Resetting account osd-creds-mgmt-5zs82v
0. Resetting account osd-creds-mgmt-226xcp
1. Resetting account osd-creds-mgmt-22gf87
2. Resetting account osd-creds-mgmt-28zjpw
3. Resetting account osd-creds-mgmt-2vdvxf
4. Resetting account osd-creds-mgmt-4nxnft
5. Resetting account osd-creds-mgmt-4zhtn9
6. Resetting account osd-creds-mgmt-5ghrww
7. Resetting account osd-creds-mgmt-5mdn5h
8. Resetting account osd-creds-mgmt-5zj2zk
9. Resetting account osd-creds-mgmt-5zs82v
```