### PR TITLE
Fix bug where osdctl network verify-egress was not requiring --cacert

### DIFF
--- a/cmd/network/verification_test.go
+++ b/cmd/network/verification_test.go
@@ -67,7 +67,7 @@ func Test_egressVerificationSetup(t *testing.T) {
 			name: "ClusterId optional",
 			e: &EgressVerification{
 				ClusterId:       "",
-				SubnetId:        []string{"subnet-a", "subnet-b", "subnet-c"},
+				SubnetIds:       []string{"subnet-a", "subnet-b", "subnet-c"},
 				SecurityGroupId: "sg-b",
 			},
 			expectErr: false,
@@ -267,8 +267,8 @@ func Test_egressVerificationGetSubnetId(t *testing.T) {
 		{
 			name: "manual override",
 			e: &EgressVerification{
-				log:      newTestLogger(t),
-				SubnetId: []string{"override"},
+				log:       newTestLogger(t),
+				SubnetIds: []string{"override"},
 			},
 			expected:  "override",
 			expectErr: false,
@@ -325,7 +325,7 @@ func Test_egressVerificationGetSubnetId(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual, err := test.e.getSubnetId(context.TODO())
+			actual, err := test.e.getSubnetIds(context.TODO())
 			if err != nil {
 				if !test.expectErr {
 					t.Errorf("expected no err, got %s", err)
@@ -412,7 +412,7 @@ func Test_egressVerificationGetSubnetIdAllSubnetsFlag(t *testing.T) {
 			name: "all subnets flag is on",
 			e: &EgressVerification{
 				log:        newTestLogger(t),
-				SubnetId:   []string{"string-1", "string-2", "string-3"},
+				SubnetIds:  []string{"string-1", "string-2", "string-3"},
 				AllSubnets: true,
 			},
 			expected:  []string{"string-1", "string-2", "string-3"},
@@ -485,7 +485,7 @@ func Test_egressVerificationGetSubnetIdAllSubnetsFlag(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual, err := test.e.getSubnetId(context.TODO())
+			actual, err := test.e.getSubnetIds(context.TODO())
 			if err != nil {
 				if !test.expectErr {
 					t.Errorf("expected no err, got %s", err)


### PR DESCRIPTION
… when no http_proxy/https_proxy is specified

As described in [OSD-16103](https://issues.redhat.com//browse/OSD-16103)

Basically, some clusters have a trust bundle specified, but no HTTP_PROXY/HTTPS_PROXY, so osdctl wasn't prompting SREs to supply an additional trust bundle when it was actually required.

Also renaming `SubnetId` --> `SubnetIds` for clarity because it's an array now