### PR TITLE
[OSD-18424] Check hibernation in cluster context

### DIFF
--- a/pkg/provider/pagerduty/pagerduty.go
+++ b/pkg/provider/pagerduty/pagerduty.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -83,6 +84,9 @@ func (c *client) buildClient() error {
 
 func (c *client) GetPDServiceIDs() ([]string, error) {
 	// TODO : do we need this to be an exposed function or could we do this when we build the client?
+	if c.pdclient == nil {
+		return nil, errors.New("No PagerDuty client available")
+	}
 	lsResponse, err := c.pdclient.ListServicesWithContext(context.TODO(), pd.ListServiceOptions{Query: c.baseDomain, TeamIDs: c.teamIds})
 	if err != nil {
 		return []string{}, fmt.Errorf("failed to ListServicesWithContext: %w", err)


### PR DESCRIPTION
Print out any hibernations that the cluster has performed.

This can make figuring out strange apiserver errors easier, as prolonged hibernation will force the internal certificates to expire.