### PR TITLE
[OSD-16139] check cluster context output format before gathering data

### DIFF
--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -159,6 +159,18 @@ func (o *contextOptions) complete(cmd *cobra.Command, args []string) error {
 
 func (o *contextOptions) run() error {
 
+	var printFunc func(*contextData)
+	switch o.output {
+	case shortOutputConfigValue:
+		printFunc = o.printShortOutput
+	case longOutputConfigValue:
+		printFunc = o.printLongOutput
+	case jsonOutputConfigValue:
+		printFunc = o.printJsonOutput
+	default:
+		return fmt.Errorf("Unknown Output Format: %s", o.output)
+	}
+
 	currentData, dataErrors := o.generateContextData()
 	if currentData == nil {
 		fmt.Fprintf(os.Stderr, "Failed to query cluster info: %+v", dataErrors)
@@ -172,16 +184,7 @@ func (o *contextOptions) run() error {
 		}
 	}
 
-	switch o.output {
-	case shortOutputConfigValue:
-		o.printShortOutput(currentData)
-	case longOutputConfigValue:
-		o.printLongOutput(currentData)
-	case jsonOutputConfigValue:
-		o.printJsonOutput(currentData)
-	default:
-		return fmt.Errorf("Unknown Output Format: %s", o.output)
-	}
+	printFunc(currentData)
 
 	return nil
 }


### PR DESCRIPTION
This PR just fixes a small bug with the cluster context command, where the output format was only checked after all the data to output has been gathered. Now, the output format is checked beforehand:

```
# before
$ ./osdctl cluster context ...... -o kkkk 
Getting Limited Support Reason...
Getting Service Logs...
Getting Jira Issues...
Getting Support Exceptions...
Getting Pagerduty Service...
Getting current Pagerduty Alerts...
Getting currently firing Pagerduty Alerts for the cluster.
error: Unknown Output Format: kkkk

# after

$ ./osdctl cluster context ...... -o kkkk 
error: Unknown Output Format: kkkk
```