### PR TITLE
OSD-17491: Add function for etcd member replacement

### DIFF
--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -34,6 +34,7 @@ func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions
 	clusterCmd.AddCommand(newCmdCheckBannedUser())
 	clusterCmd.AddCommand(newCmdValidatePullSecret(client, flags))
 	clusterCmd.AddCommand(newCmdEtcdHealthCheck(client, flags))
+	clusterCmd.AddCommand(newCmdEtcdMemberReplacement(client, flags))
 	clusterCmd.AddCommand(newCmdFromInfraId(globalOpts))
 	clusterCmd.AddCommand(NewCmdHypershiftInfo(streams))
 	return clusterCmd

--- a/cmd/cluster/etcd_replace.go
+++ b/cmd/cluster/etcd_replace.go
@@ -1,0 +1,144 @@
+package cluster
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type flagOptions struct {
+	nodeId string
+}
+
+func newCmdEtcdMemberReplacement(kubeCli client.Client, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	opts := &flagOptions{}
+	replaceCmd := &cobra.Command{
+		Use:               "etcd-member-replacement <node-id>",
+		Short:             "Replaces an unhealthy etcd node",
+		Long:              `Replaces an unhealthy ectd node using the member id provided`,
+		Args:              cobra.ExactArgs(0),
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(EtcdReplaceMember(kubeCli, *opts))
+		},
+	}
+	replaceCmd.Flags().StringVar(&opts.nodeId, "node", "", "Node ID")
+	return replaceCmd
+}
+
+func EtcdReplaceMember(kubeCli client.Client, opts flagOptions) error {
+	// TODO : 1. Identify the unhealthy members
+	// TODO : 2. Identify the cause -> CrashLoopBackOff/ Machine Not Running/ Node Not Ready
+	// TODO : 3. For each of these, perform the replacement
+
+	// CrashLoopBackOff replacement
+
+	// Machine Not Running replacement
+
+	// Node Not Ready replacement
+	var kubeconfig *string
+
+	if home := homedir.HomeDir(); home != "" {
+		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	flag.Parse()
+
+	// use the current context in kubeconfig
+	kconfig, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	// create the clientset
+	clientset, err := kubernetes.NewForConfig(kconfig)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	namespace := "openshift-etcd"
+	listOptions := metav1.ListOptions{
+		LabelSelector: "k8s-app=etcd",
+	}
+
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), listOptions)
+	if err != nil {
+		return err
+	}
+	for _, pod := range pods.Items {
+		for _, c := range pod.Status.ContainerStatuses {
+			if c.State.Waiting != nil && (c.State.Waiting.Reason == "CrashLoopBackOff" || c.State.Waiting.Reason == "Error") {
+				err := ReplaceCrashBackLoopOff(kconfig, clientset, pod.ObjectMeta.Name, opts)
+				if err != nil {
+					return err
+				}
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("the etcd member seems to be healthy. Please run health-check again")
+}
+
+func ReplaceCrashBackLoopOff(kconfig *rest.Config, client *kubernetes.Clientset, pod string, opts flagOptions) error {
+	podName := "etcd-" + opts.nodeId
+	if podName != pod {
+		return fmt.Errorf("the etcd member seems to be healthy. Please run health-check again")
+	}
+	cmd := "etcdctl member list -w table | grep " + opts.nodeId + " | awk '{ print $2 }'"
+	memberId, _ := Etcdctlhealth(kconfig, client, cmd, pod)
+	memberId = strings.TrimSpace(memberId)
+	fmt.Printf("Replacing pod %s having member id %s ", pod, memberId)
+	///
+
+	// prompt := utils.ConfirmPrompt()
+	// fmt.Printf("%T\n", prompt)
+	// if !prompt {
+	// 	return fmt.Errorf("operation cancelled by user")
+	// }
+	fmt.Print("Continue? (y/N): ")
+
+	var response string
+	_, err := fmt.Scanln(&response) // Erroneous input will be handled by the default case below
+	if err != nil {
+		fmt.Println(err)
+	}
+	switch strings.ToLower(response) {
+	case "y", "yes":
+		remove_cmd := "etcdctl member remove " + memberId
+		output, err := Etcdctlhealth(kconfig, client, remove_cmd, pod)
+		if err != nil {
+			fmt.Println("Could not replace pod. Refer error below")
+			return err
+		}
+		fmt.Println(output)
+		return nil
+	case "n", "no":
+		return fmt.Errorf("operation cancelled by user")
+	default:
+		fmt.Println("Invalid input. Expecting (y)es or (N)o")
+		return fmt.Errorf("operation cancelled by user")
+	}
+
+	///
+	// remove_cmd := "etcdctl member remove " + memberId
+	// output, err := Etcdctlhealth(kconfig, client, remove_cmd, pod)
+	// if err != nil {
+	// 	fmt.Println("Could not replace pod. Refer error below")
+	// 	return err
+	// }
+	// fmt.Println(output)
+	// return nil
+}

--- a/cmd/cluster/etcd_replace.go
+++ b/cmd/cluster/etcd_replace.go
@@ -2,18 +2,18 @@ package cluster
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	"path/filepath"
 	"strings"
+	"time"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -22,66 +22,64 @@ type flagOptions struct {
 	nodeId string
 }
 
+// Secrets List
+var secrets = []string{
+	"etcd-peer-",
+	"etcd-serving-",
+	"etcd-serving-metrics-",
+}
+
+// Patch Constants
+const (
+	EtcdQuorumTurnOffPatch = `{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}`
+	EtcdQuorumTurnOnPatch  = `{"spec": {"unsupportedConfigOverrides": null}}`
+	EtcdForceRedeployPatch = `{"spec": {"forceRedeploymentReason": "single-master-recovery-%s"}}`
+)
+
 func newCmdEtcdMemberReplacement(kubeCli client.Client, flags *genericclioptions.ConfigFlags) *cobra.Command {
 	opts := &flagOptions{}
 	replaceCmd := &cobra.Command{
-		Use:               "etcd-member-replacement <node-id>",
+		Use:               "etcd-member-replacement",
 		Short:             "Replaces an unhealthy etcd node",
 		Long:              `Replaces an unhealthy ectd node using the member id provided`,
 		Args:              cobra.ExactArgs(0),
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(EtcdReplaceMember(kubeCli, *opts))
+			cmdutil.CheckErr(EtcdReplaceMember(kubeCli, *opts, flags))
 		},
 	}
 	replaceCmd.Flags().StringVar(&opts.nodeId, "node", "", "Node ID")
 	return replaceCmd
 }
 
-func EtcdReplaceMember(kubeCli client.Client, opts flagOptions) error {
-	// TODO : 1. Identify the unhealthy members
-	// TODO : 2. Identify the cause -> CrashLoopBackOff/ Machine Not Running/ Node Not Ready
-	// TODO : 3. For each of these, perform the replacement
-
-	// CrashLoopBackOff replacement
-
-	// Machine Not Running replacement
-
-	// Node Not Ready replacement
-	var kubeconfig *string
-
-	if home := homedir.HomeDir(); home != "" {
-		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-	} else {
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
-	}
-	flag.Parse()
-
-	// use the current context in kubeconfig
-	kconfig, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+func EtcdReplaceMember(kubeCli client.Client, opts flagOptions, flags *genericclioptions.ConfigFlags) error {
+	kconfig, clientset, err := getKubeConfigAndClientSet()
 	if err != nil {
-		panic(err.Error())
+		return err
 	}
 
-	// create the clientset
-	clientset, err := kubernetes.NewForConfig(kconfig)
-	if err != nil {
-		panic(err.Error())
-	}
-
-	namespace := "openshift-etcd"
 	listOptions := metav1.ListOptions{
-		LabelSelector: "k8s-app=etcd",
+		LabelSelector: EtcdLabelSelector,
 	}
 
-	pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), listOptions)
+	if opts.nodeId == "" {
+		return fmt.Errorf("node name cannot be blank. Please provide node using --node flag")
+	}
+
+	fmt.Println("[INFO] This operation will run with the \"backplane-cluster-admin\" role")
+	// Get the etcd pods
+	pods, err := clientset.CoreV1().Pods(EtcdNamespaceName).List(context.TODO(), listOptions)
 	if err != nil {
 		return err
 	}
 	for _, pod := range pods.Items {
 		for _, c := range pod.Status.ContainerStatuses {
 			if c.State.Waiting != nil && (c.State.Waiting.Reason == "CrashLoopBackOff" || c.State.Waiting.Reason == "Error") {
-				err := ReplaceCrashBackLoopOff(kconfig, clientset, pod.ObjectMeta.Name, opts)
+				podName := "etcd-" + opts.nodeId
+				if podName != pod.ObjectMeta.Name {
+					return fmt.Errorf("the etcd member seems to be healthy. Please run health-check again")
+				}
+				err := ReplaceEtcdMember(kubeCli, kconfig, clientset, flags, opts, pod.ObjectMeta.Name)
 				if err != nil {
 					return err
 				}
@@ -89,56 +87,97 @@ func EtcdReplaceMember(kubeCli client.Client, opts flagOptions) error {
 			}
 		}
 	}
-	return fmt.Errorf("the etcd member seems to be healthy. Please run health-check again")
+	return fmt.Errorf("none of the etcd members seems to be unhealthy. Please verify once again")
 }
 
-func ReplaceCrashBackLoopOff(kconfig *rest.Config, client *kubernetes.Clientset, pod string, opts flagOptions) error {
-	podName := "etcd-" + opts.nodeId
-	if podName != pod {
-		return fmt.Errorf("the etcd member seems to be healthy. Please run health-check again")
-	}
-	cmd := "etcdctl member list -w table | grep " + opts.nodeId + " | awk '{ print $2 }'"
-	memberId, _ := Etcdctlhealth(kconfig, client, cmd, pod)
-	memberId = strings.TrimSpace(memberId)
-	fmt.Printf("Replacing pod %s having member id %s ", pod, memberId)
-	///
-
-	// prompt := utils.ConfirmPrompt()
-	// fmt.Printf("%T\n", prompt)
-	// if !prompt {
-	// 	return fmt.Errorf("operation cancelled by user")
-	// }
-	fmt.Print("Continue? (y/N): ")
-
-	var response string
-	_, err := fmt.Scanln(&response) // Erroneous input will be handled by the default case below
+func ReplaceEtcdMember(kubeCli client.Client, kconfig *rest.Config, clientset *kubernetes.Clientset, flags *genericclioptions.ConfigFlags, opts flagOptions, pod string) error {
+	// Remove the etcd member
+	err := removeEtcdMember(kconfig, clientset, pod, opts)
 	if err != nil {
-		fmt.Println(err)
+		return err
 	}
-	switch strings.ToLower(response) {
-	case "y", "yes":
-		remove_cmd := "etcdctl member remove " + memberId
-		output, err := Etcdctlhealth(kconfig, client, remove_cmd, pod)
+
+	// Turn off the quorum guard
+	fmt.Println("[INFO] Turning the quorum guard off")
+	err = patchEtcdQuorum(kubeCli, flags, EtcdQuorumTurnOffPatch)
+	if err != nil {
+		return err
+	}
+
+	// Delete the secrets for the unhealthy etcd member
+	err = removeEtcdSecrets(clientset, opts)
+	if err != nil {
+		return err
+	}
+
+	// Force etcd redeployment.
+	fmt.Println("[INFO] Forcing etcd redeployment")
+	timeStamp := time.Now().Format(time.RFC3339Nano)
+	patch := fmt.Sprintf(EtcdForceRedeployPatch, timeStamp)
+	err = patchEtcdQuorum(kubeCli, flags, patch)
+	if err != nil {
+		return err
+	}
+
+	// Turn the quorum guard back
+	fmt.Println("[INFO] Turning the quorum guard back on")
+	err = patchEtcdQuorum(kubeCli, flags, EtcdQuorumTurnOnPatch)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("The etcd member has been successfully replaced. Please verify by running health check after few minutes.")
+	return nil
+}
+
+func removeEtcdMember(kconfig *rest.Config, clientset *kubernetes.Clientset, pod string, opts flagOptions) error {
+	fmt.Println()
+	cmd := "etcdctl member list -w table | grep " + opts.nodeId + " | awk '{ print $2 }'"
+	memberId, err := Etcdctlhealth(kconfig, clientset, cmd, pod)
+	if err != nil {
+		return err
+	}
+	memberId = strings.TrimSpace(memberId)
+	fmt.Printf("[INFO] Replacing pod %s having member id %s.\n", pod, memberId)
+
+	prompt := utils.ConfirmPrompt()
+	if !prompt {
+		return fmt.Errorf("operation cancelled by user")
+	}
+
+	remove_cmd := "etcdctl member remove " + memberId
+	output, err := Etcdctlhealth(kconfig, clientset, remove_cmd, pod)
+	if err != nil {
+		fmt.Println("Could not replace pod. Refer error below")
+		return err
+	}
+	fmt.Println(output)
+	return nil
+}
+
+func patchEtcdQuorum(kubeCli client.Client, flags *genericclioptions.ConfigFlags, patch string) error {
+	etcdCR := &operatorv1.Etcd{}
+	flags.Impersonate = &BackplaneClusterAdmin
+
+	err := kubeCli.Get(context.TODO(), client.ObjectKey{Name: "cluster"}, etcdCR)
+	if err != nil {
+		return err
+	}
+	err = kubeCli.Patch(context.TODO(), etcdCR, client.RawPatch(types.MergePatchType, []byte(patch)), &client.PatchOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func removeEtcdSecrets(clientset *kubernetes.Clientset, opts flagOptions) error {
+	fmt.Println("[INFO] Deleting the secrets for the unhealthy etcd member")
+	for _, secret := range secrets {
+		name := secret + opts.nodeId
+		err := clientset.CoreV1().Secrets("openshift-etcd").Delete(context.TODO(), name, metav1.DeleteOptions{})
 		if err != nil {
-			fmt.Println("Could not replace pod. Refer error below")
 			return err
 		}
-		fmt.Println(output)
-		return nil
-	case "n", "no":
-		return fmt.Errorf("operation cancelled by user")
-	default:
-		fmt.Println("Invalid input. Expecting (y)es or (N)o")
-		return fmt.Errorf("operation cancelled by user")
 	}
-
-	///
-	// remove_cmd := "etcdctl member remove " + memberId
-	// output, err := Etcdctlhealth(kconfig, client, remove_cmd, pod)
-	// if err != nil {
-	// 	fmt.Println("Could not replace pod. Refer error below")
-	// 	return err
-	// }
-	// fmt.Println(output)
-	// return nil
+	return nil
 }


### PR DESCRIPTION
This PR aims to add a new command to osdctl i.e `osdctl cluster etcd-member-replacement --node <node-id>`

The command aims to automate the member replacement for etcd in case the state of unhealthy etcd member is `CrashLoopBackOff` or `Error` following the steps mentioned in the [doc](https://docs.openshift.com/container-platform/4.13/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-crashlooping-etcd-member_replacing-unhealthy-etcd-member)

Assuming on of the pods is in `CrashLoopBackOff`
```
 oc -n openshift-etcd get pods -l k8s-app=etcd                                    
NAME                                READY   STATUS             RESTARTS       AGE
etcd-ip-10-0-154-180.ec2.internal   3/4     CrashLoopBackOff   5 (100s ago)   9m10s
etcd-ip-10-0-165-39.ec2.internal    4/4     Running            0              5m35s
etcd-ip-10-0-210-217.ec2.internal   4/4     Running            0              7m27s
```
 On running the command, we get
```
[INFO] This operation will run with the "backplane-cluster-admin" role

[INFO] Replacing pod etcd-ip-10-0-154-180.ec2.internal having member id 363b728d88e78c7a.
Continue? (y/N): y
Member 363b728d88e78c7a removed from cluster 8234ce6cfd037151

[INFO] Turning the quorum guard off
[INFO] Deleting the secrets for the unhealthy etcd member
[INFO] Forcing etcd redeployment
[INFO] Turning the quorum guard back on
The etcd member has been successfully replaced. Please verify by running health check after few minutes.
```