### PR TITLE
Add flag to bypass aws_config value

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/openshift/osdctl/pkg/provider/aws"
+	"github.com/spf13/viper"
 	"os"
 	"strings"
 
@@ -50,6 +52,13 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 		Long:              `CLI tool to provide OSD related utilities`,
 		DisableAutoGenTag: true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			noAwsProxy, err := cmd.Flags().GetBool(aws.NoProxyFlag)
+			if err != nil {
+				fmt.Printf("flag --%v undefined\n", aws.NoProxyFlag)
+				os.Exit(1)
+			}
+			viper.Set(aws.NoProxyFlag, noAwsProxy)
+
 			skipVersionCheck, err := cmd.Flags().GetBool("skip-version-check")
 			if err != nil {
 				fmt.Println("flag --skip-version-check/-S undefined")

--- a/internal/utils/globalflags/globalflags.go
+++ b/internal/utils/globalflags/globalflags.go
@@ -2,6 +2,7 @@ package globalflags
 
 import (
 	"flag"
+	"github.com/openshift/osdctl/pkg/provider/aws"
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -12,6 +13,7 @@ import (
 type GlobalOptions struct {
 	Output           string
 	SkipVersionCheck bool
+	NoAwsProxy       bool
 }
 
 // AddGlobalFlags adds the Global Flags to the root command
@@ -19,6 +21,7 @@ func AddGlobalFlags(cmd *cobra.Command, opts *GlobalOptions) {
 	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", "", "Valid formats are ['', 'json', 'yaml', 'env']")
 	cmd.PersistentFlags().BoolVarP(&opts.SkipVersionCheck, "skip-version-check", "S", false, "skip checking to see if this is the most recent release")
+	cmd.PersistentFlags().BoolVar(&opts.NoAwsProxy, aws.NoProxyFlag, false, "Don't use the configured `aws_proxy` value")
 }
 
 // GetFlags adds the kubeFlags we care about and adds the flags from the provided command

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -44,7 +44,10 @@ type AwsClientInput struct {
 	Region          string
 }
 
-const ProxyConfigKey = "aws_proxy"
+const (
+	ProxyConfigKey = "aws_proxy"
+	NoProxyFlag    = "no-aws-proxy"
+)
 
 // TODO: Add more methods when needed
 type Client interface {
@@ -137,6 +140,11 @@ type AwsClient struct {
 }
 
 func addProxyConfigToSessionOptConfig(config *aws.Config) {
+	if viper.GetBool(NoProxyFlag) {
+		fmt.Printf("Not adding proxy to AWS client due to presence of %v flag\n", NoProxyFlag)
+		return
+	}
+
 	awsProxyUrl := viper.GetString(ProxyConfigKey)
 	if awsProxyUrl == "" {
 		_, _ = fmt.Fprintf(os.Stderr, "[ERROR] `%s` not configured. Please add this to your osdctl configuration to ensure traffic is routed though a proxy.\n", ProxyConfigKey)

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -46,7 +46,7 @@ type AwsClientInput struct {
 
 const (
 	ProxyConfigKey = "aws_proxy"
-	NoProxyFlag    = "no-aws-proxy"
+	NoProxyFlag    = "skip-aws-proxy-check"
 )
 
 // TODO: Add more methods when needed


### PR DESCRIPTION
Adds a flag to bypass the `aws_config` value set in osdctl's config. The flag purposely does not provide a shorthand since we should be extremely deliberate in using this flag.

This PR comes as a result of this thread:
https://redhat-internal.slack.com/archives/CNJPJSG3Z/p1688745686279219

Example run:
```
$ ./osdctl account console --clusterID abc123 -p my_aws_profile --no-aws-proxy
Not adding proxy to AWS client due to presence of no-aws-proxy flag
The AWS Console URL is:
<console url>
```

I've confirmed that this will work off of the VPN as well.