### PR TITLE
OSD-18260: Force-drain and terminate infra nodes after appropriate timeout for infra resize command

### DIFF
--- a/cmd/cluster/resize/infra_node_test.go
+++ b/cmd/cluster/resize/infra_node_test.go
@@ -104,3 +104,28 @@ func TestResize_embiggenMachinePool(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertProviderIDtoInstanceID(t *testing.T) {
+	tests := []struct {
+		providerID string
+		expected   string
+	}{
+		{
+			providerID: "aws:///us-east-1a/i-0a1b2c3d4e5f6g7h8",
+			expected:   "i-0a1b2c3d4e5f6g7h8",
+		},
+		{
+			providerID: "gce://some-string/europe-west4-a/my-cluster-name-n65hp-infra-a-4fbrd",
+			expected:   "my-cluster-name-n65hp-infra-a-4fbrd",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.providerID, func(t *testing.T) {
+			actual := convertProviderIDtoInstanceID(test.providerID)
+			if test.expected != actual {
+				t.Errorf("expected: %s, got %s", test.expected, actual)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.37.0
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.14.15
 	github.com/aws/aws-sdk-go-v2/service/sts v1.19.0
+	github.com/aws/smithy-go v1.14.0
 	github.com/brianvoe/gofakeit/v6 v6.23.2
 	github.com/coreos/go-semver v0.3.0
 	github.com/deckarep/golang-set v1.7.1
@@ -78,7 +79,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.14.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.12.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.10 // indirect
-	github.com/aws/smithy-go v1.14.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect


### PR DESCRIPTION
[OSD-18260](https://issues.redhat.com//browse/OSD-18260) - Force drain infra nodes; terminate after a timeout during infra resize
    
This will kick off a drain of infrastructure nodes ahead of machine pool deletion, and will terminate the nodes in AWS after a timeout has been reached.

Force-termination does not work for GCP currently because we do not have a programmatic generator of backplane credentials for the GCP Project console, but a placeholder exists for the future.
    
REF: https://issues.redhat.com/browse/OSD-18260
    
Signed-off-by: Chris Collins <collins.christopher@gmail.com>