### PR TITLE
Return all active clusters when using 'org clusters' command

### DIFF
--- a/cmd/org/aws-accounts.go
+++ b/cmd/org/aws-accounts.go
@@ -45,7 +45,7 @@ func init() {
 		"ou-id",
 		"",
 		"",
-		"specify orgnaization unit id",
+		"specify organization unit id",
 	)
 
 	AddOutputFlag(flags)


### PR DESCRIPTION
Resolves [OSD-17668](https://issues.redhat.com//browse/OSD-17668)

Rewrite the `org clusters ...` command to return all active clusters by default. Previously, this command would only return the first 100 results with no indication that the result set was incomplete, and no way to fetch more results.

Outward facing changes:
- Removed `--active` flag. This flag used to filter the result set down to only active clusters. This was no longer needed as this is now the default behavior
- Added `--all/-A` flag, which will return all clusters for an org regardless of status. This is to still allow for the old behavior, but respect the shift in default behavior as noted in the previous bullet point
- Updated `Long` description for the command and added multiple usage examples under `Example` that can be used by reviewers to test.
- Don't allow both orgId AND `--aws-profile` with `--aws-account-id` to be present - only one or the other.
- General logging improvements

Code Health changes:
- Refactored exported `SearchClusters` function to be more independent of Cobra CLI for easier testing and external calling
  - There were two flags used in the function related to AWS flags that were defined in a `common` file somewhere else. While we should absolutely stop doing this, I wasn't comfortable touching it at this time.
- Centralized call to `printClusters` to be in the command itself.
  - This is part of an effort I've been pushing to make all of our functions - even specific to a command - independent of Cobra itself. This allows functions to be re-used more freely and tested more easily.
- Removed custom structs in favor of ocm-sdk structs for calls to the accounts_management API.
- Refactored a branch of code that used to flow from "isAWSProfileSearch"
  - Prior to this, the old function `searchClustersByAWSProfile` would look up the org ID from the given AWS account info, and then call through to `searchClustersByOrg`, which was identical to the path taken when an org ID was present. I rewrote `searchClustersByAWSProfile` into `getOrganizationIdFromAWSProfile` which now only performs the one specific task it's named for. Then the two branches (aws vs. org ID) could be immediately consolidated back, making the flow of code easier to follow.
- Rewrote `searchclustersByOrg` into `searchAllClustersByOrg`. The function will now continuously page to the end of the result set, 100 items at a time.
- Rewrote `createGetClustersRequest` to use the more idiomatic notation for OCM API requests.
  - Instead of using a generic `Get` and manually providing an endpoint, search params, etc., we now chain function calls. This is more readable, easier to follow, and will return a specific API response of `*v1.SubscriptionsListRequest` instead of the generic `*sdk.Request`.
- Removed filtering from `printClusters`
  - a function named "printClusters" should do just that - print the clusters that it is given. It is left up to the caller to provide the filtered list that it wants printed.