### PR TITLE
Deprecate etcd-health-check and ask to use managed-script instead

### DIFF
--- a/cmd/cluster/etcd_health.go
+++ b/cmd/cluster/etcd_health.go
@@ -80,6 +80,7 @@ func newCmdEtcdHealthCheck() *cobra.Command {
 		Long:              `Checks etcd component health status for member replacement`,
 		Args:              cobra.ExactArgs(1),
 		DisableAutoGenTag: true,
+		Deprecated:        "please use the managed-script SREP/etcd-complete-health-check to avoid backplane elevation",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(EtcdHealthCheck(args[0]))
 		},


### PR DESCRIPTION
The command `osdctl cluster etcd-health-check` will elevate to `backplane-cluster-admin` and exec into the etcd pod locally. 

As we have a managed-script to perform health-check https://github.com/openshift/managed-scripts/tree/89151d6963debd872e797d8b765f7b2bc7c878f8/scripts/SREP/etcd-complete-health-check , we might redirect users to use the managed-script instead.