### PR TITLE
Make 'ConfirmSend' return a bool instead of an error (and rename it)

### DIFF
--- a/cmd/cluster/resizecontrolplanenode.go
+++ b/cmd/cluster/resizecontrolplanenode.go
@@ -440,17 +440,15 @@ func (o *resizeControlPlaneNodeOptions) run() error {
 	fmt.Println() // Add an empty line for better output formatting
 
 	fmt.Println("To continue, please confirm that the node is up and running and that the cluster is in the desired state to proceed.")
-	err = utils.ConfirmSend()
-	if err != nil {
-		return err
+	if !utils.ConfirmPrompt() {
+		return nil
 	}
 	fmt.Println() // Add an empty line for better output formatting
 
 	fmt.Println("To finish the node resize, it is suggested to update the machine spec. This requires ***elevated privileges***. Do you want to proceed?")
-	err = utils.ConfirmSend()
-	if err != nil {
+	if !utils.ConfirmPrompt() {
 		fmt.Println("Node resized, machine type not patched. Exiting...")
-		return err
+		return nil
 	}
 	fmt.Println() // Add an empty line for better output formatting
 

--- a/cmd/cluster/support/delete.go
+++ b/cmd/cluster/support/delete.go
@@ -105,9 +105,8 @@ func (o *deleteOptions) run() error {
 	}
 
 	// confirmSend prompt to confirm
-	err = utils.ConfirmSend()
-	if err != nil {
-		return err
+	if !utils.ConfirmPrompt() {
+		return nil
 	}
 
 	//getting the cluster

--- a/cmd/cluster/support/post.go
+++ b/cmd/cluster/support/post.go
@@ -128,10 +128,9 @@ func (o *postOptions) run() error {
 		return nil
 	}
 
-	// ConfirmSend prompt to confirm
-	err = ctlutil.ConfirmSend()
-	if err != nil {
-		return err
+	// ConfirmPrompt prompt to confirm
+	if !ctlutil.ConfirmPrompt() {
+		return nil
 	}
 
 	//getting the cluster

--- a/cmd/cluster/transferowner.go
+++ b/cmd/cluster/transferowner.go
@@ -136,17 +136,15 @@ func (o *transferOwnerOptions) run() error {
 
 	fmt.Printf("Transfer cluster: \t\t'%v' (%v)\n", externalClusterID, cluster.Name())
 	fmt.Printf("from user \t\t\t'%v' to '%v'\n", oldOwnerAccount.ID(), accountID)
-	err = utils.ConfirmSend()
-	if err != nil {
-		return err
+	if !utils.ConfirmPrompt() {
+		return nil
 	}
 
 	ok = validateOldOwner(oldOrganizationId, subscription, oldOwnerAccount)
 	if !ok {
 		fmt.Print("can't validate this is old owners cluster, this could be because of a previously failed run\n")
-		err = utils.ConfirmSend()
-		if err != nil {
-			return err
+		if !utils.ConfirmPrompt() {
+			return nil
 		}
 	}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -139,18 +139,9 @@ func versionCheck() {
 	if utils.Version != strings.TrimPrefix(latestVersion, "v") {
 		fmt.Printf("The current version (%s) is different than the latest released version (%s).", utils.Version, latestVersion)
 		fmt.Println("It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.")
-		fmt.Println("Please confirm that you would like to continue with [y|n]")
 
-		var input string
-		for {
-			fmt.Scanln(&input)
-			if strings.ToLower(input) == "y" {
-				break
-			}
-			if strings.ToLower(input) == "n" {
-				fmt.Println("Exiting")
-				os.Exit(0)
-			}
+		if !utils.ConfirmPrompt() {
+			os.Exit(0)
 		}
 	}
 }

--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -174,9 +174,8 @@ func (o *PostCmdOptions) Run() error {
 	}
 
 	if !o.skipPrompts {
-		err = ctlutil.ConfirmSend()
-		if err != nil {
-			log.Fatal(err)
+		if !ctlutil.ConfirmPrompt() {
+			return nil
 		}
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -224,37 +224,38 @@ func GetAccount(connection *sdk.Connection, key string) (account *amv1.Account, 
 	return
 }
 
-func ConfirmSend() error {
+func ConfirmPrompt() bool {
 	fmt.Print("Continue? (y/N): ")
 
 	var response string
 	_, err := fmt.Scanln(&response)
 	if err != nil {
-		return err
+		fmt.Println("Invalid input. Expecting (yes) or (N)o")
+		return ConfirmPrompt()
 	}
 
 	switch strings.ToLower(response) {
 	case "y", "yes":
-		return nil
+		return true
 	case "n", "no":
-		return fmt.Errorf("Exiting...")
+		return false
 	default:
 		fmt.Println("Invalid input. Expecting (y)es or (N)o")
-		return ConfirmSend()
+		return ConfirmPrompt()
 	}
 }
 
-// streamPrintln appends a newline then prints the given msg using the provided IOStreams
+// StreamPrintln appends a newline then prints the given msg using the provided IOStreams
 func StreamPrintln(stream genericclioptions.IOStreams, msg string) {
 	stream.Out.Write([]byte(fmt.Sprintln(msg)))
 }
 
-// streamPrint prints the given msg using the provided IOStreams
+// StreamPrint prints the given msg using the provided IOStreams
 func StreamPrint(stream genericclioptions.IOStreams, msg string) {
 	stream.Out.Write([]byte(msg))
 }
 
-// streamPrint prints the given error msg using the provided IOStreams
+// StreamErrorln prints the given error msg using the provided IOStreams
 func StreamErrorln(stream genericclioptions.IOStreams, msg string) {
 	stream.ErrOut.Write([]byte(fmt.Sprintln(msg)))
 }


### PR DESCRIPTION
Currently:
```
$ ./osdctl servicelog post -t <template_id> <cluster_id>
...
INFO[0009] The following template will be sent:         
...
Continue? (y/N): N
FATA[0003] Exiting...
```

Outputting a fatal error message on a negative confirmation seems like something crashed. With this new change:
```
$ ./osdctl servicelog post -t <template_id> <cluster_id>
...
INFO[0009] The following template will be sent:         
...
Continue? (y/N): N
```

Also on the side - I came across a situation on accident where the version check logic would seemingly stall out if the user input anything other than "y" or "n". For consistency in UX, I updated it to use the same logic as everywhere else.