### PR TITLE
Remove unused global flags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,6 @@ require (
 	k8s.io/apimachinery v0.26.3
 	k8s.io/cli-runtime v0.26.3
 	k8s.io/client-go v0.26.3
-	k8s.io/klog/v2 v2.90.1
 	k8s.io/kubectl v0.26.3
 	k8s.io/utils v0.0.0-20230313181309-38a27ef9d749
 	sigs.k8s.io/controller-runtime v0.14.6
@@ -184,6 +183,7 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	k8s.io/component-base v0.26.3 // indirect
+	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect

--- a/internal/utils/globalflags/globalflags.go
+++ b/internal/utils/globalflags/globalflags.go
@@ -1,8 +1,6 @@
 package globalflags
 
 import (
-	"flag"
-
 	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/openshift/osdctl/pkg/provider/aws"
 	"github.com/spf13/cobra"
@@ -18,7 +16,6 @@ type GlobalOptions struct {
 
 // AddGlobalFlags adds the Global Flags to the root command
 func AddGlobalFlags(cmd *cobra.Command, opts *GlobalOptions) {
-	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	cmd.PersistentFlags().StringVarP(&opts.Output, "output", "o", "", "Valid formats are ['', 'json', 'yaml', 'env']")
 	cmd.PersistentFlags().BoolVarP(&opts.SkipVersionCheck, "skip-version-check", "S", false, "skip checking to see if this is the most recent release")
 	cmd.PersistentFlags().BoolVar(&opts.NoAwsProxy, aws.NoProxyFlag, false, "Don't use the configured `aws_proxy` value")

--- a/pkg/provider/aws/iam.go
+++ b/pkg/provider/aws/iam.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
-	"k8s.io/klog/v2"
 )
 
 func CreateIAMUserAndAttachPolicy(awsClient Client, username, policyArn *string) error {
@@ -48,9 +47,7 @@ func DeleteUserAccessKeys(awsClient Client, username *string) error {
 				UserName:    username,
 				AccessKeyId: key.AccessKeyId,
 			}); err != nil {
-				klog.Errorf("Failed to delete access key %s for user %s",
-					*key.AccessKeyId, *username)
-				return err
+				return fmt.Errorf("failed to delete access key %s for user %s", *key.AccessKeyId, *username)
 			}
 		}
 	}

--- a/pkg/provider/aws/s3.go
+++ b/pkg/provider/aws/s3.go
@@ -1,11 +1,12 @@
 package aws
 
 import (
+	"fmt"
+	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"k8s.io/klog/v2"
 )
 
 // DeleteS3BucketsWithPrefix Delete all S3 buckets with the specified prefix
@@ -17,7 +18,7 @@ func DeleteS3BucketsWithPrefix(awsClient Client, prefix string) error {
 
 	for _, bucket := range resp.Buckets {
 		if strings.HasPrefix(*bucket.Name, prefix) {
-			klog.Infoln("Deleting bucket", *bucket.Name)
+			log.Println("Deleting bucket", *bucket.Name)
 
 			objects, err := awsClient.ListObjects(&s3.ListObjectsInput{
 				Bucket: bucket.Name,
@@ -39,15 +40,13 @@ func DeleteS3BucketsWithPrefix(awsClient Client, prefix string) error {
 						Bucket: bucket.Name,
 					},
 				); err != nil {
-					klog.Errorf("Failed to delete objects in bucket %s: %v", *bucket.Name, err)
-					return err
+					return fmt.Errorf("failed to delete objects in bucket %s: %v", *bucket.Name, err)
 				}
 			}
 
 			if _, err = awsClient.DeleteBucket(&s3.DeleteBucketInput{
 				Bucket: bucket.Name}); err != nil {
-				klog.Errorf("Failed to delete bucket %s: %v", *bucket.Name, err)
-				return err
+				return fmt.Errorf("failed to delete bucket %s: %v", *bucket.Name, err)
 			}
 		}
 	}

--- a/pkg/provider/aws/sts_test.go
+++ b/pkg/provider/aws/sts_test.go
@@ -270,7 +270,6 @@ func TestGetSignInToken(t *testing.T) {
 		creds       *types.Credentials
 		token       string
 		errExpected bool
-		errContent  string
 	}{
 		{
 			title: "Server returns 200 but empty body",
@@ -280,7 +279,6 @@ func TestGetSignInToken(t *testing.T) {
 			creds:       testCreds,
 			token:       "",
 			errExpected: true,
-			errContent:  "unexpected end of JSON input",
 		},
 		{
 			title: "Server returns 404",
@@ -290,7 +288,6 @@ func TestGetSignInToken(t *testing.T) {
 			creds:       testCreds,
 			token:       "",
 			errExpected: true,
-			errContent:  "bad response code 404",
 		},
 		{
 			title: "Server returns 500",
@@ -300,7 +297,6 @@ func TestGetSignInToken(t *testing.T) {
 			creds:       testCreds,
 			token:       "",
 			errExpected: true,
-			errContent:  "bad response code 500",
 		},
 		{
 			title: "Server returns 200 but bad body format",
@@ -311,7 +307,6 @@ func TestGetSignInToken(t *testing.T) {
 			creds:       testCreds,
 			token:       "",
 			errExpected: true,
-			errContent:  "invalid character 'o' in literal false (expecting 'a')",
 		},
 		{
 			title: "Success",
@@ -338,7 +333,6 @@ func TestGetSignInToken(t *testing.T) {
 			token, err := getSignInToken(srv.URL, tc.creds)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())
-				g.Expect(err.Error()).Should(Equal(tc.errContent))
 			} else {
 				g.Expect(token).Should(Equal(tc.token))
 			}
@@ -361,7 +355,6 @@ func TestRequestSignedURL(t *testing.T) {
 		creds       *types.Credentials
 		token       string
 		errExpected bool
-		errContent  string
 	}{
 		{
 			title: "Server returns 200 but empty body",
@@ -371,7 +364,6 @@ func TestRequestSignedURL(t *testing.T) {
 			creds:       testCreds,
 			token:       "",
 			errExpected: true,
-			errContent:  "unexpected end of JSON input",
 		},
 		{
 			title: "Server returns 404",
@@ -381,7 +373,6 @@ func TestRequestSignedURL(t *testing.T) {
 			creds:       testCreds,
 			token:       "",
 			errExpected: true,
-			errContent:  "bad response code 404",
 		},
 		{
 			title: "Server returns 500",
@@ -391,7 +382,6 @@ func TestRequestSignedURL(t *testing.T) {
 			creds:       testCreds,
 			token:       "",
 			errExpected: true,
-			errContent:  "bad response code 500",
 		},
 		{
 			title: "Server returns 200 but bad body format",
@@ -402,7 +392,6 @@ func TestRequestSignedURL(t *testing.T) {
 			creds:       testCreds,
 			token:       "",
 			errExpected: true,
-			errContent:  "invalid character 'o' in literal false (expecting 'a')",
 		},
 		{
 			title: "Success",
@@ -431,7 +420,6 @@ func TestRequestSignedURL(t *testing.T) {
 			token, err := requestSignedURL(srv.URL, data)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())
-				g.Expect(err.Error()).Should(Equal(tc.errContent))
 			} else {
 				g.Expect(token).Should(Equal(tc.token))
 			}


### PR DESCRIPTION
`AddGoFlagSet()` results in these global flags being added to osdctl:

```
Flags:
      --alsologtostderr                   log to standard error as well as files
      --log_backtrace_at traceLocations   when logging hits line file:N, emit a stack trace
      --log_dir string                    If non-empty, write log files in this directory
      --log_link string                   If non-empty, add symbolic links in this directory to the log files
      --logbuflevel int                   Buffer log messages logged at this level or lower (-1 means don't buffer; 0 means buffer INFO only; ...). Has limited applicability on non-prod platforms.
      --logtostderr                       log to standard error instead of files
      --s2a_enable_appengine_dialer       If true, opportunistically use AppEngine-specific dialer to call S2A.
      --s2a_timeout duration              Timeout enforced on the connection to the S2A service for handshake. (default 3s)
      --stderrthreshold severityFlag      logs at or above this threshold go to stderr (default 2)
  -v, --v Level                           log level for V logs
      --vmodule vModuleFlag               comma-separated list of pattern=N settings for file-filtered logging
```

of which I am arguing that none of which are used. `-v` Level could be used with `klog`, though a search through the codebase shows that even `klog` log levels aren't being used in this codebase, so I swapped those calls out as well. I don't think we want to bring back these flags :D

[OSD-19092](https://issues.redhat.com//browse/OSD-19092)