### PR TITLE
Add support for aws_proxy

### DIFF
--- a/cmd/account/mgmt/account-unassign_test.go
+++ b/cmd/account/mgmt/account-unassign_test.go
@@ -2,6 +2,8 @@ package mgmt
 
 import (
 	"fmt"
+	awsInternal "github.com/openshift/osdctl/pkg/provider/aws"
+	"github.com/spf13/viper"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -19,6 +21,8 @@ import (
 )
 
 func TestAssumeRoleForAccount(t *testing.T) {
+	viper.Set(awsInternal.ProxyConfigKey, "")
+	viper.Set(awsInternal.SkipProxyCheckKey, true)
 	mocks := setupDefaultMocks(t, []runtime.Object{})
 
 	mockAWSClient := mock.NewMockClient(mocks.mockCtrl)


### PR DESCRIPTION
Adds support for two new configuration values: aws_proxy and skip_aws_proxy_check. The former configures the proxy url for the client connections to AWS. The latter determines whether a prompt is displayed; if set to true, no prompt is shown.

Below are example runs with varying configuration values set.

Only `aws_proxy` set to a proxy:
```
❯ cat ~/.config/osdctl | rg aws_proxy
#skip_aws_proxy_check: true
aws_proxy: "http://squid.corp.redhat.com:3128"

❯ ./dist/osdctl_darwin_arm64/osdctl -S account console -i 296929422197 -p osd-staging-2
The AWS Console URL is:
https://signin.aws.amazon.com...
```

Set `aws_proxy` to a proxy and `skip_aws_proxy_check` set to true (same as previous):
```
❯ cat ~/.config/osdctl | rg aws_proxy
#skip_aws_proxy_check: true
aws_proxy: "http://squid.corp.redhat.com:3128"

❯ ./dist/osdctl_darwin_arm64/osdctl -S account console -i 296929422197 -p osd-staging-2
The AWS Console URL is:
https://signin.aws.amazon.com...
```

Without `aws_proxy` set and `skip_aws_proxy_check` set to true:
```
❯ cat ~/.config/osdctl | rg aws_proxy
skip_aws_proxy_check: true
#aws_proxy: "http://squid.corp.redhat.com:3128"

❯ ./dist/osdctl_darwin_arm64/osdctl -S account console -i 296929422197 -p osd-staging-2
[WARNING] `aws_proxy` not configured. Please add this to your osdctl configuration to ensure traffic is routed though a proxy.
The AWS Console URL is:
https://signin.aws.amazon.com...
```

Without either `aws_proxy` and without `skip_aws_proxy_check` set:
```
❯ cat ~/.config/osdctl | rg aws_proxy                                                  
#skip_aws_proxy_check: true
#aws_proxy: "http://squid.corp.redhat.com:3128"

❯ ./dist/osdctl_darwin_arm64/osdctl -S account console -i 296929422197 -p osd-staging-2
[WARNING] `aws_proxy` not configured. Please add this to your osdctl configuration to ensure traffic is routed though a proxy.
Please confirm that you would like to continue with [y|N] y
The AWS Console URL is:
https://signin.aws.amazon.com...
```

Setting `skip_aws_proxy_check` to false without `aws_proxy`:
```
❯ cat ~/.config/osdctl | rg aws_proxy
skip_aws_proxy_check: false
#aws_proxy: "http://squid.corp.redhat.com:3128"

❯ ./dist/osdctl_darwin_arm64/osdctl -S account console -i 296929422197 -p osd-staging-2
[WARNING] `aws_proxy` not configured. Please add this to your osdctl configuration to ensure traffic is routed though a proxy.
Please confirm that you would like to continue with [y|N] 
```

[OSD-15754](https://issues.redhat.com/browse/OSD-15754)