### PR TITLE
OSD-17941: Add etcd member replacement command

### DIFF
--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -34,6 +34,7 @@ func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions
 	clusterCmd.AddCommand(newCmdCheckBannedUser())
 	clusterCmd.AddCommand(newCmdValidatePullSecret(client, flags))
 	clusterCmd.AddCommand(newCmdEtcdHealthCheck(client, flags))
+	clusterCmd.AddCommand(newCmdEtcdMemberReplacement(client, flags))
 	clusterCmd.AddCommand(newCmdFromInfraId(globalOpts))
 	clusterCmd.AddCommand(NewCmdHypershiftInfo(streams))
 	return clusterCmd

--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -33,8 +33,8 @@ func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions
 	clusterCmd.AddCommand(newCmdCpd())
 	clusterCmd.AddCommand(newCmdCheckBannedUser())
 	clusterCmd.AddCommand(newCmdValidatePullSecret(client, flags))
-	clusterCmd.AddCommand(newCmdEtcdHealthCheck(client, flags))
-	clusterCmd.AddCommand(newCmdEtcdMemberReplacement(client, flags))
+	clusterCmd.AddCommand(newCmdEtcdHealthCheck())
+	clusterCmd.AddCommand(newCmdEtcdMemberReplacement())
 	clusterCmd.AddCommand(newCmdFromInfraId(globalOpts))
 	clusterCmd.AddCommand(NewCmdHypershiftInfo(streams))
 	return clusterCmd

