### PR TITLE
Use existing struct from the SDK instead of our own custom code

### DIFF
--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"os"
 	"os/exec"
 	"sort"
@@ -63,7 +64,7 @@ type contextData struct {
 	ClusterVersion string
 	ClusterID      string
 	// limited Support Status
-	LimitedSupportReasons []*utils.LimitedSupportReasonItem
+	LimitedSupportReasons []*cmv1.LimitedSupportReason
 	// Service Logs
 	ServiceLogs []sl.ServiceLogShort
 
@@ -730,7 +731,7 @@ func printServiceLogs(serviceLogs []sl.ServiceLogShort, verbose bool, sinceDays 
 }
 
 // printSupportStatus reports if a cluster is in limited support or fully supported.
-func printSupportStatus(limitedSupportReasons []*utils.LimitedSupportReasonItem) {
+func printSupportStatus(limitedSupportReasons []*cmv1.LimitedSupportReason) {
 
 	fmt.Println("============================================================")
 	fmt.Println("Limited Support Status")
@@ -746,7 +747,7 @@ func printSupportStatus(limitedSupportReasons []*utils.LimitedSupportReasonItem)
 	table := printer.NewTablePrinter(os.Stdout, 20, 1, 3, ' ')
 	table.AddRow([]string{"Reason ID", "Summary", "Details"})
 	for _, clusterLimitedSupportReason := range limitedSupportReasons {
-		table.AddRow([]string{clusterLimitedSupportReason.ID, clusterLimitedSupportReason.Summary, clusterLimitedSupportReason.Details})
+		table.AddRow([]string{clusterLimitedSupportReason.ID(), clusterLimitedSupportReason.Summary(), clusterLimitedSupportReason.Details()})
 	}
 	// Add empty row for readability
 	table.AddRow([]string{})

--- a/cmd/cluster/support/common.go
+++ b/cmd/cluster/support/common.go
@@ -3,6 +3,7 @@ package support
 import (
 	"errors"
 	"fmt"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	ctlutil "github.com/openshift/osdctl/pkg/utils"
 	"os"
 
@@ -18,7 +19,7 @@ func sendRequest(request *sdk.Request) (*sdk.Response, error) {
 	return response, nil
 }
 
-func getLimitedSupportReasons(clusterId string) ([]*ctlutil.LimitedSupportReasonItem, error) {
+func getLimitedSupportReasons(clusterId string) ([]*cmv1.LimitedSupportReason, error) {
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection
 	err := ctlutil.IsValidClusterKey(clusterId)

--- a/cmd/cluster/support/delete.go
+++ b/cmd/cluster/support/delete.go
@@ -121,7 +121,7 @@ func (o *deleteOptions) run() error {
 	if o.removeAll {
 		limitedSupportReasons, err := getLimitedSupportReasons(o.clusterID)
 		for _, limitedSupportReason := range limitedSupportReasons {
-			limitedSupportReasonIds = append(limitedSupportReasonIds, limitedSupportReason.ID)
+			limitedSupportReasonIds = append(limitedSupportReasonIds, limitedSupportReason.ID())
 		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to get limited support reasons: %v\n", err)

--- a/cmd/cluster/support/status.go
+++ b/cmd/cluster/support/status.go
@@ -74,7 +74,7 @@ func (o *statusOptions) run() error {
 	table := printer.NewTablePrinter(os.Stdout, 20, 1, 3, ' ')
 	table.AddRow([]string{"Reason ID", "Summary", "Details"})
 	for _, clusterLimitedSupportReason := range clusterLimitedSupportReasons {
-		table.AddRow([]string{clusterLimitedSupportReason.ID, clusterLimitedSupportReason.Summary, clusterLimitedSupportReason.Details})
+		table.AddRow([]string{clusterLimitedSupportReason.ID(), clusterLimitedSupportReason.Summary(), clusterLimitedSupportReason.Details()})
 	}
 	// Add empty row for readability
 	table.AddRow([]string{})

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -12,12 +12,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-type LimitedSupportReasonItem struct {
-	ID      string
-	Summary string
-	Details string
-}
-
 var clusterKeyRE = regexp.MustCompile(`^(\w|-)+$`)
 
 func IsValidKey(clusterKey string) bool {
@@ -142,8 +136,7 @@ func GetCluster(connection *sdk.Connection, key string) (cluster *cmv1.Cluster, 
 	return
 }
 
-func GetClusterLimitedSupportReasons(connection *sdk.Connection, clusterID string) ([]*LimitedSupportReasonItem, error) {
-
+func GetClusterLimitedSupportReasons(connection *sdk.Connection, clusterID string) ([]*cmv1.LimitedSupportReason, error) {
 	limitedSupportReasons, err := connection.ClustersMgmt().V1().
 		Clusters().
 		Cluster(clusterID).
@@ -154,20 +147,7 @@ func GetClusterLimitedSupportReasons(connection *sdk.Connection, clusterID strin
 		return nil, fmt.Errorf("Failed to get limited Support Reasons: %s", err)
 	}
 
-	lmtReason := limitedSupportReasons.Items().Slice()
-
-	var clusterLmtSprReasons []*LimitedSupportReasonItem
-
-	for _, reason := range lmtReason {
-		clusterLmtSprReason := LimitedSupportReasonItem{
-			ID:      reason.ID(),
-			Summary: reason.Summary(),
-			Details: reason.Details(),
-		}
-		clusterLmtSprReasons = append(clusterLmtSprReasons, &clusterLmtSprReason)
-	}
-
-	return clusterLmtSprReasons, nil
+	return limitedSupportReasons.Items().Slice(), nil
 }
 
 // GetSubscription Function allows to get a single subscription with any identifier (displayname, ID, internal or external ID)


### PR DESCRIPTION
Removes a custom struct (and the code needed to translate to it) in favor of using the structs defined by the OCM sdk.

OSD-16105