### PR TITLE
Disable interactive version check and print warning to stderr

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -142,17 +142,13 @@ func getSkipVersionCommands() []string {
 func versionCheck() {
 	latestVersion, err := utils.GetLatestVersion()
 	if err != nil {
-		fmt.Println("Warning: Unable to verify that osdctl is running under the latest released version. Error trying to reach GitHub:")
-		fmt.Println(err)
-		fmt.Println("Please be aware that you are possibly running an outdated or unreleased version.")
+		fmt.Fprintln(os.Stderr, "Warning: Unable to verify that osdctl is running under the latest released version. Error trying to reach GitHub:")
+		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, "Please be aware that you are possibly running an outdated or unreleased version.")
 	}
 
 	if utils.Version != strings.TrimPrefix(latestVersion, "v") {
-		fmt.Printf("The current version (%s) is different than the latest released version (%s).", utils.Version, latestVersion)
-		fmt.Println("It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.")
-
-		if !utils.ConfirmPrompt() {
-			os.Exit(0)
-		}
+		fmt.Fprintf(os.Stderr, "The current version (%s) is different than the latest released version (%s).\n", utils.Version, latestVersion)
+		fmt.Fprintln(os.Stderr, "It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.")
 	}
 }


### PR DESCRIPTION
This PR makes sure that the version check error message does not interfere with scripts and pipes anymore. This is achieved by simply removing the interactive prompt and printing the warning messages to stderr instead.

* Before:
```
$ osdctl cluster context $CLUSTER_ID -ojson  | jq '.ClusterName'
parse error: Invalid numeric literal at line 1, column 4
<waiting indefinitely for user input without telling so>
```
* after:
```
$ ./osdctl cluster context 261d49qlcpj1q9pa8it33bsceqgl5euo -ojson | jq '.ClusterName'
The current version () is different than the latest released version (v0.18.0).
It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.
"cluster-name"
$
```
