### PR TITLE
Enable promotion for HCP Operators into Canary env

### DIFF
--- a/cmd/promote/saas/utils.go
+++ b/cmd/promote/saas/utils.go
@@ -58,7 +58,7 @@ func servicePromotion(serviceName, gitHash string, osd, hcp bool) error {
 		return fmt.Errorf("failed to read SAAS file: %v", err)
 	}
 
-	currentGitHash, serviceRepo, err := git.GetCurrentGitHashFromAppInterface(serviceData, serviceName)
+	currentGitHash, serviceRepo, err := git.GetCurrentGitHashFromAppInterface(serviceData, serviceName, osd, hcp)
 	if err != nil {
 		return fmt.Errorf("failed to get current git hash or service repo: %v", err)
 	}


### PR DESCRIPTION
[SDCICD-992](https://issues.redhat.com/browse/SDCICD-992)

This commits adds support to promote Hypershift Operators using the $REGION-$SECTOR approach into the Production Canary environment. 

Tested Locally:
I had to use the current integration environment to make sure the logic would replace the correct env. The output matches the int environment going from "main" to the current head of AVO. 

./osdctl promote saas --serviceName saas-aws-vpce-operator --hcp
The current version () is different than the latest released version (v0.16.0).It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.
Continue? (y/N): Usage: For SaaS services/operators, please provide --serviceName and --gitHash
--serviceName is the name of the service, i.e. saas-managed-cluster-config
--gitHash is the target git commit in the service, if not specified defaults to HEAD of master

Running in checkout of app-interface.
### Checking 'master' branch is up to date ###
### 'master' branch is up to date ###

### Checking if service saas-aws-vpce-operator exists ###
Service saas-aws-vpce-operator found
SAAS Directory: $PATH/app-interface/data/services/osd-operators/cicd/saas/saas-aws-vpce-operator/hypershift-deploy.yaml
Current Git Hash: main
Git Repo: https://github.com/openshift/aws-vpce-operator

No git hash provided. Using HEAD.
Service: saas-aws-vpce-operator will be promoted to 30257036032781baf08e88eb97eea04d76edb2e8
The branch promote-saas-aws-vpce-operator-30257036032781baf08e88eb97eea04d76edb2e8 is ready to be pushed

service: saas-aws-vpce-operator
from: main
to: 30257036032781baf08e88eb97eea04d76edb2e8
READY TO PUSH, saas-aws-vpce-operator promotion commit is ready locally