### PR TITLE
Manage .ci-operator.yaml build image from osdctl

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: golang-1.20


### PR DESCRIPTION
Updating Go versions is a little annoying with this repo because the CI base image is managed by Prow https://github.com/openshift/release/blob/b7b083dee9df82315b73b0f42f24b405747ad9bd/ci-operator/config/openshift/osdctl/openshift-osdctl-master.yaml

This PR will let us manage the base image from osdctl, which is simpler as contributors don't have to hop over to openshift/release

[OSD-19069](https://issues.redhat.com//browse/OSD-19069)