### PR TITLE
Remove unused kube client and flags from sts/promote commands

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -93,7 +93,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	rootCmd.AddCommand(servicelog.NewCmdServiceLog())
 	rootCmd.AddCommand(org.NewCmdOrg())
 	rootCmd.AddCommand(sts.NewCmdSts())
-	rootCmd.AddCommand(promote.NewCmdPromote(kubeFlags, globalOpts))
+	rootCmd.AddCommand(promote.NewCmdPromote())
 	rootCmd.AddCommand(jira.Cmd)
 
 	// add completion command

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -92,7 +92,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	rootCmd.AddCommand(network.NewCmdNetwork(streams, kubeFlags, kubeClient))
 	rootCmd.AddCommand(servicelog.NewCmdServiceLog())
 	rootCmd.AddCommand(org.NewCmdOrg())
-	rootCmd.AddCommand(sts.NewCmdSts(streams, kubeFlags, kubeClient))
+	rootCmd.AddCommand(sts.NewCmdSts())
 	rootCmd.AddCommand(promote.NewCmdPromote(kubeFlags, globalOpts))
 	rootCmd.AddCommand(jira.Cmd)
 

--- a/cmd/promote/cmd.go
+++ b/cmd/promote/cmd.go
@@ -3,16 +3,13 @@ package promote
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-
 	"github.com/openshift/osdctl/cmd/promote/pko"
 	"github.com/openshift/osdctl/cmd/promote/saas"
-	"github.com/openshift/osdctl/internal/utils/globalflags"
+	"github.com/spf13/cobra"
 )
 
 // NewCmdPromote implements the promote command to promote services/operators
