### PR TITLE
use single-quoted character literal for region value

### DIFF
--- a/cmd/account/cli.go
+++ b/cmd/account/cli.go
@@ -149,7 +149,7 @@ func (o *cliOptions) run() error {
 	}
 
 	if o.output == "json" {
-		fmt.Printf("{\n\"AccessKeyId\": %q, \n\"Expiration\": %q, \n\"SecretAccessKey\": %q, \n\"SessionToken\": %q, \n\"Region\": %s\n}",
+		fmt.Printf("{\n\"AccessKeyId\": %q, \n\"Expiration\": %q, \n\"SecretAccessKey\": %q, \n\"SessionToken\": %q, \n\"Region\": %q\n}",
 			*assumedRoleCreds.AccessKeyId,
 			*assumedRoleCreds.Expiration,
 			*assumedRoleCreds.SecretAccessKey,


### PR DESCRIPTION
currently osdctl account cli -o json returns invalid json object because region value is not quoted
```
{
"AccessKeyId": "***", 
"Expiration": "***", 
"SecretAccessKey": "***", 
"SessionToken": "***", 
"Region": us-west-2
}
```