### PR TITLE
Add org context command

### DIFF
--- a/cmd/org/cmd.go
+++ b/cmd/org/cmd.go
@@ -29,6 +29,7 @@ func NewCmdOrg() *cobra.Command {
 	orgCmd.AddCommand(clustersCmd)
 	orgCmd.AddCommand(customersCmd)
 	orgCmd.AddCommand(awsAccountsCmd)
+	orgCmd.AddCommand(contextCmd)
 
 	return orgCmd
 }

--- a/cmd/org/common_test.go
+++ b/cmd/org/common_test.go
@@ -2,8 +2,6 @@ package org
 
 import (
 	"testing"
-
-	"github.com/spf13/cobra"
 )
 
 func TestCheckOrgId(t *testing.T) {
@@ -30,7 +28,7 @@ func TestCheckOrgId(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := checkOrgId(&cobra.Command{}, test.Args)
+		err := checkOrgId(test.Args)
 		if test.ErrorExpected {
 			if err == nil {
 				t.Fatalf("Test '%s' failed. Expected error, but got none", test.Name)

--- a/cmd/org/context.go
+++ b/cmd/org/context.go
@@ -1,0 +1,312 @@
+package org
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	pd "github.com/PagerDuty/go-pagerduty"
+	"github.com/andygrunwald/go-jira"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/osdctl/cmd/servicelog"
+	sl "github.com/openshift/osdctl/internal/servicelog"
+	"github.com/openshift/osdctl/pkg/printer"
+	"github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+	"os"
+	"strconv"
+	"sync"
+)
+
+const (
+	ServiceLogDaysSince = 30
+)
+
+type ClusterInfo struct {
+	Name                  string
+	Version               string
+	ID                    string
+	CloudProvider         string
+	Plan                  string
+	NodeCount             float64
+	ServiceLogs           []sl.ServiceLogShort
+	PdAlerts              map[string][]pd.Incident
+	JiraIssues            []jira.Issue
+	LimitedSupportReasons []*cmv1.LimitedSupportReason
+}
+
+type clusterInfoView struct {
+	DisplayName string  `json:"displayName"`
+	ClusterId   string  `json:"clusterId"`
+	Version     string  `json:"version"`
+	Status      string  `json:"status"`
+	Provider    string  `json:"provider"`
+	Plan        string  `json:"plan"`
+	NodeCount   float64 `json:"nodeCount"`
+	RecentSLs   int     `json:"recentSLs"`
+	ActivePDs   int     `json:"activePDs"`
+	OHSS        int     `json:"ohssTickets"`
+}
+
+var contextCmd = &cobra.Command{
+	Use:   "context orgId",
+	Short: "fetches information about the given organization",
+	Long: `Fetches information about the given organization. This data is presented as a table where each row includes the name, version, ID, cloud provider, and plan for the cluster.
+Rows will also include the number of recent service logs, active PD Alerts, Jira Issues, and limited support status for that specific cluster.`,
+	Example: `# Get context data for a cluster
+osdctl org context 1a2B3c4DefghIjkLMNOpQrSTUV5
+
+#Get context data for cluster in json format
+osdctl org context 1a2B3c4DefghIjkLMNOpQrSTUV5 -o json`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		outputFormat, err := cmd.Flags().GetString("output")
+		if err != nil {
+			return fmt.Errorf("error reading flag 'json': %w", err)
+		}
+		if outputFormat != "" && outputFormat != "json" {
+			return errors.New("unsupported output format, only 'json' is accepted")
+		}
+
+		clusterInfos, err := Context(args[0])
+		if err != nil {
+			return fmt.Errorf("error fetching org context: %w", err)
+		}
+		if len(clusterInfos) == 0 {
+			fmt.Println("Org has no clusters")
+			return nil
+		}
+
+		if outputFormat == "json" {
+			return printContextJson(clusterInfos)
+		}
+
+		return printContext(clusterInfos)
+	},
+}
+
+func init() {
+	contextCmd.Flags().StringP("output", "o", "", "output format for the results. only supported value currently is 'json'")
+}
+
+func printContextJson(clusterInfos []ClusterInfo) error {
+	clusterInfoViews := make([]clusterInfoView, 0, len(clusterInfos))
+	for _, clusterInfo := range clusterInfos {
+		plan := clusterInfo.Plan
+		if plan == "MOA" {
+			plan = "ROSA"
+		}
+		if plan == "MOA-HostedControlPlane" {
+			plan = "HCP"
+		}
+
+		view := clusterInfoView{
+			DisplayName: clusterInfo.Name,
+			ClusterId:   clusterInfo.ID,
+			Version:     clusterInfo.Version,
+			Status:      getSupportStatusDisplayText(clusterInfo.LimitedSupportReasons),
+			Provider:    clusterInfo.CloudProvider,
+			Plan:        plan,
+			NodeCount:   clusterInfo.NodeCount,
+			RecentSLs:   len(clusterInfo.ServiceLogs),
+			ActivePDs:   len(clusterInfo.PdAlerts),
+			OHSS:        len(clusterInfo.JiraIssues),
+		}
+
+		clusterInfoViews = append(clusterInfoViews, view)
+	}
+
+	bytes, err := json.MarshalIndent(clusterInfoViews, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal json response: %w", err)
+	}
+	fmt.Println(string(bytes))
+
+	return nil
+}
+
+func printContext(clusterInfos []ClusterInfo) error {
+	table := printer.NewTablePrinter(os.Stdout, 0, 1, 3, ' ')
+	table.AddRow([]string{"DISPLAY NAME", "CLUSTER ID", "VERSION", "STATUS", "PROVIDER", "PLAN", "NODE COUNT", "RECENT SLs", "ACTIVE PDs", "OHSS TICKETS"})
+
+	for _, clusterInfo := range clusterInfos {
+		recentSLs := len(clusterInfo.ServiceLogs)
+		activePDs := len(clusterInfo.PdAlerts)
+		ohss := len(clusterInfo.JiraIssues)
+		table.AddRow([]string{
+			clusterInfo.Name,
+			clusterInfo.ID,
+			clusterInfo.Version,
+			getSupportStatusDisplayText(clusterInfo.LimitedSupportReasons),
+			clusterInfo.CloudProvider,
+			getPlanDisplayText(clusterInfo.Plan),
+			fmt.Sprintf("%v", clusterInfo.NodeCount),
+			strconv.Itoa(recentSLs),
+			strconv.Itoa(activePDs),
+			strconv.Itoa(ohss),
+		})
+	}
+
+	table.AddRow([]string{})
+	if err := table.Flush(); err != nil {
+		return fmt.Errorf("error writing data to console: %w", err)
+	}
+	return nil
+}
+
+func getSupportStatusDisplayText(limitedSupportReasons []*cmv1.LimitedSupportReason) string {
+	if len(limitedSupportReasons) > 0 {
+		return "Limited Support"
+	}
+	return "Fully Supported"
+}
+
+func getPlanDisplayText(plan string) string {
+	if plan == "MOA" {
+		return "ROSA"
+	}
+	if plan == "MOA-HostedControlPlane" {
+		return "HCP"
+	}
+	return plan
+}
+
+func Context(orgId string) ([]ClusterInfo, error) {
+	clusterSubscriptions, err := SearchAllSubscriptionsByOrg(orgId, statusActive, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch cluster subscriptions for org with ID %s: %w", orgId, err)
+	}
+
+	clusterSubscriptionsCount := len(clusterSubscriptions)
+	if clusterSubscriptionsCount == 0 {
+		return nil, nil
+	}
+
+	// cluster info
+	ocmClient, err := utils.CreateConnection()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create OCM client: %w", err)
+	}
+	defer ocmClient.Close()
+
+	var orgClustersInfo []ClusterInfo
+
+	eg, ctx := errgroup.WithContext(context.Background())
+	var mutex sync.Mutex
+	count := 0
+
+	// Print these to stderr so the actual results can be piped to different parsers without worrying about these lines
+	_, _ = fmt.Fprintf(os.Stderr, "Fetching data for %v clusters in org %v...\n", clusterSubscriptionsCount, orgId)
+	_, _ = fmt.Fprintf(os.Stderr, "Fetched data for 0 of %v clusters...\n", clusterSubscriptionsCount)
+	for _, subscription := range clusterSubscriptions {
+		sub := subscription
+		eg.Go(func() error {
+			defer ctx.Done()
+			clusterId := sub.ClusterID()
+			cluster, getClusterErr := utils.GetCluster(ocmClient, clusterId)
+			if getClusterErr != nil {
+				return fmt.Errorf("failed to get cluster %s: %w", clusterId, getClusterErr)
+			}
+
+			clusterInfo := ClusterInfo{
+				Name:          cluster.Name(),
+				Version:       cluster.Version().RawID(),
+				ID:            cluster.ID(),
+				CloudProvider: sub.CloudProviderID(),
+				Plan:          sub.Plan().ID(),
+			}
+
+			if metrics, ok := sub.GetMetrics(); ok {
+				clusterInfo.NodeCount = metrics[0].Nodes().Total()
+			}
+
+			dataErrs, dataCtx := errgroup.WithContext(context.Background())
+			dataErrs.Go(func() error {
+				defer dataCtx.Done()
+				ci := &clusterInfo
+				return addLimitedSupportReasons(ci, ocmClient)
+			})
+
+			dataErrs.Go(func() error {
+				defer dataCtx.Done()
+				ci := &clusterInfo
+				return addServiceLogs(ci)
+			})
+
+			dataErrs.Go(func() error {
+				defer dataCtx.Done()
+				ci := &clusterInfo
+				externalId := cluster.ExternalID()
+				return addJiraIssues(ci, externalId)
+			})
+
+			dataErrs.Go(func() error {
+				defer dataCtx.Done()
+				ci := &clusterInfo
+				baseDomain := cluster.DNS().BaseDomain()
+				return addPDAlerts(ci, baseDomain)
+			})
+
+			if errs := dataErrs.Wait(); errs != nil {
+				return errs
+			}
+
+			mutex.Lock()
+			_, _ = fmt.Fprintf(os.Stderr, "\033[1A\033[K")
+			count++
+			_, _ = fmt.Fprintf(os.Stderr, "Fetched data for %v of %v clusters...\n", count, clusterSubscriptionsCount)
+			orgClustersInfo = append(orgClustersInfo, clusterInfo)
+			mutex.Unlock()
+
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, fmt.Errorf("failed to get context data: %w", err)
+	}
+	return orgClustersInfo, nil
+}
+
+func addLimitedSupportReasons(clusterInfo *ClusterInfo, ocmClient *sdk.Connection) error {
+	var limitedSupportReasonsErr error
+	clusterInfo.LimitedSupportReasons, limitedSupportReasonsErr = utils.GetClusterLimitedSupportReasons(ocmClient, clusterInfo.ID)
+	if limitedSupportReasonsErr != nil {
+		return fmt.Errorf("failed to fetch limited support reasons for cluster %v: %w", clusterInfo.ID, limitedSupportReasonsErr)
+	}
+	return nil
+}
+
+func addServiceLogs(clusterInfo *ClusterInfo) error {
+	var err error
+	clusterInfo.ServiceLogs, err = servicelog.GetServiceLogsSince(clusterInfo.ID, ServiceLogDaysSince)
+	if err != nil {
+		return fmt.Errorf("failed to fetch service logs for cluster %v: %w", clusterInfo.ID, err)
+	}
+	return nil
+}
+
+func addJiraIssues(clusterInfo *ClusterInfo, externalId string) error {
+	var jiraIssuesErr error
+	clusterInfo.JiraIssues, jiraIssuesErr = utils.GetJiraIssuesForCluster(clusterInfo.ID, externalId)
+	if jiraIssuesErr != nil {
+		return fmt.Errorf("failed to fetch Jira issues for cluster %v: %v", clusterInfo.ID, jiraIssuesErr)
+	}
+	return nil
+}
+
+func addPDAlerts(clusterInfo *ClusterInfo, baseDomain string) error {
+	pdServiceIds, pdServiceIdsErr := utils.GetPDServiceIDs(baseDomain, "", "", []string{})
+	if pdServiceIdsErr != nil {
+		return fmt.Errorf("failed to get PD ServiceID for cluster %v: %v", clusterInfo.ID, pdServiceIdsErr)
+	} else {
+		var pdAlertsErr error
+		clusterInfo.PdAlerts, pdAlertsErr = utils.GetCurrentPDAlertsForCluster(pdServiceIds, "", "")
+		if pdAlertsErr != nil {
+			return fmt.Errorf("failed to get PD Alerts for cluster %v: %v", clusterInfo.ID, pdAlertsErr)
+		}
+	}
+	return nil
+}

--- a/cmd/org/describe.go
+++ b/cmd/org/describe.go
@@ -19,7 +19,7 @@ var (
 		Args:          cobra.ArbitraryArgs,
 		SilenceErrors: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(checkOrgId(cmd, args))
+			cmdutil.CheckErr(checkOrgId(args))
 			cmdutil.CheckErr(describeOrg(cmd, args[0]))
 		},
 	}

--- a/cmd/org/labels.go
+++ b/cmd/org/labels.go
@@ -21,7 +21,7 @@ var (
 		Args:          cobra.ArbitraryArgs,
 		SilenceErrors: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(checkOrgId(cmd, args))
+			cmdutil.CheckErr(checkOrgId(args))
 			cmdutil.CheckErr(searchLabelsByOrg(cmd, args[0]))
 		},
 	}

--- a/cmd/org/users.go
+++ b/cmd/org/users.go
@@ -20,7 +20,7 @@ var (
 		Args:          cobra.ArbitraryArgs,
 		SilenceErrors: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(checkOrgId(cmd, args))
+			cmdutil.CheckErr(checkOrgId(args))
 			cmdutil.CheckErr(getUsers(args[0]))
 		},
 	}

