### PR TITLE
Removing kubeflags from `aao` and `env` commands

### DIFF
--- a/cmd/aao/cmd.go
+++ b/cmd/aao/cmd.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewCmdAao implements the base aao command
-func NewCmdAao(streams genericclioptions.IOStreams, client client.Client) *cobra.Command {
+func NewCmdAao(client client.Client) *cobra.Command {
 	aaoCmd := &cobra.Command{
 		Use:               "aao",
 		Short:             "AWS Account Operator Debugging Utilities",
@@ -17,7 +16,7 @@ func NewCmdAao(streams genericclioptions.IOStreams, client client.Client) *cobra
 		DisableAutoGenTag: true,
 	}
 
-	aaoCmd.AddCommand(newCmdPool(streams, client))
+	aaoCmd.AddCommand(newCmdPool(client))
 
 	return aaoCmd
 }

--- a/cmd/aao/cmd.go
+++ b/cmd/aao/cmd.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewCmdAao implements the base aao command
-func NewCmdAao(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
+func NewCmdAao(streams genericclioptions.IOStreams, client client.Client) *cobra.Command {
 	aaoCmd := &cobra.Command{
 		Use:               "aao",
 		Short:             "AWS Account Operator Debugging Utilities",
@@ -17,7 +17,7 @@ func NewCmdAao(streams genericclioptions.IOStreams, flags *genericclioptions.Con
 		DisableAutoGenTag: true,
 	}
 
-	aaoCmd.AddCommand(newCmdPool(streams, flags, client))
+	aaoCmd.AddCommand(newCmdPool(streams, client))
 
 	return aaoCmd
 }

--- a/cmd/aao/pool.go
+++ b/cmd/aao/pool.go
@@ -16,8 +16,8 @@ import (
 )
 
 // newCmdPool gets the current status of the AWS Account Operator AccountPool
-func newCmdPool(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
-	ops := newPoolOptions(streams, flags, client)
+func newCmdPool(streams genericclioptions.IOStreams, client client.Client) *cobra.Command {
+	ops := newPoolOptions(streams, client)
 	poolCmd := &cobra.Command{
 		Use:               "pool",
 		Short:             "Get the status of the AWS Account Operator AccountPool",
@@ -38,7 +38,7 @@ type poolOptions struct {
 	kubeCli client.Client
 }
 
-func newPoolOptions(streams genericclioptions.IOStreams, _ *genericclioptions.ConfigFlags, client client.Client) *poolOptions {
+func newPoolOptions(streams genericclioptions.IOStreams, client client.Client) *poolOptions {
 	return &poolOptions{
 		IOStreams: streams,
 		kubeCli:   client,

--- a/cmd/aao/pool.go
+++ b/cmd/aao/pool.go
@@ -10,14 +10,13 @@ import (
 	awsv1alpha1 "github.com/openshift/aws-account-operator/api/v1alpha1"
 	"github.com/openshift/osdctl/pkg/printer"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // newCmdPool gets the current status of the AWS Account Operator AccountPool
-func newCmdPool(streams genericclioptions.IOStreams, client client.Client) *cobra.Command {
-	ops := newPoolOptions(streams, client)
+func newCmdPool(client client.Client) *cobra.Command {
+	ops := newPoolOptions(client)
 	poolCmd := &cobra.Command{
 		Use:               "pool",
 		Short:             "Get the status of the AWS Account Operator AccountPool",
@@ -34,14 +33,12 @@ func newCmdPool(streams genericclioptions.IOStreams, client client.Client) *cobr
 
 // poolOptions defines the struct for running the pool command
 type poolOptions struct {
-	genericclioptions.IOStreams
 	kubeCli client.Client
 }
 
-func newPoolOptions(streams genericclioptions.IOStreams, client client.Client) *poolOptions {
+func newPoolOptions(client client.Client) *poolOptions {
 	return &poolOptions{
-		IOStreams: streams,
-		kubeCli:   client,
+		kubeCli: client,
 	}
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -81,12 +81,12 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	kubeClient := k8s.NewClient(kubeFlags)
 
 	// add sub commands
-	rootCmd.AddCommand(aao.NewCmdAao(streams, kubeClient))
+	rootCmd.AddCommand(aao.NewCmdAao(kubeClient))
 	rootCmd.AddCommand(account.NewCmdAccount(streams, kubeFlags, kubeClient, globalOpts))
 	rootCmd.AddCommand(cluster.NewCmdCluster(streams, kubeFlags, kubeClient, globalOpts))
 	rootCmd.AddCommand(clusterdeployment.NewCmdClusterDeployment(streams, kubeFlags, kubeClient))
 	rootCmd.AddCommand(newCmdCompletion())
-	rootCmd.AddCommand(env.NewCmdEnv(streams, kubeFlags))
+	rootCmd.AddCommand(env.NewCmdEnv())
 	rootCmd.AddCommand(federatedrole.NewCmdFederatedRole(streams, kubeFlags, kubeClient))
 	rootCmd.AddCommand(jumphost.NewCmdJumphost())
 	rootCmd.AddCommand(network.NewCmdNetwork(streams, kubeFlags, kubeClient))

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -81,7 +81,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	kubeClient := k8s.NewClient(kubeFlags)
 
 	// add sub commands
-	rootCmd.AddCommand(aao.NewCmdAao(streams, kubeFlags, kubeClient))
+	rootCmd.AddCommand(aao.NewCmdAao(streams, kubeClient))
 	rootCmd.AddCommand(account.NewCmdAccount(streams, kubeFlags, kubeClient, globalOpts))
 	rootCmd.AddCommand(cluster.NewCmdCluster(streams, kubeFlags, kubeClient, globalOpts))
 	rootCmd.AddCommand(clusterdeployment.NewCmdClusterDeployment(streams, kubeFlags, kubeClient))

--- a/cmd/env/env.go
+++ b/cmd/env/env.go
@@ -16,7 +16,6 @@ import (
 	ocmconfig "github.com/openshift-online/ocm-cli/pkg/config"
 	config "github.com/openshift/osdctl/pkg/envConfig"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 type Options struct {
@@ -71,7 +70,7 @@ To log in to a cluster within the environment using backplane, osdctl creates th
 The ocb command is created in the bin directory in the environment folder and added to the PATH when inside the environment.
 `
 
-func NewCmdEnv(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+func NewCmdEnv() *cobra.Command {
 	options := Options{}
 	config := config.LoadYaml(Config_Filepath)
 


### PR DESCRIPTION
Neither of these commands use kubeflags either

OSD-19092