### PR TITLE
Enhance internal service log output

### DIFF
--- a/internal/servicelog/reply.go
+++ b/internal/servicelog/reply.go
@@ -17,10 +17,11 @@ type GoodReply struct {
 }
 
 type ServiceLogShort struct {
-	Summary     string    `json:"summary"`
-	Description string    `json:"description"`
-	CreatedAt   time.Time `json:"created_at"`
-	Severity    string    `json:"severity"`
+	Summary      string    `json:"summary"`
+	Description  string    `json:"description"`
+	CreatedAt    time.Time `json:"created_at"`
+	Severity     string    `json:"severity"`
+	InternalOnly bool      `json:"internal_only"`
 }
 
 type ClusterListGoodReply struct {


### PR DESCRIPTION
In a recent meeting we discussed enhancing internal service log output. Currently, we only see _that_ an internal service log has been set via the hard coded summary. This change uses the first line of the description to provide more information. Abbreviated output is shown below to demonstrate the effect of this change. 

```
$ ./osdctl cluster context -S a-test-cluster --output short

Version             Supported?          SLs (last 30 d)     Jira Tickets        Current Alerts      Historical Alerts (last 30 d)
4.12.15             true                1 (1 internal)      0                   H: 0 | L: 0         N/A
```

```
$ ./osdctl cluster context -S a-test-cluster

============================================================
Service Logs sent in the past 30 Days
============================================================
0. INT # This is a test description (2023-05-16T14:06:55Z)

```