### PR TITLE
New promote.sh now in osdctl

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/osdctl/cmd/jumphost"
 	"github.com/openshift/osdctl/cmd/network"
 	"github.com/openshift/osdctl/cmd/org"
+	"github.com/openshift/osdctl/cmd/promote"
 	"github.com/openshift/osdctl/cmd/servicelog"
 	"github.com/openshift/osdctl/cmd/sts"
 	"github.com/openshift/osdctl/internal/utils/globalflags"
@@ -79,6 +80,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	rootCmd.AddCommand(servicelog.NewCmdServiceLog())
 	rootCmd.AddCommand(org.NewCmdOrg())
 	rootCmd.AddCommand(sts.NewCmdSts(streams, kubeFlags, kubeClient))
+	rootCmd.AddCommand(promote.NewCmdPromote(kubeFlags, globalOpts))
 
 	// add docs command
 	rootCmd.AddCommand(newCmdDocs(streams))

--- a/cmd/promote/cmd.go
+++ b/cmd/promote/cmd.go
@@ -1,0 +1,32 @@
+package promote
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/openshift/osdctl/cmd/promote/saas"
+	"github.com/openshift/osdctl/internal/utils/globalflags"
+)
+
+// NewCmdPromote implements the promote command to promote services/operators
+func NewCmdPromote(flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	promoteCmd := &cobra.Command{
+		Use:               "promote",
+		Short:             "Utilities to promote services/operators",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+	}
+
+	promoteCmd.AddCommand(saas.NewCmdSaas(flags, globalOpts))
+
+	return promoteCmd
+}
+
+func help(cmd *cobra.Command, _ []string) {
+	err := cmd.Help()
+	if err != nil {
+		fmt.Println("Error while calling cmd.Help(): ", err.Error())
+	}
+}

--- a/cmd/promote/git/app_interface.go
+++ b/cmd/promote/git/app_interface.go
@@ -1,0 +1,162 @@
+package git
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Service struct {
+	Name              string `yaml:"name"`
+	ResourceTemplates []struct {
+		URL     string `yaml:"url"`
+		Targets []struct {
+			Namespace map[string]string `yaml:"namespace"`
+			Ref       string            `yaml:"ref"`
+		} `yaml:"targets"`
+	} `yaml:"resourceTemplates"`
+}
+
+func BootstrapOsdCtlForAppInterfaceAndServicePromotions() {
+	_, err := getBaseDir()
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = checkAppInterfaceCheckout()
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = checkBehindMaster()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// checkAppInterfaceCheckout checks if the script is running in the checkout of app-interface
+func checkAppInterfaceCheckout() error {
+	cmd := exec.Command("git", "remote", "-v")
+	cmd.Dir = BaseDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error executing 'git remote -v': %v", err)
+	}
+
+	outputString := string(output)
+
+	// Check if the output contains the app-interface repository URL
+	if !strings.Contains(outputString, "gitlab.cee.redhat.com") && !strings.Contains(outputString, "app-interface") {
+		return fmt.Errorf("not running in checkout of app-interface")
+
+	}
+	fmt.Println("Running in checkout of app-interface.")
+
+	return nil
+}
+
+func GetCurrentGitHashFromAppInterface(saarYamlFile []byte, serviceName string) (string, string, error) {
+	var currentGitHash string
+	var serviceRepo string
+	var service Service
+	err := yaml.Unmarshal(saarYamlFile, &service)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if strings.Contains(service.Name, "configuration-anomaly-detection") {
+		for _, resourceTemplate := range service.ResourceTemplates {
+			for _, target := range resourceTemplate.Targets {
+				if strings.Contains(target.Namespace["$ref"], "configuration-anomaly-detection-production") {
+					currentGitHash = target.Ref
+					break
+				}
+			}
+		}
+	} else if strings.Contains(service.Name, "rhobs-rules-and-dashboards") {
+		for _, resourceTemplate := range service.ResourceTemplates {
+			for _, target := range resourceTemplate.Targets {
+				if strings.Contains(service.Name, "rhobsp02ue1-production") {
+					currentGitHash = target.Ref
+					break
+				}
+			}
+		}
+	} else {
+		for _, resourceTemplate := range service.ResourceTemplates {
+			for _, target := range resourceTemplate.Targets {
+				if strings.Contains(target.Namespace["$ref"], "hivep") {
+					currentGitHash = target.Ref
+					break
+				}
+			}
+		}
+	}
+
+	if currentGitHash == "" {
+		return "", "", fmt.Errorf("production namespace not found for service %s", serviceName)
+	}
+
+	if len(service.ResourceTemplates) > 0 {
+		serviceRepo = service.ResourceTemplates[0].URL
+	}
+
+	if serviceRepo == "" {
+		return "", "", fmt.Errorf("service repo not found for service %s", serviceName)
+	}
+
+	return currentGitHash, serviceRepo, nil
+}
+
+func UpdateAndCommitChangesForAppInterface(serviceName, saasFile, currentGitHash, promotionGitHash string) error {
+	// Create a branch for promotion
+	branchName := fmt.Sprintf("promote-%s-%s", serviceName, promotionGitHash)
+
+	cmd := exec.Command("git", "checkout", "-b", branchName, "master")
+	cmd.Dir = BaseDir
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to create branch %s: %v", branchName, err)
+	}
+
+	// Update the hash in the SAAS file
+	fileContent, err := os.ReadFile(saasFile)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %v", saasFile, err)
+	}
+
+	// Replace the hash in the file content
+	newContent := strings.ReplaceAll(string(fileContent), currentGitHash, promotionGitHash)
+
+	err = os.WriteFile(saasFile, []byte(newContent), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write to file %s: %v", saasFile, err)
+	}
+
+	// Commit the change
+	cmd = exec.Command("git", "add", saasFile)
+	cmd.Dir = BaseDir
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to add file %s: %v", saasFile, err)
+	}
+
+	commitMessage := fmt.Sprintf("Promote %s to %s", serviceName, promotionGitHash)
+	cmd = exec.Command("git", "commit", "-m", commitMessage)
+	cmd.Dir = BaseDir
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to commit changes: %v", err)
+	}
+
+	fmt.Printf("The branch %s is ready to be pushed\n", branchName)
+	fmt.Println("")
+	fmt.Println("service:", serviceName)
+	fmt.Println("from:", currentGitHash)
+	fmt.Println("to:", promotionGitHash)
+	fmt.Println("READY TO PUSH,", serviceName, "promotion commit is ready locally")
+
+	return nil
+}

