### PR TITLE
Add infra resize support for govcloud

### DIFF
--- a/pkg/utils/ocm.go
+++ b/pkg/utils/ocm.go
@@ -17,23 +17,28 @@ import (
 const ClusterServiceClusterSearch = "id = '%s' or name = '%s' or external_id = '%s'"
 
 const (
-	productionURL  = "https://api.openshift.com"
-	stagingURL     = "https://api.stage.openshift.com"
-	integrationURL = "https://api.integration.openshift.com"
+	productionURL    = "https://api.openshift.com"
+	stagingURL       = "https://api.stage.openshift.com"
+	integrationURL   = "https://api.integration.openshift.com"
+	productionGovURL = "https://api.openshiftusgov.com"
 )
 
 var urlAliases = map[string]string{
-	"production":   productionURL,
-	"prod":         productionURL,
-	"prd":          productionURL,
-	productionURL:  productionURL,
-	"staging":      stagingURL,
-	"stage":        stagingURL,
-	"stg":          stagingURL,
-	stagingURL:     stagingURL,
-	"integration":  integrationURL,
-	"int":          integrationURL,
-	integrationURL: integrationURL,
+	"production":     productionURL,
+	"prod":           productionURL,
+	"prd":            productionURL,
+	productionURL:    productionURL,
+	"staging":        stagingURL,
+	"stage":          stagingURL,
+	"stg":            stagingURL,
+	stagingURL:       stagingURL,
+	"integration":    integrationURL,
+	"int":            integrationURL,
+	integrationURL:   integrationURL,
+	"productiongov":  productionGovURL,
+	"prodgov":        productionGovURL,
+	"prdgov":         productionGovURL,
+	productionGovURL: productionGovURL,
 }
 
 // Config describes the OCM client configuration


### PR DESCRIPTION
Add infra resize support for govcloud openshift api. Infra nodes will be rescaled by using osdctl in FedRAMP.

Tested this out in FedRAMP prod cluster.  We just need to export our refresh token and set the backplane config to the appropriate hive backplane api URL.

Ticket https://issues.redhat.com/browse/OSD-17847