### PR TITLE
Add make target for local installation of osdctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ build:
 release:
 	goreleaser release --clean
 
+install:
+	goreleaser build --single-target -o "$(shell go env GOPATH)/bin/osdctl" --snapshot --clean
+
 vet:
 	go vet ${BUILDFLAGS} ./...
 


### PR DESCRIPTION
* `make install` builds a binary and copies it to `/bin`
* Comparable behavior to `go install`

jira: [OSD-16141](https://issues.redhat.com//browse/OSD-16141)