### PR TITLE
Fix bug when sending servicelog for GCP infra resize

### DIFF
--- a/cmd/cluster/resize/cmd.go
+++ b/cmd/cluster/resize/cmd.go
@@ -20,8 +20,10 @@ type Resize struct {
 	hive      client.Client
 	hiveAdmin client.Client
 
-	cluster      *cmv1.Cluster
-	clusterId    string
+	cluster   *cmv1.Cluster
+	clusterId string
+
+	// instanceType is the type of instance being resized to
 	instanceType string
 }
 

--- a/cmd/cluster/resize/infra_node.go
+++ b/cmd/cluster/resize/infra_node.go
@@ -53,8 +53,8 @@ func newCmdResizeInfra() *cobra.Command {
 		},
 	}
 
-	infraResizeCmd.Flags().StringVarP(&r.clusterId, "cluster-id", "C", "", "OCM internal cluster id to resize infra nodes for.")
-	infraResizeCmd.Flags().StringVar(&r.instanceType, "instance-type", "", "(optional) AWS EC2 instance type to resize the infra nodes to.")
+	infraResizeCmd.Flags().StringVarP(&r.clusterId, "cluster-id", "C", "", "OCM internal/external cluster id or cluster name to resize infra nodes for.")
+	infraResizeCmd.Flags().StringVar(&r.instanceType, "instance-type", "", "(optional) Override for an AWS or GCP instance type to resize the infra nodes to, by default supported instance types are automatically selected.")
 
 	infraResizeCmd.MarkFlagRequired("cluster-id")
 
@@ -245,7 +245,7 @@ func (r *Resize) RunInfra(ctx context.Context) error {
 		return err
 	}
 
-	postCmd := generateServiceLog(newMp.Spec.Platform.AWS.InstanceType, r.clusterId)
+	postCmd := generateServiceLog(r.instanceType, r.clusterId)
 	if err := postCmd.Run(); err != nil {
 		fmt.Println("Failed to generate service log. Please manually send a service log to the customer for the blocked egresses with:")
 		fmt.Printf("osdctl servicelog post %v -t %v -p %v\n",


### PR DESCRIPTION
[OSD-18226](https://issues.redhat.com//browse/OSD-18226)

Behavior before the fix:
```
2023/08/22 18:40:11 found 2 infra nodes, infra resize complete
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x25e9cd9]

goroutine 1 [running]:
github.com/openshift/osdctl/cmd/cluster/resize.(*Resize).RunInfra(0xc0004bd6e0, {0x4530c90?, 0xc00013e000})
        github.com/openshift/osdctl/cmd/cluster/resize/infra_node.go:248 +0xb19
github.com/openshift/osdctl/cmd/cluster/resize.newCmdResizeInfra.func1(0xc00053ac00?, {0x3e1bd0e?, 0x4?, 0x4?})
        github.com/openshift/osdctl/cmd/cluster/resize/infra_node.go:52 +0x2b
github.com/spf13/cobra.(*Command).execute(0xc00053ac00, {0xc000085e00, 0x4, 0x4})
        github.com/spf13/cobra@v1.7.0/command.go:940 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xc000638300)
        github.com/spf13/cobra@v1.7.0/command.go:1068 +0x3bd
github.com/spf13/cobra.(*Command).Execute(0x44fbf40?)
        github.com/spf13/cobra@v1.7.0/command.go:992 +0x19
main.main()
        github.com/openshift/osdctl/main.go:23 +0x10d
```

We should be using `r.instanceType` which gets populated here: https://github.com/openshift/osdctl/blob/dab896de457406e64d76156c8923b92ed6246ca4/cmd/cluster/resize/infra_node.go#L329-L336