### PR TITLE
Enforce that payer accounts cannot be assigned to individual users

### DIFF
--- a/cmd/account/cli.go
+++ b/cmd/account/cli.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/sts"
-	osdCloud "github.com/openshift/osdctl/pkg/osdCloud"
+	"github.com/openshift/osdctl/pkg/osdCloud"
 	"github.com/openshift/osdctl/pkg/provider/aws"
 	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"

--- a/cmd/account/servicequotas/describe.go
+++ b/cmd/account/servicequotas/describe.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	//"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicequotas"
 
 	"github.com/spf13/cobra"


### PR DESCRIPTION
This will prevent osdctl from assigning users to payer accounts regardless of the structure of the parent OUs. I use the same client that is initially set up with the provided payer account to call `GetCallerIdentity` and pull the account ID off of the result. Then we can make sure that an account with that ID is passed over during the assignment checks.

As for tests, I added a few cases and cleaned up nil-values in existing test cases.

I also reformatted some deprecated code using the `rand` package that I came across.

Resolves [OSD-16129](https://issues.redhat.com//browse/OSD-16129)