### PR TITLE
Improvements to cluster support post command

### DIFF
--- a/cmd/cluster/support/post.go
+++ b/cmd/cluster/support/post.go
@@ -4,28 +4,40 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
+
 	"github.com/openshift-online/ocm-cli/pkg/dump"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	slv1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 	ctlutil "github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 const (
-	LimitedSupportSummaryCluster  = "Cluster is in Limited Support due to unsupported cluster configuration"
-	LimitedSupportSummaryCloud    = "Cluster is in Limited Support due to unsupported cloud provider configuration"
-	MisconfigurationFlag          = "misconfiguration"
-	ProblemFlag                   = "problem"
-	ResolutionFlag                = "resolution"
-	EvidenceFlag                  = "evidence"
-	InternalServiceLogSeverity    = "Warning"
-	InternalServiceLogServiceName = "SREManualAction"
-	InternalServiceLogSummary     = "LimitedSupportEvidence"
+	LimitedSupportSummaryCluster                         = "Cluster is in Limited Support due to unsupported cluster configuration"
+	LimitedSupportSummaryCloud                           = "Cluster is in Limited Support due to unsupported cloud provider configuration"
+	MisconfigurationFlag                                 = "misconfiguration"
+	cloud                         MisconfigurationReason = "cloud"
+	cluster                       MisconfigurationReason = "cluster"
+	ProblemFlag                                          = "problem"
+	ResolutionFlag                                       = "resolution"
+	EvidenceFlag                                         = "evidence"
+	InternalServiceLogSeverity                           = "Warning"
+	InternalServiceLogServiceName                        = "SREManualAction"
+	InternalServiceLogSummary                            = "LimitedSupportEvidence"
 )
 