--- a/cmd/cluster/etcd_health.go
+++ b/cmd/cluster/etcd_health.go
@@ -3,22 +3,20 @@ package cluster
 import (
 	"bytes"
 	"context"
-	"flag"
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
+	"strings"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	bplogin "github.com/openshift/backplane-cli/cmd/ocm-backplane/login"
+	bpconfig "github.com/openshift/backplane-cli/pkg/cli/config"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/client-go/util/homedir"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -53,55 +51,54 @@ func (capture *logCapture) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-func getKubeConfigAndClientSet() (*rest.Config, *kubernetes.Clientset, error) {
-	var kubeconfig *string
-
-	if home := homedir.HomeDir(); home != "" {
-		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-	} else {
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
-	}
-	flag.Parse()
-
-	// use the current context in kubeconfig
-	kconfig, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+func getKubeConfigAndClient(clusterID string) (client.Client, *rest.Config, *kubernetes.Clientset, error) {
+	bp, err := bpconfig.GetBackplaneConfiguration()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, fmt.Errorf("failed to load backplane-cli config: %v", err)
 	}
 
-	kconfig.Impersonate = rest.ImpersonationConfig{
-		UserName: BackplaneClusterAdmin,
+	kubeconfig, err := bplogin.GetRestConfigAsUser(bp, clusterID, "backplane-cluster-admin")
+	if err != nil {
+		return nil, nil, nil, err
 	}
 	// create the clientset
-	clientset, err := kubernetes.NewForConfig(kconfig)
+	clientset, err := kubernetes.NewForConfig(kubeconfig)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-
-	return kconfig, clientset, err
+	kubeCli, err := client.New(kubeconfig, client.Options{})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return kubeCli, kubeconfig, clientset, err
 }
 
-func newCmdEtcdHealthCheck(kubeCli client.Client, flags *genericclioptions.ConfigFlags) *cobra.Command {
+func newCmdEtcdHealthCheck() *cobra.Command {
 	return &cobra.Command{
-		Use:               "etcd-health-check",
+		Use:               "etcd-health-check <cluster-id>",
 		Short:             "Checks the etcd components and member health",
 		Long:              `Checks etcd component health status for member replacement`,
-		Args:              cobra.ExactArgs(0),
+		Args:              cobra.ExactArgs(1),
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(EtcdHealthCheck(kubeCli))
+			cmdutil.CheckErr(EtcdHealthCheck(args[0]))
 		},
 	}
 }
 
-func EtcdHealthCheck(kubeCli client.Client) error {
+func EtcdHealthCheck(clusterId string) error {
 	defer func() {
 		if err := recover(); err != nil {
 			log.Fatal("error : ", err)
 		}
 	}()
 
-	err := ControlplaneNodeStatus(kubeCli)
+	kubeCli, kconfig, clientset, err := getKubeConfigAndClient(clusterId)
+	if err != nil {
+		return err
+	}
+
+	err = ControlplaneNodeStatus(kubeCli)
 	if err != nil {
 		return err
 	}
@@ -111,35 +108,22 @@ func EtcdHealthCheck(kubeCli client.Client) error {
 		return err
 	}
 
-	err = EtcdCrStatus(kubeCli)
+	unhealthyMember, err := EtcdCrStatus(kubeCli)
 	if err != nil {
 		return err
-	}
-
-	kconfig, clientset, err := getKubeConfigAndClientSet()
-	if err != nil {
-		return err
-	}
-
-	MatchPodName := false
-	var etcdPodName string
-	for !MatchPodName {
-		fmt.Print("Enter Etcd Pod Name: ")
-		fmt.Scan(&etcdPodName)
-		for _, pods := range podlist.Items {
-			if etcdPodName == pods.Name {
-				MatchPodName = true
-			}
-		}
 	}
 
 	for _, v := range etcdctlCmd {
-		output, err := Etcdctlhealth(kconfig, clientset, v, etcdPodName)
+		output, err := Etcdctlhealth(kconfig, clientset, v, podlist.Items[0].Name)
 		if err != nil {
 			fmt.Println(err)
 		}
 		fmt.Printf("$ %s\n", v)
 		fmt.Println(output)
+	}
+
+	if unhealthyMember != "" {
+		fmt.Printf("[INFO] %s is unhealthy.\nRun \"osdctl cluster etcd-member-replace %s --node %s\" to replace the member \n", unhealthyMember, clusterId, unhealthyMember)
 	}
 	return nil
 }
@@ -187,25 +171,34 @@ func EtcdPodStatus(kubeCli client.Client) (*corev1.PodList, error) {
 	return pods, nil
 }
 
-func EtcdCrStatus(kubeCli client.Client) error {
+func EtcdCrStatus(kubeCli client.Client) (string, error) {
 
 	etcdCR := &operatorv1.Etcd{}
 	if err := kubeCli.Get(context.TODO(), client.ObjectKey{
 		Name: "cluster",
 	}, etcdCR); err != nil {
-		return err
+		return "", err
 	}
 
 	etcdConditionList := etcdCR.Status.Conditions
+	var message string
 	for _, v := range etcdConditionList {
 		if v.Type == EtcdMemberConditionType {
 			fmt.Println("+---------------------------------------------------------------+")
 			fmt.Println("|               ETCD MEMBER HEALTH STATUS                       |")
 			fmt.Println("+---------------------------------------------------------------+")
 			fmt.Printf("%s\n\n", v.Message)
+			message = v.Message
 		}
 	}
-	return nil
+
+	// Getting the unhealthy member name
+	list := strings.Split(message, ",")
+	if len(list) == 1 {
+		return "", nil
+	}
+	message = strings.Split(strings.TrimSpace(list[1]), " ")[0]
+	return message, nil
 }
 
 func Etcdctlhealth(kconfig *rest.Config, clientset *kubernetes.Clientset, etcdctlCmd string, etcdPodName string) (string, error) {

--- a/cmd/cluster/etcd_replace.go
+++ b/cmd/cluster/etcd_replace.go
@@ -1,0 +1,188 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type flagOptions struct {
+	nodeId string
+}
+
+// Secrets List
+var secrets = []string{
+	"etcd-peer-",
+	"etcd-serving-",
+	"etcd-serving-metrics-",
+}
+
+// Patch Constants
+const (
+	EtcdQuorumTurnOffPatch = `{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}`
+	EtcdQuorumTurnOnPatch  = `{"spec": {"unsupportedConfigOverrides": null}}`
+	EtcdForceRedeployPatch = `{"spec": {"forceRedeploymentReason": "single-master-recovery-%s"}}`
+)
+
+func newCmdEtcdMemberReplacement(kubeCli client.Client, flags *genericclioptions.ConfigFlags) *cobra.Command {
+	opts := &flagOptions{}
+	replaceCmd := &cobra.Command{
+		Use:               "etcd-member-replacement",
+		Short:             "Replaces an unhealthy etcd node",
+		Long:              `Replaces an unhealthy ectd node using the member id provided`,
+		Args:              cobra.ExactArgs(0),
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(EtcdReplaceMember(kubeCli, *opts, flags))
+		},
+	}
+	replaceCmd.Flags().StringVar(&opts.nodeId, "node", "", "Node ID")
+	return replaceCmd
+}
+
+func EtcdReplaceMember(kubeCli client.Client, opts flagOptions, flags *genericclioptions.ConfigFlags) error {
+	kconfig, clientset, err := getKubeConfigAndClientSet()
+	if err != nil {
+		return err
+	}
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: EtcdLabelSelector,
+	}
+
+	if opts.nodeId == "" {
+		return fmt.Errorf("node name cannot be blank. Please provide node using --node flag")
+	}
+
+	fmt.Println("[INFO] This operation will run with the \"backplane-cluster-admin\" role")
+	// Get the etcd pods
+	pods, err := clientset.CoreV1().Pods(EtcdNamespaceName).List(context.TODO(), listOptions)
+	if err != nil {
+		return err
+	}
+	for _, pod := range pods.Items {
+		for _, c := range pod.Status.ContainerStatuses {
+			if c.State.Waiting != nil && (c.State.Waiting.Reason == "CrashLoopBackOff" || c.State.Waiting.Reason == "Error") {
+				podName := "etcd-" + opts.nodeId
+				if podName != pod.ObjectMeta.Name {
+					return fmt.Errorf("the etcd member seems to be healthy. Please run health-check again")
+				}
+				err := ReplaceEtcdMember(kubeCli, kconfig, clientset, flags, opts, pod.ObjectMeta.Name)
+				if err != nil {
+					return err
+				}
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("none of the etcd members seems to be unhealthy. Please verify once again")
+}
+
+func ReplaceEtcdMember(kubeCli client.Client, kconfig *rest.Config, clientset *kubernetes.Clientset, flags *genericclioptions.ConfigFlags, opts flagOptions, pod string) error {
+	// Remove the etcd member
+	fmt.Printf("[INFO] Starting etcd member replacement for pod %s", pod)
+	err := removeEtcdMember(kconfig, clientset, pod, opts)
+	if err != nil {
+		return err
+	}
+
+	// Turn off the quorum guard
+	fmt.Println("[INFO] Turning the quorum guard off")
+	err = patchEtcd(kubeCli, flags, EtcdQuorumTurnOffPatch)
+	if err != nil {
+		fmt.Println("[ERROR] Could not Turn the quorum guard off. Refer error below")
+		return err
+	}
+
+	// Delete the secrets for the unhealthy etcd member
+	fmt.Println("[INFO] Deleting the secrets for the unhealthy etcd member")
+	err = removeEtcdSecrets(clientset, opts)
+	if err != nil {
+		fmt.Println("[ERROR] Could not delete the secrets for the unhealthy etcd member. Refer error below")
+		return err
+	}
+
+	// Force etcd redeployment.
+	fmt.Println("[INFO] Forcing etcd redeployment")
+	timeStamp := time.Now().Format(time.RFC3339Nano)
+	patch := fmt.Sprintf(EtcdForceRedeployPatch, timeStamp)
+	err = patchEtcd(kubeCli, flags, patch)
+	if err != nil {
+		fmt.Println("[ERROR] Could not force etcd redeployment. Refer error below")
+		return err
+	}
+
+	// Turn the quorum guard back
+	fmt.Println("[INFO] Turning the quorum guard back on")
+	err = patchEtcd(kubeCli, flags, EtcdQuorumTurnOnPatch)
+	if err != nil {
+		fmt.Println("[ERROR]  Could not Turn the quorum guard back on. Refer error below")
+		return err
+	}
+
+	fmt.Println("The etcd member has been successfully replaced. Please verify by running health check after few minutes.")
+	return nil
+}
+
+func removeEtcdMember(kconfig *rest.Config, clientset *kubernetes.Clientset, pod string, opts flagOptions) error {
+	fmt.Println()
+	cmd := "etcdctl member list -w table | grep " + opts.nodeId + " | awk '{ print $2 }'"
+	memberId, err := Etcdctlhealth(kconfig, clientset, cmd, pod)
+	if err != nil {
+		return err
+	}
+	memberId = strings.TrimSpace(memberId)
+	fmt.Printf("[INFO] Replacing pod %s having member id %s.\n", pod, memberId)
+
+	prompt := utils.ConfirmPrompt()
+	if !prompt {
+		return fmt.Errorf("operation cancelled by user")
+	}
+
+	remove_cmd := "etcdctl member remove " + memberId
+	output, err := Etcdctlhealth(kconfig, clientset, remove_cmd, pod)
+	if err != nil {
+		fmt.Println("[ERROR] Could not replace pod. Refer error below")
+		return err
+	}
+	fmt.Println(output)
+	return nil
+}
+
+func patchEtcd(kubeCli client.Client, flags *genericclioptions.ConfigFlags, patch string) error {
+	etcdCR := &operatorv1.Etcd{}
+	flags.Impersonate = &BackplaneClusterAdmin
+
+	err := kubeCli.Get(context.TODO(), client.ObjectKey{Name: "cluster"}, etcdCR)
+	if err != nil {
+		return err
+	}
+	err = kubeCli.Patch(context.TODO(), etcdCR, client.RawPatch(types.MergePatchType, []byte(patch)), &client.PatchOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func removeEtcdSecrets(clientset *kubernetes.Clientset, opts flagOptions) error {
+	for _, secret := range secrets {
+		name := secret + opts.nodeId
+		err := clientset.CoreV1().Secrets("openshift-etcd").Delete(context.TODO(), name, metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR aims to add a new command to osdctl i.e `osdctl cluster etcd-member-replacement --node <node-id>`

The command aims to automate the member replacement for etcd in case the state of unhealthy etcd member is `CrashLoopBackOff` or `Error` following the steps mentioned in the [doc](https://docs.openshift.com/container-platform/4.13/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-crashlooping-etcd-member_replacing-unhealthy-etcd-member)

Assuming on of the pods is in `CrashLoopBackOff`
```
 oc -n openshift-etcd get pods -l k8s-app=etcd                                    
NAME                                READY   STATUS             RESTARTS       AGE
etcd-ip-10-0-154-180.ec2.internal   3/4     CrashLoopBackOff   5 (100s ago)   9m10s
etcd-ip-10-0-165-39.ec2.internal    4/4     Running            0              5m35s
etcd-ip-10-0-210-217.ec2.internal   4/4     Running            0              7m27s
```
 On running the command, we get
```
[INFO] This operation will run with the "backplane-cluster-admin" role

[INFO] Replacing pod etcd-ip-10-0-154-180.ec2.internal having member id 363b728d88e78c7a.
Continue? (y/N): y
Member 363b728d88e78c7a removed from cluster 8234ce6cfd037151

[INFO] Turning the quorum guard off
[INFO] Deleting the secrets for the unhealthy etcd member
[INFO] Forcing etcd redeployment
[INFO] Turning the quorum guard back on
The etcd member has been successfully replaced. Please verify by running health check after few minutes.
```