### PR TITLE
Add cluster orgId command

### DIFF
--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -38,6 +38,7 @@ func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions
 	clusterCmd.AddCommand(newCmdEtcdMemberReplacement())
 	clusterCmd.AddCommand(newCmdFromInfraId(globalOpts))
 	clusterCmd.AddCommand(NewCmdHypershiftInfo(streams))
+	clusterCmd.AddCommand(newCmdOrgId())
 	return clusterCmd
 }
 

--- a/cmd/cluster/org_id.go
+++ b/cmd/cluster/org_id.go
@@ -1,0 +1,59 @@
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+	ctlutil "github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type OrgId struct {
+}
+
+type OrgIdOutput struct {
+	ExternalId string `json:"external_id"`
+	InternalId string `json:"internal_id"`
+}
+
+func newCmdOrgId() *cobra.Command {
+	o := &OrgId{}
+
+	orgIdCmd := &cobra.Command{
+		Use:   "orgId CLUSTER_ID",
+		Short: "Get the OCM org ID for a given cluster",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Run(args[0]); err != nil {
+				return fmt.Errorf("error fetching OCM org ID for cluster %v", args[0])
+			}
+			return nil
+		},
+	}
+	return orgIdCmd
+}
+
+func (o *OrgId) Run(clusterID string) error {
+	if err := ctlutil.IsValidClusterKey(clusterID); err != nil {
+		return err
+	}
+
+	connection, err := ctlutil.CreateConnection()
+	if err != nil {
+		return err
+	}
+	defer connection.Close()
+
+	org, err := ctlutil.GetOrganization(connection, clusterID)
+	if err != nil {
+		return err
+	}
+
+	output, _ := json.MarshalIndent(OrgIdOutput{
+		ExternalId: org.ExternalID(),
+		InternalId: org.ID(),
+	}, "", "  ")
+
+	fmt.Println(string(output))
+
+	return nil
+}

--- a/cmd/jira/quick-task.go
+++ b/cmd/jira/quick-task.go
@@ -27,10 +27,10 @@ var quickTaskCmd = &cobra.Command{
 The ticket will be assigned to the caller and added to their team's current sprint as an OSD Task.
 A link to the created ticket will be printed to the console.`,
 	Example: `#Create a new Jira issue
-osdctl jira create "Update command to take new flag"
+osdctl jira quick-task "Update command to take new flag"
 
 #Create a new Jira issue and add to the caller's current sprint
-osdctl jira create "Update command to take new flag" --add-to-sprint
+osdctl jira quick-task "Update command to take new flag" --add-to-sprint
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -188,6 +188,19 @@ func GetSubscription(connection *sdk.Connection, key string) (subscription *amv1
 	return
 }
 
+// GetOrganization returns an *amv1.Organization given an OCM cluster name, external id, or internal id as key
+func GetOrganization(connection *sdk.Connection, key string) (*amv1.Organization, error) {
+	subscription, err := GetSubscription(connection, key)
+	if err != nil {
+		return nil, err
+	}
+	orgResponse, err := connection.AccountsMgmt().V1().Organizations().Organization(subscription.OrganizationID()).Get().Send()
+	if err != nil {
+		return nil, err
+	}
+	return orgResponse.Body(), nil
+}
+
 // GetAccount Function allows to get a single account with any identifier (username, ID)
 func GetAccount(connection *sdk.Connection, key string) (account *amv1.Account, err error) {
 	// Prepare the resources that we will be using:


### PR DESCRIPTION
With the new isolated backplane flow, it can be helpful to know the external org ID of a cluster in the event of backplane failures. This command makes that easy.

Resolves [OSD-19611](https://issues.redhat.com//browse/OSD-19611)

Example run:
```
$ ./osdctl -S cluster orgId 16708aq3bjcegto32sduqkinc3cd392j
{
  "external_id": "1234567",
  "internal_id": "1GZa79autPFQcwk3tN64c55KORz"
}
```