### PR TITLE
Check for registry credentials in OCM, Part II

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -224,6 +224,15 @@ func GetAccount(connection *sdk.Connection, key string) (account *amv1.Account, 
 	return
 }
 
+func GetRegistryCredentials(connection *sdk.Connection, accountId string) ([]*amv1.RegistryCredential, error) {
+	searchString := fmt.Sprintf("account_id = '%s'", accountId)
+	registryCredentials, err := connection.AccountsMgmt().V1().RegistryCredentials().List().Search(searchString).Send()
+	if err != nil {
+		return nil, err
+	}
+	return registryCredentials.Items().Slice(), nil
+}
+
 func ConfirmPrompt() bool {
 	fmt.Print("Continue? (y/N): ")
 


### PR DESCRIPTION
This check is standard procedure if the cluster is reported missing.

The first attempt identified an issue with our procedure. That has been fixed and this reflects the new steps that should work reliably.