+type Post struct {
+	Misconfiguration MisconfigurationReason
+	Problem          string
+	Resolution       string
+	Evidence         string
+	cluster          *cmv1.Cluster
+}
+
 func newCmdpost() *cobra.Command {
+	p := &Post{}
 
 	postCmd := &cobra.Command{
 		Use:   "post CLUSTER_ID",
@@ -39,31 +51,7 @@ osdctl cluster support post 1a2B3c4DefghIjkLMNOpQrSTUV5 --misconfiguration clust
 		Args:              cobra.ExactArgs(1),
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			misconfiguration, err := cmd.Flags().GetString(MisconfigurationFlag)
-			if err != nil {
-				return fmt.Errorf("error reading --%v flag", MisconfigurationFlag)
-			}
-			if misconfiguration != "cloud" && misconfiguration != "cluster" {
-				return errors.New("--misconfiguration flag must be either `cloud` or `cluster`")
-			}
-
-			problem, err := cmd.Flags().GetString(ProblemFlag)
-			if err != nil {
-				return fmt.Errorf("error reading --%v flag", ProblemFlag)
-			}
-
-			resolution, err := cmd.Flags().GetString(ResolutionFlag)
-			if err != nil {
-				return fmt.Errorf("error reading --%v flag", ResolutionFlag)
-			}
-
-			evidence, err := cmd.Flags().GetString(EvidenceFlag)
-			if err != nil {
-				return fmt.Errorf("error reading --%v flag", EvidenceFlag)
-			}
-
-			err = PostLimitedSupport(args[0], misconfiguration, problem, resolution, evidence)
-			if err != nil {
+			if err := p.Run(args[0]); err != nil {
 				return fmt.Errorf("error posting limited support reason: %w", err)
 			}
 
@@ -72,23 +60,39 @@ osdctl cluster support post 1a2B3c4DefghIjkLMNOpQrSTUV5 --misconfiguration clust
 	}
 
 	// Define required flags
-	postCmd.Flags().String(MisconfigurationFlag, "", "The type of misconfiguration responsible for the cluster being placed into limited support. Valid values are `cloud` or `cluster`.")
-	postCmd.Flags().String(ProblemFlag, "", "The problem responsible for the cluster being placed into limited support.")
-	postCmd.Flags().String(ResolutionFlag, "", "Steps for the customer to take to resolve the issue and move out of limited support.")
-	postCmd.Flags().String(EvidenceFlag, "", "The reasoning that led to the decision to place the cluster in limited support. Can also be a link to a Jira case. Used for internal service log only.")
+	postCmd.Flags().Var(&p.Misconfiguration, MisconfigurationFlag, "The type of misconfiguration responsible for the cluster being placed into limited support. Valid values are `cloud` or `cluster`.")
+	postCmd.Flags().StringVar(&p.Problem, ProblemFlag, "", "Complete sentence(s) describing the problem responsible for the cluster being placed into limited support. Will form the limited support message with the contents of --resolution appended")
+	postCmd.Flags().StringVar(&p.Resolution, ResolutionFlag, "", "Complete sentence(s) describing the steps for the customer to take to resolve the issue and move out of limited support. Will form the limited support message with the contents of --problem prepended")
+	postCmd.Flags().StringVar(&p.Evidence, EvidenceFlag, "", "(optional) The reasoning that led to the decision to place the cluster in limited support. Can also be a link to a Jira case. Used for internal service log only.")
+
+	postCmd.MarkFlagRequired(MisconfigurationFlag)
+	postCmd.MarkFlagRequired(ProblemFlag)
+	postCmd.MarkFlagRequired(ResolutionFlag)
 
 	return postCmd
 }
 
-func PostLimitedSupport(clusterID string, misconfiguration string, problem string, resolution string, evidence string) error {
-	if misconfiguration != "cloud" && misconfiguration != "cluster" {
-		return errors.New("misconfiguration must be either `cloud` or `cluster`")
+func (p *Post) setup() error {
+	switch p.Problem[len(p.Problem)-1:] {
+	case ".", "?", "!":
+		return errors.New("--problem should not end in punctuation")
+	}
+	switch p.Resolution[len(p.Resolution)-1:] {
+	case ".", "?", "!":
+		return errors.New("--resolution should not end in punctuation")
+	}
+
+	return nil
+}
+
+func (p *Post) Run(clusterID string) error {
+	if err := p.setup(); err != nil {
+		return err
 	}
 
 	// Check that the cluster key (name, identifier or external identifier) given by the user
 	// is reasonably safe so that there is no risk of SQL injection
-	err := ctlutil.IsValidClusterKey(clusterID)
-	if err != nil {
+	if err := ctlutil.IsValidClusterKey(clusterID); err != nil {
 		return err
 	}
 
@@ -103,7 +107,12 @@ func PostLimitedSupport(clusterID string, misconfiguration string, problem strin
 		}
 	}()
 
-	limitedSupport, err := buildLimitedSupport(misconfiguration, problem, resolution)
+	p.cluster, err = ctlutil.GetCluster(connection, clusterID)
+	if err != nil {
+		return fmt.Errorf("can't retrieve cluster: %w", err)
+	}
+
+	limitedSupport, err := p.buildLimitedSupport()
 	if err != nil {
 		return err
 	}
@@ -117,48 +126,45 @@ func PostLimitedSupport(clusterID string, misconfiguration string, problem strin
 		return nil
 	}
 
-	cluster, err := ctlutil.GetCluster(connection, clusterID)
-	if err != nil {
-		return fmt.Errorf("can't retrieve cluster: %w", err)
-	}
-
-	postLimitedSupportResponse, err := sendLimitedSupportPostRequest(connection, cluster.ID(), limitedSupport)
+	postLimitedSupportResponse, err := sendLimitedSupportPostRequest(connection, p.cluster.ID(), limitedSupport)
 	if err != nil {
 		return fmt.Errorf("failed to post limited support reason: %w", err)
 	}
-
 	fmt.Printf("Successfully added new limited support reason with ID %v\n", postLimitedSupportResponse.Body().ID())
 
-	var subscriptionId string
-	if subscription, ok := cluster.GetSubscription(); ok {
-		subscriptionId = subscription.ID()
-	}
-	log, err := buildInternalServiceLog(cluster.ExternalID(), cluster.ID(), postLimitedSupportResponse.Body().ID(), evidence, subscriptionId)
-	if err != nil {
-		return err
-	}
+	if p.Evidence != "" {
+		var subscriptionId string
+		if subscription, ok := p.cluster.GetSubscription(); ok {
+			subscriptionId = subscription.ID()
+		}
+		log, err := p.buildInternalServiceLog(postLimitedSupportResponse.Body().ID(), subscriptionId)
+		if err != nil {
+			return err
+		}
 
-	fmt.Printf("Sending the following internal service log to %s:\n", clusterID)
-	if err = printInternalServiceLog(log); err != nil {
-		return fmt.Errorf("failed to print internal service log template: %w", err)
-	}
+		fmt.Printf("Sending the following internal service log to %s:\n", clusterID)
+		if err = printInternalServiceLog(log); err != nil {
+			return fmt.Errorf("failed to print internal service log template: %w", err)
+		}
 
-	postServiceLogResponse, err := sendInternalServiceLogPostRequest(connection, log)
-	if err != nil {
-		return fmt.Errorf("failed to post internal service log: %w", err)
+		postServiceLogResponse, err := sendInternalServiceLogPostRequest(connection, log)
+		if err != nil {
+			return fmt.Errorf("failed to post internal service log: %w", err)
+		}
+		fmt.Printf("Successfully sent internal service log with ID %v\n", postServiceLogResponse.Body().ID())
 	}
-	fmt.Printf("Successfully sent internal service log with ID %v\n", postServiceLogResponse.Body().ID())
 
 	return nil
 }
 
-func buildLimitedSupport(misconfiguration string, problem string, resolution string) (*cmv1.LimitedSupportReason, error) {
+func (p *Post) buildLimitedSupport() (*cmv1.LimitedSupportReason, error) {
 	limitedSupportBuilder := cmv1.NewLimitedSupportReason().
-		Details(fmt.Sprintf("%v. %v", problem, resolution)).
+		Details(fmt.Sprintf("%v. %v", p.Problem, p.Resolution)).
 		DetectionType(cmv1.DetectionTypeManual)
-	if misconfiguration == "cloud" {
+	switch p.Misconfiguration {
+	case cloud:
 		limitedSupportBuilder.Summary(LimitedSupportSummaryCloud)
-	} else if misconfiguration == "cluster" {
+	case cluster:
 		limitedSupportBuilder.Summary(LimitedSupportSummaryCluster)
 	}
 
@@ -187,15 +193,15 @@ func sendLimitedSupportPostRequest(ocmClient *sdk.Connection, clusterID string, 
 	return response, nil
 }
 
-func buildInternalServiceLog(externalId string, internalId string, limitedSupportId string, evidence string, subscriptionId string) (*slv1.LogEntry, error) {
+func (p *Post) buildInternalServiceLog(limitedSupportId string, subscriptionId string) (*slv1.LogEntry, error) {
 	logEntryBuilder := slv1.NewLogEntry().
-		ClusterUUID(externalId).
-		ClusterID(internalId).
+		ClusterUUID(p.cluster.ExternalID()).
+		ClusterID(p.cluster.ID()).
 		InternalOnly(true).
 		Severity(InternalServiceLogSeverity).
 		ServiceName(InternalServiceLogServiceName).
 		Summary(InternalServiceLogSummary).
-		Description(fmt.Sprintf("%v - %v", limitedSupportId, evidence))
+		Description(fmt.Sprintf("%v - %v", limitedSupportId, p.Evidence))
 	if subscriptionId != "" {
 		logEntryBuilder.SubscriptionID(subscriptionId)
 	}
@@ -221,4 +227,24 @@ func sendInternalServiceLogPostRequest(ocmClient *sdk.Connection, logEntry *slv1
 		return nil, fmt.Errorf("failed to post new internal service log: %w", err)
 	}
 	return response, nil
+}
+
+type MisconfigurationReason string
+
+func (m *MisconfigurationReason) String() string {
+	return string(*m)
+}
+
+func (m *MisconfigurationReason) Set(v string) error {
+	switch v {
+	case "cloud", "cluster":
+		*m = MisconfigurationReason(v)
+		return nil
+	default:
+		return errors.New(`must be one of "cloud" or "cluster"`)
+	}
+}
+
+func (m *MisconfigurationReason) Type() string {
+	return "MisconfigurationReason"
 }


### PR DESCRIPTION
This commit makes the following improvements to the cluster support post command:

* A MisconfigurationReason type to centralize validation
* A Post struct to centralize variables that are needed throughout the process
* --misconfiguration, --problem, and --resolution are now required flags as intended
* --problem and --resolution fail client-side validation if they end in punctuation before getting sent to OCM

[OSD-18820](https://issues.redhat.com//browse/OSD-18820)