### PR TITLE
Get the port from the OCM info.

### DIFF
--- a/cmd/cluster/hypershift_info.go
+++ b/cmd/cluster/hypershift_info.go
@@ -150,7 +150,9 @@ func (i *infoOptions) complete(cmd *cobra.Command) error {
 }
 
 func baseApiUrl(c *v1.Cluster) string {
-	return strings.Replace(strings.Replace(strings.Replace(c.API().URL(), "https://api.", "", 1), c.Name(), "", 1), ":443", "", 1)
+	apiUrlSplit := strings.Split(c.API().URL(), ":")
+	clusterPort := fmt.Sprintf(":%s", apiUrlSplit[len(apiUrlSplit)-1])
+	return strings.Replace(strings.Replace(strings.Replace(c.API().URL(), "https://api.", "", 1), c.Name(), "", 1), clusterPort, "", 1)
 }
 
 func (i *infoOptions) run() error {


### PR DESCRIPTION
Some clusters used 6443 as the api port and not 443, so don't hard code the port.