### PR TITLE
Skips version check for osdctl in `make docs`

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -125,7 +125,7 @@ func canCommandSkipVersionCheck(commandName string) bool {
 
 // Returns allowlist of commands that can skip version check
 func getSkipVersionCommands() []string {
-	return []string{"upgrade", "version"}
+	return []string{"docs", "upgrade", "version"}
 }
 
 func versionCheck() {


### PR DESCRIPTION
    Skips version check for osdctl in `make docs`
    
    This skips the version check for osdctl when used to generate docs.
    
    This is most likely to only be used in the Makefile, and without
    skipping the version check, breaks the usage in `make docs`, as the
    newly built ./dist/$OSDCTL from `make build` will not appear to be a
    proper, later release.
    
    I don't think there's an issue if this doesn't prompt if someone were to
    run the `osdctl docs` command manually, for some reason, as any official
    usage would be committed, and would fail tests if the docs generated by
    an old version don't match what the prow pipeline generates during
    testing.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
