### PR TITLE
Cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ unexport GOFLAGS
 # but otherwise can be installed elsewhere on developers machines
 BASE_DIR=$(shell pwd)
 export PATH:=$(BASE_DIR)/bin:$(PATH)
-SHELL := env PATH=$(PATH) /bin/bash
+SHELL := /bin/bash
 
 
 all: format mod build test lint
@@ -39,7 +39,7 @@ build:
 	goreleaser build --clean --snapshot --single-target=${SINGLE_TARGET}
 
 release:
-	./bin/goreleaser release --clean
+	goreleaser release --clean
 
 vet:
 	go vet ${BUILDFLAGS} ./...

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Currently, it mainly supports related work for AWS, especially [aws-account-oper
 #### Requirements
 
 - Go >= 1.19
-- make
+- make (gmake if on macOS)
 - [goreleaser](https://github.com/goreleaser)
 - `GOPROXY` contains `proxy.golang.org` as highest priority
   ```shell

--- a/cmd/cluster/from_infra_id_test.go
+++ b/cmd/cluster/from_infra_id_test.go
@@ -31,8 +31,8 @@ func TestGetClusterNameFromInfraIdWithOneSegment(t *testing.T) {
 }
 
 func TestGetClusterNameFromEmptyInfraId(t *testing.T) {
-	infraIdWithOneSegment := "" // one segment, no hyphens
-	actualName, err := getClusterNameFromInfraId(infraIdWithOneSegment)
+	emptyInfraId := "" // one segment, no hyphens
+	actualName, err := getClusterNameFromInfraId(emptyInfraId)
 	if actualName != "" {
 		t.Errorf("no name should be returned from empty infrastructure id, got %s", actualName)
 	}

--- a/docs/command/osdctl_cluster_from-infra-id.md
+++ b/docs/command/osdctl_cluster_from-infra-id.md
@@ -1,11 +1,15 @@
-## osdctl cluster
+## osdctl cluster from-infra-id
 
-Provides information for a specified cluster
+Get cluster ID and external ID from a given infrastructure ID commonly used by Splunk
+
+```
+osdctl cluster from-infra-id [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for cluster
+  -h, --help   help for from-infra-id
 ```
 
 ### Options inherited from parent commands
@@ -31,17 +35,5 @@ Provides information for a specified cluster
 
 ### SEE ALSO
 
-* [osdctl](osdctl.md)	 - OSD CLI
-* [osdctl cluster break-glass](osdctl_cluster_break-glass.md)	 - Emergency access to a cluster
-* [osdctl cluster check-banned-user](osdctl_cluster_check-banned-user.md)	 - Checks if the cluster owner is a banned user.
-* [osdctl cluster context](osdctl_cluster_context.md)	 - Shows the context of a specified cluster
-* [osdctl cluster cpd](osdctl_cluster_cpd.md)	 - Runs diagnostic for a Cluster Provisioning Delay (CPD)
-* [osdctl cluster from-infra-id](osdctl_cluster_from-infra-id.md)	 - Get cluster ID and external ID from a given infrastructure ID commonly used by Splunk
-* [osdctl cluster health](osdctl_cluster_health.md)	 - Describes health of cluster nodes and provides other cluster vitals.
-* [osdctl cluster logging-check](osdctl_cluster_logging-check.md)	 - Shows the logging support status of a specified cluster
-* [osdctl cluster owner](osdctl_cluster_owner.md)	 - List the clusters owned by the user (can be specified to any user, not only yourself)
-* [osdctl cluster resize-control-plane-node](osdctl_cluster_resize-control-plane-node.md)	 - Resize a control plane node. Requires previous login to the api server via `ocm login` and being tunneled to the backplane.
-* [osdctl cluster support](osdctl_cluster_support.md)	 - Cluster Support
-* [osdctl cluster transfer-owner](osdctl_cluster_transfer-owner.md)	 - Transfer cluster ownership to a new user (to be done by Region Lead)
-* [osdctl cluster validate-pull-secret](osdctl_cluster_validate-pull-secret.md)	 - Checks if the pull secret email matches the owner email
+* [osdctl cluster](osdctl_cluster.md)	 - Provides information for a specified cluster
 

--- a/docs/command/osdctl_network_verify-egress.md
+++ b/docs/command/osdctl_network_verify-egress.md
@@ -43,14 +43,15 @@ osdctl network verify-egress [flags]
 ### Options
 
 ```
+  -A, --all-subnets             (optional) an option for Privatelink clusters to run osd-network-verifier against all subnets listed by ocm.
       --cacert string           (optional) path to a file containing the additional CA trust bundle. Typically set so that the verifier can use a configured cluster-wide proxy.
-      --cluster-id string       (optional) OCM internal/external cluster id to run osd-network-verifier against.
+  -C, --cluster-id string       (optional) OCM internal/external cluster id to run osd-network-verifier against.
       --debug                   (optional) if provided, enable additional debug-level logging
   -h, --help                    help for verify-egress
       --no-tls                  (optional) if provided, ignore all ssl certificate validations on client-side.
       --region string           (optional) AWS region
       --security-group string   (optional) security group ID override for osd-network-verifier, required if not specifying --cluster-id
-      --subnet-id string        (optional) private subnet ID override, required if not specifying --cluster-id
+      --subnet-id stringArray   (optional) private subnet ID override, required if not specifying --cluster-id and can be specified multiple times to run against multiple subnets
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Recently when making changes to this project, I noticed a couple things to tidy up.

1. the Makefile did not run if you had a space in a PATH element
2. using gmake on macOS requires fewer changes and is what our Linux colleagues are using so doc that in the README
3. doc generation for new and updated commands
4. fix copy-paste issue in a test I recently added