--- a/cmd/servicelog/list.go
+++ b/cmd/servicelog/list.go
@@ -85,7 +85,7 @@ func FetchServiceLogs(clusterID string) (*sdk.Response, error) {
 	cluster := clusters[0]
 
 	// Now get the SLs for the cluster
-	return sendRequest(CreateListSLRequest(ocmClient, cluster, serviceLogListAllMessagesFlag, serviceLogListInternalOnlyFlag))
+	return utils.SendRequest(CreateListSLRequest(ocmClient, cluster, serviceLogListAllMessagesFlag, serviceLogListInternalOnlyFlag))
 }
 
 func init() {

--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -201,7 +201,7 @@ func (o *PostCmdOptions) Run() error {
 			continue
 		}
 
-		response, err := sendRequest(request)
+		response, err := ocmutils.SendRequest(request)
 		if err != nil {
 			o.failedClusters[cluster.ExternalID()] = err.Error()
 			continue

--- a/go.mod
+++ b/go.mod
@@ -36,11 +36,13 @@ require (
 	github.com/openshift/hive/apis v0.0.0-20230314202213-17cb22fc3d7c
 	github.com/openshift/osd-network-verifier v0.4.1
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
+	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.2.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
+	golang.org/x/sync v0.2.0
 	google.golang.org/api v0.122.0
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
 	gopkg.in/yaml.v2 v2.4.0
@@ -147,7 +149,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/perimeterx/marshmallow v1.1.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -879,6 +879,7 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.2.0 h1:PUR+T4wwASmuSTYdKjYHI5TD22Wy5ogLU5qZCOLxBrI=
+golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/utils/jira.go
+++ b/pkg/utils/jira.go
@@ -1,0 +1,70 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/andygrunwald/go-jira"
+	"github.com/spf13/viper"
+)
+
+const (
+	JiraTokenConfigKey = "jira_token"
+	JiraBaseURL        = "https://issues.redhat.com"
+)
+
+// GetJiraClient creates a jira client that connects to
+// https://issues.redhat.com. To work, the jiraToken needs to be set in the
+// config
+func GetJiraClient() (*jira.Client, error) {
+	if !viper.IsSet(JiraTokenConfigKey) {
+		return nil, fmt.Errorf("key %s is not set in config file", JiraTokenConfigKey)
+	}
+
+	jiratoken := viper.GetString(JiraTokenConfigKey)
+
+	tp := jira.PATAuthTransport{
+		Token: jiratoken,
+	}
+	return jira.NewClient(tp.Client(), JiraBaseURL)
+}
+
+func GetJiraIssuesForCluster(clusterID string, externalClusterID string) ([]jira.Issue, error) {
+	jiraClient, err := GetJiraClient()
+	if err != nil {
+		return nil, fmt.Errorf("error connecting to jira: %v", err)
+	}
+
+	jql := fmt.Sprintf(
+		`(project = "OpenShift Hosted SRE Support" AND "Cluster ID" ~ "%s") 
+		OR (project = "OpenShift Hosted SRE Support" AND "Cluster ID" ~ "%s") 
+		ORDER BY created DESC`,
+		externalClusterID,
+		clusterID,
+	)
+
+	issues, _, err := jiraClient.Issue.Search(jql, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search for jira issues: %w\n", err)
+	}
+
+	return issues, nil
+}
+
+func GetJiraSupportExceptionsForOrg(organizationID string) ([]jira.Issue, error) {
+	jiraClient, err := GetJiraClient()
+	if err != nil {
+		return nil, fmt.Errorf("error connecting to jira: %v", err)
+	}
+
+	jql := fmt.Sprintf(
+		`project = "Support Exceptions" AND type = Story AND Status = Approved AND
+		 Resolution = Unresolved AND "Customer Name" ~ "%s"`,
+		organizationID,
+	)
+
+	issues, _, err := jiraClient.Issue.Search(jql, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search for jira issues %w", err)
+	}
+
+	return issues, nil
+}

--- a/pkg/utils/ocm.go
+++ b/pkg/utils/ocm.go
@@ -418,3 +418,11 @@ func GetHiveCluster(clusterId string) (*cmv1.Cluster, error) {
 
 	return resp.Items().Get(0), nil
 }
+
+func SendRequest(request *sdk.Request) (*sdk.Response, error) {
+	response, err := request.Send()
+	if err != nil {
+		return nil, fmt.Errorf("cannot send request: %q", err)
+	}
+	return response, nil
+}

--- a/pkg/utils/pagerduty.go
+++ b/pkg/utils/pagerduty.go
@@ -1,0 +1,118 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	pd "github.com/PagerDuty/go-pagerduty"
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+)
+
+const (
+	PagerDutyUserTokenConfigKey  = "pd_user_token"
+	PagerDutyOauthTokenConfigKey = "pd_oauth_token"
+	PagerDutyTeamIDsKey          = "team_ids"
+)
+
+func GetPagerDutyClient(usertoken string, oauthtoken string) (*pd.Client, error) {
+	client, err := getPDUserClient(usertoken)
+	if client != nil {
+		return client, err
+	}
+
+	client, err = getPDOauthClient(oauthtoken)
+	if err != nil {
+		return nil, errors.New("failed to create both user and oauth clients for pd, neither key pd_oauth_token or pd_user_token are set in config file")
+	}
+	return client, err
+}
+
+func GetPDServiceIDs(baseDomain string, usertoken string, oauthtoken string, teamIds []string) ([]string, error) {
+	pdClient, err := GetPagerDutyClient(usertoken, oauthtoken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to GetPagerDutyClient: %w", err)
+	}
+
+	// Gets the PD Team IDS
+	teams := getPDTeamIDs(teamIds)
+
+	lsResponse, err := pdClient.ListServicesWithContext(context.TODO(), pd.ListServiceOptions{Query: baseDomain, TeamIDs: teams})
+	if err != nil {
+		return []string{}, fmt.Errorf("failed to ListServicesWithContext: %w", err)
+	}
+
+	var serviceIDS []string
+	for _, service := range lsResponse.Services {
+		serviceIDS = append(serviceIDS, service.ID)
+	}
+
+	return serviceIDS, nil
+}
+
+func GetCurrentPDAlertsForCluster(pdServiceIDs []string, pdUsertoken string, pdAuthToken string) (map[string][]pd.Incident, error) {
+	pdClient, err := GetPagerDutyClient(pdUsertoken, pdAuthToken)
+	if err != nil {
+		return nil, fmt.Errorf("error getting pd client: %w", err)
+	}
+	incidents := map[string][]pd.Incident{}
+
+	var incidentLimit uint = 25
+	var incidentListOffset uint = 0
+	for _, pdServiceID := range pdServiceIDs {
+		for {
+			listIncidentsResponse, err := pdClient.ListIncidentsWithContext(
+				context.TODO(),
+				pd.ListIncidentsOptions{
+					ServiceIDs: []string{pdServiceID},
+					Statuses:   []string{"triggered", "acknowledged"},
+					SortBy:     "urgency:DESC",
+					Limit:      incidentLimit,
+					Offset:     incidentListOffset,
+				},
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			incidents[pdServiceID] = append(incidents[pdServiceID], listIncidentsResponse.Incidents...)
+
+			if !listIncidentsResponse.More {
+				break
+			}
+			incidentListOffset += incidentLimit
+		}
+	}
+	return incidents, nil
+}
+
+func getPDUserClient(usertoken string) (*pd.Client, error) {
+	if usertoken == "" {
+		if !viper.IsSet(PagerDutyUserTokenConfigKey) {
+			return nil, fmt.Errorf("key %s is not set in config file", PagerDutyUserTokenConfigKey)
+		}
+		usertoken = viper.GetString(PagerDutyUserTokenConfigKey)
+	}
+	return pd.NewClient(usertoken), nil
+}
+
+func getPDOauthClient(oauthtoken string) (*pd.Client, error) {
+	if oauthtoken == "" {
+		if !viper.IsSet(PagerDutyOauthTokenConfigKey) {
+			return nil, fmt.Errorf("key %s is not set in config file", PagerDutyOauthTokenConfigKey)
+		}
+		oauthtoken = viper.GetString(PagerDutyOauthTokenConfigKey)
+	}
+	return pd.NewOAuthClient(oauthtoken), nil
+}
+
+// Returns an empty array if team_ids has not been informed via CLI or config file
+// that will make the query show all PD Alerts for all PD services by default
+func getPDTeamIDs(teamIds []string) []string {
+	if len(teamIds) == 0 {
+		if !viper.IsSet(PagerDutyTeamIDsKey) {
+			return []string{}
+		}
+		teamIds = viper.GetStringSlice(PagerDutyTeamIDsKey)
+	}
+	return teamIds
+}

--- a/pkg/utils/print.go
+++ b/pkg/utils/print.go
@@ -1,0 +1,121 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	pd "github.com/PagerDuty/go-pagerduty"
+	"github.com/andygrunwald/go-jira"
+	"github.com/openshift-online/ocm-cli/pkg/dump"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	sl "github.com/openshift/osdctl/internal/servicelog"
+	"github.com/openshift/osdctl/pkg/printer"
+	"math"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	delimiter = ">> "
+)
+
+func PrintServiceLogs(serviceLogs []sl.ServiceLogShort, verbose bool, sinceDays int) {
+	var name = fmt.Sprintf("Service Logs in the past %v days", sinceDays)
+	fmt.Println(delimiter + name)
+
+	if verbose {
+		marshalledSLs, err := json.MarshalIndent(serviceLogs, "", "  ")
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Couldn't prepare service logs for printing: %v", err)
+		}
+		_ = dump.Pretty(os.Stdout, marshalledSLs)
+	} else if len(serviceLogs) == 0 {
+		fmt.Println("None")
+	} else {
+		// Non-verbose only prints the summaries
+		for i, errorServiceLog := range serviceLogs {
+			var serviceLogSummary string
+			if errorServiceLog.InternalOnly {
+				internalServiceLogLines := strings.Split(errorServiceLog.Description, "\n")
+				if len(internalServiceLogLines) > 0 {
+					// if the description is "", Split returns []
+					serviceLogSummary = fmt.Sprintf("INT %s", internalServiceLogLines[0])
+				} else {
+					serviceLogSummary = errorServiceLog.Summary
+				}
+			} else {
+				serviceLogSummary = errorServiceLog.Summary
+			}
+			serviceLogSummaryAbbreviated := serviceLogSummary[:int(math.Min(40, float64(len(serviceLogSummary))))]
+			fmt.Printf("%d. %s (%s)\n", i, serviceLogSummaryAbbreviated, errorServiceLog.CreatedAt.Format(time.RFC3339))
+		}
+	}
+}
+
+func PrintPDAlerts(incidents map[string][]pd.Incident, serviceIDs []string) {
+	var name = "PagerDuty Alerts"
+	fmt.Println(delimiter + name)
+
+	if len(serviceIDs) == 0 {
+		fmt.Println("No PD Service Found")
+		return
+	}
+
+	for _, ID := range serviceIDs {
+		fmt.Printf("Service: https://redhat.pagerduty.com/service-directory/%s\n", ID)
+
+		tableHasContent := false
+		table := printer.NewTablePrinter(os.Stdout, 20, 1, 3, ' ')
+		table.AddRow([]string{"Urgency", "Title", "Created At"})
+		for _, incident := range incidents[ID] {
+			table.AddRow([]string{incident.Urgency, incident.Title, incident.CreatedAt})
+			tableHasContent = true
+		}
+		if tableHasContent {
+			// Add empty row for readability
+			table.AddRow([]string{})
+			if err := table.Flush(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error printing %s - %s: %v\n", name, ID, err)
+			}
+		} else {
+			fmt.Println("None")
+		}
+	}
+}
+
+func PrintJiraIssues(issues []jira.Issue) {
+	var name = "OHSS Issues"
+	fmt.Println(delimiter + name)
+
+	for _, i := range issues {
+		fmt.Printf("[%s](%s/%s): %+v\n", i.Key, i.Fields.Type.Name, i.Fields.Priority.Name, i.Fields.Summary)
+		fmt.Printf("- Created: %s\tStatus: %s\n", time.Time(i.Fields.Created).Format("2006-01-02 15:04"), i.Fields.Status.Name)
+		fmt.Printf("- Link: %s/browse/%s\n\n", JiraBaseURL, i.Key)
+	}
+
+	if len(issues) == 0 {
+		fmt.Println("None")
+	}
+}
+
+func PrintLimitedSupportReasons(limitedSupportReasons []*cmv1.LimitedSupportReason) {
+	var name = "Limited Support Status"
+	fmt.Println(delimiter + name)
+
+	// No reasons found, cluster is fully supported
+	if len(limitedSupportReasons) == 0 {
+		fmt.Printf("Fully supported\n")
+		return
+	}
+
+	table := printer.NewTablePrinter(os.Stdout, 20, 1, 3, ' ')
+	table.AddRow([]string{"Reason ID", "Summary", "Details"})
+	for _, clusterLimitedSupportReason := range limitedSupportReasons {
+		table.AddRow([]string{clusterLimitedSupportReason.ID(), clusterLimitedSupportReason.Summary(), clusterLimitedSupportReason.Details()})
+	}
+	// Add empty row for readability
+	table.AddRow([]string{})
+	if err := table.Flush(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error printing %s: %v\n", name, err)
+	}
+}


### PR DESCRIPTION
Outputs a high level overview for all of the clusters owned by a specific org. Sample output below with display names, cluster IDs, and org ID redacted:
```
Fetching data for 11 clusters in org <org ID>...
Fetched data for 11 of 11 clusters... <-- this number auto updates
VERSION   STATUS            PROVIDER   PLAN   NODE COUNT   RECENT SLs   ACTIVE PDs   OHSS
4.11.5    Fully Supported   aws        ROSA   12           1            1            3
4.12.27   Fully Supported   aws        ROSA   10           0            1            1
4.11.5    Fully Supported   aws        ROSA   32           1            1            7
4.11.5    Fully Supported   aws        ROSA   15           1            1            2
4.12.27   Fully Supported   aws        ROSA   12           4            1            3
4.11.5    Fully Supported   aws        ROSA   58           1            1            5
4.11.5    Fully Supported   aws        ROSA   61           1            1            7
4.11.5    Fully Supported   aws        ROSA   32           4            1            11
4.11.5    Fully Supported   aws        ROSA   13           1            1            9
4.12.27   Fully Supported   aws        ROSA   25           0            1            7
4.12.27   Fully Supported   aws        ROSA   12           0            1            1
```