### PR TITLE
Let erroneous input fall through to the default switch case

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -228,11 +228,7 @@ func ConfirmPrompt() bool {
 	fmt.Print("Continue? (y/N): ")
 
 	var response string
-	_, err := fmt.Scanln(&response)
-	if err != nil {
-		fmt.Println("Invalid input. Expecting (yes) or (N)o")
-		return ConfirmPrompt()
-	}
+	_, _ = fmt.Scanln(&response) // Erroneous input will be handled by the default case below
 
 	switch strings.ToLower(response) {
 	case "y", "yes":


### PR DESCRIPTION
Simplify the logic of ConfirmPrompt a bit - since an error in `Scanln` is handled the same as the `default` case in the switch statement, just let it fall through to there.