-func NewCmdPromote(flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+func NewCmdPromote() *cobra.Command {
 	promoteCmd := &cobra.Command{
 		Use:               "promote",
 		Short:             "Utilities to promote services/operators",
@@ -20,8 +17,8 @@ func NewCmdPromote(flags *genericclioptions.ConfigFlags, globalOpts *globalflags
 		DisableAutoGenTag: true,
 	}
 
-	promoteCmd.AddCommand(saas.NewCmdSaas(flags, globalOpts))
-	promoteCmd.AddCommand(pko.NewCmdPKO(flags, globalOpts))
+	promoteCmd.AddCommand(saas.NewCmdSaas())
+	promoteCmd.AddCommand(pko.NewCmdPKO())
 
 	return promoteCmd
 }

--- a/cmd/promote/pko/pko.go
+++ b/cmd/promote/pko/pko.go
@@ -5,14 +5,12 @@ import (
 
 	"github.com/openshift/osdctl/cmd/promote/git"
 	"github.com/openshift/osdctl/cmd/promote/saas"
-	"github.com/openshift/osdctl/internal/utils/globalflags"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
-func NewCmdPKO(flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
-	ops := newPKOOptions(flags, globalOpts)
+func NewCmdPKO() *cobra.Command {
+	ops := &pkoOptions{}
 	pkoCmd := &cobra.Command{
 		Use:               "package",
 		Short:             "Utilities to promote package-operator services",
@@ -39,17 +37,6 @@ type pkoOptions struct {
 	serviceName string
 	packageTag  string
 	hcp         bool
-
-	*genericclioptions.ConfigFlags
-	*globalflags.GlobalOptions
-}
-
-func newPKOOptions(flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *pkoOptions {
-	opts := &pkoOptions{
-		ConfigFlags:   flags,
-		GlobalOptions: globalOpts,
-	}
-	return opts
 }
 
 func (p pkoOptions) ValidatePKOOptions() error {

--- a/cmd/promote/saas/saas.go
+++ b/cmd/promote/saas/saas.go
@@ -5,9 +5,7 @@ import (
 	"os"
 
 	"github.com/openshift/osdctl/cmd/promote/git"
-	"github.com/openshift/osdctl/internal/utils/globalflags"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 type saasOptions struct {
@@ -20,8 +18,8 @@ type saasOptions struct {
 }
 
 // newCmdSaas implementes the saas command to interact with promoting SaaS services/operators
-func NewCmdSaas(flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
-	ops := newSaasOptions(flags, globalOpts)
+func NewCmdSaas() *cobra.Command {
+	ops := &saasOptions{}
 	saasCmd := &cobra.Command{
 		Use:               "saas",
 		Short:             "Utilities to promote SaaS services/operators",
@@ -73,10 +71,6 @@ func NewCmdSaas(flags *genericclioptions.ConfigFlags, globalOpts *globalflags.Gl
 	saasCmd.Flags().BoolVarP(&ops.hcp, "hcp", "", false, "Git hash of the SaaS service/operator commit getting promoted")
 
 	return saasCmd
-}
-
-func newSaasOptions(flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *saasOptions {
-	return &saasOptions{}
 }
 
 func (o *saasOptions) validateSaasFlow() {

--- a/cmd/sts/cmd.go
+++ b/cmd/sts/cmd.go
@@ -3,12 +3,10 @@ package sts
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewCmdSts implements the STS utilities
-func NewCmdSts(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
+func NewCmdSts() *cobra.Command {
 	clusterCmd := &cobra.Command{
 		Use:               "sts",
 		Short:             "STS related utilities",
@@ -16,8 +14,8 @@ func NewCmdSts(streams genericclioptions.IOStreams, flags *genericclioptions.Con
 		DisableAutoGenTag: true,
 	}
 
-	clusterCmd.AddCommand(newCmdPolicyDiff(streams, flags, client))
-	clusterCmd.AddCommand(newCmdPolicy(streams, flags, client))
+	clusterCmd.AddCommand(newCmdPolicyDiff())
+	clusterCmd.AddCommand(newCmdPolicy())
 	return clusterCmd
 }
 

--- a/cmd/sts/policy.go
+++ b/cmd/sts/policy.go
@@ -4,32 +4,17 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/spf13/cobra"
-
 	"github.com/coreos/go-semver/semver"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"github.com/spf13/cobra"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type policyOptions struct {
 	ReleaseVersion string
-
-	flags *genericclioptions.ConfigFlags
-	genericclioptions.IOStreams
-	kubeCli client.Client
 }
 
-func newPolicyOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *policyOptions {
-	return &policyOptions{
-		flags:     flags,
-		IOStreams: streams,
-		kubeCli:   client,
-	}
-}
-
-func newCmdPolicy(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
-	ops := newPolicyOptions(streams, flags, client)
+func newCmdPolicy() *cobra.Command {
+	ops := &policyOptions{}
 	policyCmd := &cobra.Command{
 		Use:               "policy",
 		Short:             "Get OCP STS policy",

--- a/cmd/sts/policydiff.go
+++ b/cmd/sts/policydiff.go
@@ -4,33 +4,18 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/spf13/cobra"
-
 	"github.com/coreos/go-semver/semver"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"github.com/spf13/cobra"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type policyDiffOptions struct {
 	oldReleaseVersion string
 	newReleaseVersion string
-
-	flags *genericclioptions.ConfigFlags
-	genericclioptions.IOStreams
-	kubeCli client.Client
 }
 
-func newPolicyDiffOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *policyDiffOptions {
-	return &policyDiffOptions{
-		flags:     flags,
-		IOStreams: streams,
-		kubeCli:   client,
-	}
-}
-
-func newCmdPolicyDiff(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
-	ops := newPolicyDiffOptions(streams, flags, client)
+func newCmdPolicyDiff() *cobra.Command {
+	ops := &policyDiffOptions{}
 	policyDiffCmd := &cobra.Command{
 		Use:               "policy-diff",
 		Short:             "Get diff between two versions of OCP STS policy",


### PR DESCRIPTION
On a quest to remove the global kube flags, working one subcommand at a time. The `sts` subcommand never actually used any of the kubeClient/kubeFlags that was given, so it's a relatively straightforward removal. The commands that acutally need a kube client/kube flags can define them on their own so that we don't pollute the whole osdctl with kube flags.

P.S. This command actually has other issues, like it has flags `osdctl sts --release-version` and the values are never used, however I'm not trying to fix the commands with this PR.

Added a second commit to do more of the same with the `promote` subcommand

[OSD-19092](https://issues.redhat.com//browse/OSD-19092)