### PR TITLE
Prevent err overwriting for failed fetching SL

### DIFF
--- a/cmd/servicelog/list.go
+++ b/cmd/servicelog/list.go
@@ -47,9 +47,9 @@ func run(cmd *cobra.Command, clusterID string) error {
 	response, err := FetchServiceLogs(clusterID)
 	if err != nil {
 		// If the response has errored, likely the input was bad, so show usage
-		err := cmd.Help()
-		if err != nil {
-			return err
+		helpErr := cmd.Help()
+		if helpErr != nil {
+			return helpErr
 		}
 		return err
 	}


### PR DESCRIPTION
When we try to query the SL for a deleted cluster, it will prompt the usage without the actual error, which can be hard for users to find out what went wrong.

Before:
```
$ osdctl servicelog list ${cluster-id}
gets all servicelog messages for a given cluster

Usage:
  osdctl servicelog list [flags] [options] cluster-identifier

Flags:
  -A, --all-messages   Toggle if we should see all of the messages or only SRE-P specific ones
  -h, --help           help for list
  -i, --internal       Toggle if we should see internal messages

Global Flags:
      --alsologtostderr                   log to standard error as well as files
      --as string                         Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
      --cluster string                    The name of the kubeconfig cluster to use
      --context string                    The name of the kubeconfig context to use
      --insecure-skip-tls-verify          If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string                 Path to the kubeconfig file to use for CLI requests.
      --log_backtrace_at traceLocations   when logging hits line file:N, emit a stack trace
      --log_dir string                    If non-empty, write log files in this directory
      --log_link string                   If non-empty, add symbolic links in this directory to the log files
      --logbuflevel int                   Buffer log messages logged at this level or lower (-1 means don't buffer; 0 means buffer INFO only; ...). Has limited applicability on non-prod platforms.
      --logtostderr                       log to standard error instead of files
  -o, --output string                     Valid formats are ['', 'json', 'yaml', 'env']
      --request-timeout string            The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
      --s2a_enable_appengine_dialer       If true, opportunistically use AppEngine-specific dialer to call S2A.
      --s2a_timeout duration              Timeout enforced on the connection to the S2A service for handshake. (default 3s)
  -s, --server string                     The address and port of the Kubernetes API server
  -S, --skip-version-check                skip checking to see if this is the most recent release
      --stderrthreshold severityFlag      logs at or above this threshold go to stderr (default 2)
  -v, --v Level                           log level for V logs (default 0)
      --vmodule vModuleFlag               comma-separated list of pattern=N settings for file-filtered logging
```


With this PR:
```
$ osdctl servicelog list ${cluster-id}
gets all servicelog messages for a given cluster

Usage:
  osdctl servicelog list [flags] [options] cluster-identifier

Flags:
  -A, --all-messages   Toggle if we should see all of the messages or only SRE-P specific ones
  -h, --help           help for list
  -i, --internal       Toggle if we should see internal messages

Global Flags:
      --alsologtostderr                   log to standard error as well as files
      --as string                         Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
      --cluster string                    The name of the kubeconfig cluster to use
      --context string                    The name of the kubeconfig context to use
      --insecure-skip-tls-verify          If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string                 Path to the kubeconfig file to use for CLI requests.
      --log_backtrace_at traceLocations   when logging hits line file:N, emit a stack trace
      --log_dir string                    If non-empty, write log files in this directory
      --log_link string                   If non-empty, add symbolic links in this directory to the log files
      --logbuflevel int                   Buffer log messages logged at this level or lower (-1 means don't buffer; 0 means buffer INFO only; ...). Has limited applicability on non-prod platforms.
      --logtostderr                       log to standard error instead of files
  -o, --output string                     Valid formats are ['', 'json', 'yaml', 'env']
      --request-timeout string            The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
      --s2a_enable_appengine_dialer       If true, opportunistically use AppEngine-specific dialer to call S2A.
      --s2a_timeout duration              Timeout enforced on the connection to the S2A service for handshake. (default 3s)
  -s, --server string                     The address and port of the Kubernetes API server
      --skip-aws-proxy-check aws_proxy    Don't use the configured aws_proxy value
  -S, --skip-version-check                skip checking to see if this is the most recent release
      --stderrthreshold severityFlag      logs at or above this threshold go to stderr (default 2)
  -v, --v Level                           log level for V logs
      --vmodule vModuleFlag               comma-separated list of pattern=N settings for file-filtered logging
error: GetClusters expected to return 1 cluster, got: 0
```