### PR TITLE
osd-network-verifier v0.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/openshift/backplane-cli v0.1.3
 	github.com/openshift/gcp-project-operator v0.0.0-20220920194256-df38e31387a7
 	github.com/openshift/hive/apis v0.0.0-20230314202213-17cb22fc3d7c
-	github.com/openshift/osd-network-verifier v0.3.0
+	github.com/openshift/osd-network-verifier v0.3.1
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -560,8 +560,8 @@ github.com/openshift/gcp-project-operator v0.0.0-20220920194256-df38e31387a7 h1:
 github.com/openshift/gcp-project-operator v0.0.0-20220920194256-df38e31387a7/go.mod h1:BKXSfGFecnNJ/NBv61AjSP9ngf9jiP4KbPShTkO9XtA=
 github.com/openshift/hive/apis v0.0.0-20230314202213-17cb22fc3d7c h1:6UcCZQIfknM18J9VNN39i8uTrwD9QFj4B0PnyyoAGU8=
 github.com/openshift/hive/apis v0.0.0-20230314202213-17cb22fc3d7c/go.mod h1:VIxA5HhvBmsqVn7aUVQYs004B9K4U5A+HrFwvRq2nK8=
-github.com/openshift/osd-network-verifier v0.3.0 h1:3Iy1BA4dQPdB6faR1M4bsquvCHwezdLCegUQ0xUZung=
-github.com/openshift/osd-network-verifier v0.3.0/go.mod h1:A89hA4CpxJjxx2qNbZVJmJc3MVa+bEWftKadBCJoxw4=
+github.com/openshift/osd-network-verifier v0.3.1 h1:ecqxNthFH3S5akTzBamwJSracmxXEFDZe7YYDh0Ej30=
+github.com/openshift/osd-network-verifier v0.3.1/go.mod h1:A89hA4CpxJjxx2qNbZVJmJc3MVa+bEWftKadBCJoxw4=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/perimeterx/marshmallow v1.1.4 h1:pZLDH9RjlLGGorbXhcaQLhfuV0pFMNfPO55FuFkxqLw=


### PR DESCRIPTION
This commit pulls in bugfixes that will enable valid osdctl network verify-egress runs against clusters with hosted control planes and represents the fixes to the bugs in #390

```
❯ ~/git/openshift/osdctl/osdctl network verify-egress --cluster-id mshen-hyper
The current version () is different than the latest released version (v0.15.0).It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.
Please confirm that you would like to continue with [y|n]
y
2023/06/06 22:02:10 getting AWS credentials from backplane-api
2023/06/06 22:02:11 using platform: hostedcluster
2023/06/06 22:02:11 detected BYOVPC PrivateLink cluster, using first subnet from OCM: subnet-0abb6bf9fa290d988
2023/06/06 22:02:11 searching for security group by tags: [name: tag:Name, values: 246pb99o8houi5ilke2mvpteetdbi1qp-default-sg name: tag:kubernetes.io/cluster/246pb99o8houi5ilke2mvpteetdbi1qp, values: owned]
2023/06/06 22:02:12 using security-group-id: sg-011b7612f8fda977b
2023/06/06 22:02:12 Preparing to check 1 subnet(s) with network verifier.
2023/06/06 22:02:12 running network verifier for subnet  subnet-0abb6bf9fa290d988, security group sg-011b7612f8fda977b
2023/06/06 22:02:13 Created instance with ID: i-04ce114ca57fb9707
Summary:
All tests passed!
```

[OSD-16065](https://issues.redhat.com//browse/OSD-16065)