### PR TITLE
Use JSON as the default output for account cli as current default output is broken

### DIFF
--- a/cmd/account/cli.go
+++ b/cmd/account/cli.go
@@ -152,11 +152,8 @@ func (o *cliOptions) run() error {
 	}
 
 	// Output section
-	if o.output == "" {
-		fmt.Printf("Temporary AWS Credentials:\n%v\n", assumedRoleCreds)
-	}
-
-	if o.output == "json" {
+	// Default to json
+	if o.output == "" || o.output == "json" {
 		fmt.Printf("{\n\"AccessKeyId\": %q, \n\"Expiration\": %q, \n\"SecretAccessKey\": %q, \n\"SessionToken\": %q, \n\"Region\": %q\n}",
 			*assumedRoleCreds.AccessKeyId,
 			*assumedRoleCreds.Expiration,


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OSD-18825

Currently, osdctl account cli gives broken output:
```
$ osdctl account cli -i 335462696174 -p osd-staging-2

Temporary AWS Credentials:
&{0x14000115be0 2023-10-02 21:28:03 +0000 UTC 0x14000115c20 0x14000115c60 {}}
```

This is due to the changes in #411. Since the old output is so similar to JSON, this PR fixes the issue by treating default and JSON as the same. 