--- a/cmd/promote/git/service_repo.go
+++ b/cmd/promote/git/service_repo.go
@@ -1,0 +1,49 @@
+package git
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func CheckoutAndCompareGitHash(gitURL, gitHash, currentGitHash string) (string, error) {
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	err = os.Chdir(tempDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to change directory to temporary directory: %v", err)
+	}
+
+	cmd := exec.Command("git", "clone", gitURL, "source-dir")
+	err = cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("failed to clone git repository: %v", err)
+	}
+
+	err = os.Chdir("source-dir")
+	if err != nil {
+		return "", fmt.Errorf("failed to change directory to source-dir: %v", err)
+	}
+
+	if gitHash == "" {
+		fmt.Printf("No git hash provided. Using HEAD.\n")
+		cmd = exec.Command("git", "rev-parse", "HEAD")
+		output, err := cmd.Output()
+		if err != nil {
+			return "", fmt.Errorf("failed to get git hash: %v", err)
+		}
+		gitHash = strings.TrimSpace(string(output))
+	}
+
+	if currentGitHash == gitHash {
+		return "", fmt.Errorf("git hash %s is already at HEAD", gitHash)
+	}
+
+	return gitHash, nil
+}

--- a/cmd/promote/saas/saas.go
+++ b/cmd/promote/saas/saas.go
@@ -1,0 +1,89 @@
+package saas
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openshift/osdctl/cmd/promote/git"
+	"github.com/openshift/osdctl/internal/utils/globalflags"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+type saasOptions struct {
+	list bool
+	osd  bool
+	hcp  bool
+
+	serviceName string
+	gitHash     string
+}
+
+// newCmdSaas implementes the saas command to interact with promoting SaaS services/operators
+func NewCmdSaas(flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newSaasOptions(flags, globalOpts)
+	saasCmd := &cobra.Command{
+		Use:               "saas",
+		Short:             "Utilities to promote SaaS services/operators",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		Example: `
+		# List all SaaS services/operators
+		osdctl promote saas --list
+
+		# Promote a SaaS service/operator
+		osdctl promote saas --serviceName <service-name> --gitHash <git-hash> --osd
+		or
+		osdctl promote saas --serviceName <service-name> --gitHash <git-hash> --hcp`,
+		Run: func(cmd *cobra.Command, args []string) {
+			ops.validateSaasFlow()
+			git.BootstrapOsdCtlForAppInterfaceAndServicePromotions()
+
+			if ops.list {
+				if ops.serviceName != "" || ops.gitHash != "" || ops.osd || ops.hcp {
+					fmt.Printf("Error: --list cannot be used with any other flags\n\n")
+					cmd.Help()
+					os.Exit(1)
+				}
+				listServiceNames()
+				os.Exit(0)
+			}
+
+			if !(ops.osd || ops.hcp) && ops.serviceName != "" {
+				fmt.Printf("Error: --serviceName cannot be used without either --osd or --hcp\n\n")
+				cmd.Help()
+				os.Exit(1)
+			}
+
+			err := servicePromotion(ops.serviceName, ops.gitHash, ops.osd, ops.hcp)
+			if err != nil {
+				fmt.Printf("Error while promoting service: %v\n", err)
+				os.Exit(1)
+			}
+
+			os.Exit(0)
+
+		},
+	}
+
+	saasCmd.Flags().BoolVarP(&ops.list, "list", "l", false, "List all SaaS services/operators")
+	saasCmd.Flags().StringVarP(&ops.serviceName, "serviceName", "", "", "SaaS service/operator getting promoted")
+	saasCmd.Flags().StringVarP(&ops.gitHash, "gitHash", "g", "", "Git hash of the SaaS service/operator commit getting promoted")
+	saasCmd.Flags().BoolVarP(&ops.osd, "osd", "", false, "OSD service/operator getting promoted")
+	saasCmd.Flags().BoolVarP(&ops.hcp, "hcp", "", false, "Git hash of the SaaS service/operator commit getting promoted")
+
+	return saasCmd
+}
+
+func newSaasOptions(flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *saasOptions {
+	return &saasOptions{}
+}
+
+func (o *saasOptions) validateSaasFlow() {
+	if o.serviceName == "" || o.gitHash == "" {
+		fmt.Printf("Usage: For SaaS services/operators, please provide --serviceName and --gitHash\n")
+		fmt.Printf("--serviceName is the name of the service, i.e. saas-managed-cluster-config\n")
+		fmt.Printf("--gitHash is the target git commit in the service, if not specified defaults to HEAD of master\n\n")
+		return
+	}
+}

--- a/cmd/promote/saas/utils.go
+++ b/cmd/promote/saas/utils.go
@@ -1,0 +1,132 @@
+package saas
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/openshift/osdctl/cmd/promote/git"
+)
+
+const (
+	osdSaasDir = "data/services/osd-operators/cicd/saas"
+	bpSaasDir  = "data/services/backplane/cicd/saas"
+	cadSaasDir = "data/services/configuration-anomaly-detection/cicd"
+)
+
+var (
+	servicesSlice    []string
+	servicesFilesMap = map[string]string{}
+)
+
+func listServiceNames() error {
+	_, err := getServiceNames(osdSaasDir, bpSaasDir, cadSaasDir)
+	if err != nil {
+		return err
+	}
+
+	sort.Strings(servicesSlice)
+	fmt.Println("### Available service names ###")
+	for _, service := range servicesSlice {
+		fmt.Println(service)
+	}
+
+	return nil
+}
+
+func servicePromotion(serviceName, gitHash string, osd, hcp bool) error {
+	_, err := getServiceNames(osdSaasDir, bpSaasDir, cadSaasDir)
+	if err != nil {
+		return err
+	}
+
+	err = validateServiceName(servicesSlice, serviceName)
+	if err != nil {
+		return err
+	}
+
+	saasDir, err := getSaasDir(serviceName, osd, hcp)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("SAAS Directory: %v\n", saasDir)
+
+	serviceData, err := os.ReadFile(saasDir)
+	if err != nil {
+		return fmt.Errorf("failed to read SAAS file: %v", err)
+	}
+
+	currentGitHash, serviceRepo, err := git.GetCurrentGitHashFromAppInterface(serviceData, serviceName)
+	if err != nil {
+		return fmt.Errorf("failed to get current git hash or service repo: %v", err)
+	}
+	fmt.Printf("Current Git Hash: %v\nGit Repo: %v\n\n", currentGitHash, serviceRepo)
+
+	promotionGitHash, err := git.CheckoutAndCompareGitHash(serviceRepo, gitHash, currentGitHash)
+	if err != nil {
+		return fmt.Errorf("failed to checkout and compare git hash: %v", err)
+	} else if promotionGitHash == "" {
+		fmt.Printf("Unable to find a git hash to promote. Exiting.\n")
+		os.Exit(6)
+	}
+	fmt.Printf("Service: %s will be promoted to %s\n", serviceName, promotionGitHash)
+
+	err = git.UpdateAndCommitChangesForAppInterface(serviceName, saasDir, currentGitHash, promotionGitHash)
+	if err != nil {
+		fmt.Printf("FAILURE: %v\n", err)
+	}
+
+	return nil
+}
+
+func getServiceNames(saaDirs ...string) ([]string, error) {
+	baseDir := git.BaseDir
+	for _, dir := range saaDirs {
+		dirGlob := filepath.Join(baseDir, dir, "saas-*")
+		filepaths, err := filepath.Glob(dirGlob)
+		if err != nil {
+			return nil, err
+		}
+		for _, filepath := range filepaths {
+			filename := strings.TrimPrefix(filepath, baseDir+"/"+dir+"/")
+			filename = strings.TrimSuffix(filename, ".yaml")
+			servicesSlice = append(servicesSlice, filename)
+			servicesFilesMap[filename] = filepath
+		}
+	}
+
+	return servicesSlice, nil
+}
+
+func validateServiceName(serviceSlice []string, serviceName string) error {
+	fmt.Printf("### Checking if service %s exists ###\n", serviceName)
+	for _, service := range serviceSlice {
+		if service == serviceName {
+			fmt.Printf("Service %s found\n", serviceName)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("service %s not found", serviceName)
+}
+
+func getSaasDir(serviceName string, osd bool, hcp bool) (string, error) {
+	if saasDir, ok := servicesFilesMap[serviceName]; ok {
+		if strings.Contains(saasDir, ".yaml") && osd {
+			return saasDir, nil
+		}
+
+		// This is a hack while we migrate the rest of the operators unto Progressive Delivery
+		if osd {
+			saasDir = saasDir + "/deploy.yaml"
+			return saasDir, nil
+		} else if hcp {
+			saasDir = saasDir + "/hypershift-deploy.yaml"
+			return saasDir, nil
+		}
+	}
+
+	return "", fmt.Errorf("saas directory for service %s not found", serviceName)
+}

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	google.golang.org/api v0.122.0
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
 	k8s.io/cli-runtime v0.26.3
@@ -163,7 +164,6 @@ require (
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.26.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect


### PR DESCRIPTION
[SDCICD-992](https://issues.redhat.com/browse/SDCICD-992)

This commits adds the [promote.sh](https://github.com/openshift/ops-sop/blob/master/v4/utils/promote.sh) that is used to promote operators into production. 
https://github.com/openshift/ops-sop/blob/master/v4/utils/promote.sh

This first iteration keep the base logic of the script while supporting AVO which has been onboarded unto the new dir structure inside of app-interface, this also sets the roadwork for progressive delivery once we decide the new rollout strategy. 

Tested Locally:
./osdctl promote saas --serviceName saas-custom-domains-operator --osd=true

Output:
Usage: For SaaS services/operators, please provide --serviceName and --gitHash
--serviceName is the name of the service, i.e. saas-managed-cluster-config
--gitHash is the target git commit in the service, if not specified defaults to HEAD of master

Running in checkout of app-interface.
### Checking 'master' branch is up to date ###
### 'master' branch is up to date ###

### Checking if service saas-custom-domains-operator exists ###
Service saas-custom-domains-operator found
SAAS Directory: $MyLocalPath/app-interface/data/services/osd-operators/cicd/saas/saas-custom-domains-operator.yaml
Current Git Hash: 22ce1596a078a56016cf4d613593b52abbedd488
Git Repo: https://github.com/openshift/custom-domains-operator

No git hash provided. Using HEAD.
Service: saas-custom-domains-operator will be promoted to 415bfed39e474594b0687e4613a1f9bfd7fefc13
The branch promote-saas-custom-domains-operator-415bfed39e474594b0687e4613a1f9bfd7fefc13 is ready to be pushed

service: saas-custom-domains-operator
from: 22ce1596a078a56016cf4d613593b52abbedd488
to: 415bfed39e474594b0687e4613a1f9bfd7fefc13
READY TO PUSH, saas-custom-domains-operator promotion commit is ready locally