### PR TITLE
Added the 'Get cluster context' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,19 @@ osdctl sts policy <OCP version>
 osdctl sts policy-diff <old version> <new version>
 ```
 
+### Get cluster context
+
+`context` command shows the context of a specified cluster. 
+```bash
+osdctl cluster context <cluster identifier> --jiratoken jira_token --oauthtoken pd_oauth_token --usertoken pd_user_token 
+```
+The command flags can be suppressed from CLI if the variables are informed in the ~/.config/osdctl config file:
+```
+pd_oauth_token: TOKEN
+pd_user_token: TOKEN
+jira_token: TOKEN
+```
+
 ### Hive ClusterDeployment CR list
 
 ```bash


### PR DESCRIPTION
I have added the get cluster context section to the README file since the _context_ command fails with segfault if the PD tokens are not informed:
```
$ osdctl cluster context xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
The current version () is different than the latest released version (v0.14.3).It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.
Please confirm that you would like to continue with [y|n]
y
Getting Limited Support Reason...
Getting Service Logs...
Getting Jira Issues...
Getting Support Exceptions...
Getting Pagerduty Service...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x3c2712c]

goroutine 1 [running]:
github.com/PagerDuty/go-pagerduty.(*Client).get(0xc00077c540?, {0x5c07800?, 0xc000078290?}, {0xc0006dccc0?, 0x10?})
	/home/givaldolins/go/pkg/mod/github.com/!pager!duty/go-pagerduty@v1.5.1/client.go:470 +0x2c
github.com/PagerDuty/go-pagerduty.(*Client).ListServicesWithContext(0x1b213c0?, {0x5c07800, 0xc000078290}, {0x0, 0x0, 0x0, {0xc000499400, 0x1, 0x1}, {0x0, ...}, ...})
	/home/givaldolins/go/pkg/mod/github.com/!pager!duty/go-pagerduty@v1.5.1/service.go:163 +0xe5
github.com/openshift/osdctl/cmd/cluster.GetPDSeviceID({0xc0010fd0c0, 0x19}, {0x0?, 0x1?}, {0x0?, 0xc0003fd0f8?})
	/home/givaldolins/git/osdctl/cmd/cluster/context.go:614 +0x14f
github.com/openshift/osdctl/cmd/cluster.(*contextOptions).generateContextData(0xc00026c840)
	/home/givaldolins/git/osdctl/cmd/cluster/context.go:332 +0x995
github.com/openshift/osdctl/cmd/cluster.(*contextOptions).run(0xc00026c840)
	/home/givaldolins/git/osdctl/cmd/cluster/context.go:159 +0x25
github.com/openshift/osdctl/cmd/cluster.newCmdContext.func1(0xc0003a4f00?, {0xc0001692b0?, 0x1?, 0x1?})
	/home/givaldolins/git/osdctl/cmd/cluster/context.go:96 +0x4f
github.com/spf13/cobra.(*Command).execute(0xc0003a4f00, {0xc000169280, 0x1, 0x1})
	/home/givaldolins/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:920 +0x847
github.com/spf13/cobra.(*Command).ExecuteC(0xc0002bf800)
	/home/givaldolins/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/home/givaldolins/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
main.main()
	/home/givaldolins/git/osdctl/main.go:23 +0x10d
$
``` 