### PR TITLE
Add osdctl mc list command to return info about management clusters

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/osdctl/cmd/hive"
 	"github.com/openshift/osdctl/cmd/jira"
 	"github.com/openshift/osdctl/cmd/jumphost"
+	"github.com/openshift/osdctl/cmd/mc"
 	"github.com/openshift/osdctl/cmd/network"
 	"github.com/openshift/osdctl/cmd/org"
 	"github.com/openshift/osdctl/cmd/promote"
@@ -88,6 +89,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	rootCmd.AddCommand(newCmdCompletion())
 	rootCmd.AddCommand(env.NewCmdEnv())
 	rootCmd.AddCommand(jumphost.NewCmdJumphost())
+	rootCmd.AddCommand(mc.NewCmdMC())
 	rootCmd.AddCommand(network.NewCmdNetwork(streams, kubeFlags, kubeClient))
 	rootCmd.AddCommand(servicelog.NewCmdServiceLog())
 	rootCmd.AddCommand(org.NewCmdOrg())

--- a/cmd/mc/cmd.go
+++ b/cmd/mc/cmd.go
@@ -1,0 +1,14 @@
+package mc
+
+import "github.com/spf13/cobra"
+
+func NewCmdMC() *cobra.Command {
+	mc := &cobra.Command{
+		Use:  "mc",
+		Args: cobra.NoArgs,
+	}
+
+	mc.AddCommand(newCmdList())
+
+	return mc
+}

--- a/cmd/mc/list.go
+++ b/cmd/mc/list.go
@@ -1,0 +1,75 @@
+package mc
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"text/tabwriter"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type list struct {
+}
+
+func newCmdList() *cobra.Command {
+	l := &list{}
+
+	listCmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List ROSA HCP Management Clusters",
+		Long:    "List ROSA HCP Management Clusters",
+		Example: "osdctl mc list",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return l.Run()
+		},
+	}
+
+	return listCmd
+}
+
+func (l *list) Run() error {
+	ocm, err := utils.CreateConnection()
+	if err != nil {
+		return err
+	}
+	defer ocm.Close()
+
+	managementClusters, err := ocm.OSDFleetMgmt().V1().ManagementClusters().List().Send()
+	if err != nil {
+		return fmt.Errorf("failed to list management clusters: %v", err)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
+	fmt.Fprintln(w, "NAME\tID\tSECTOR\tREGION\tACCOUNT_ID\tSTATUS")
+	for _, mc := range managementClusters.Items().Slice() {
+		cluster, err := ocm.ClustersMgmt().V1().Clusters().Cluster(mc.ClusterManagementReference().ClusterId()).Get().Send()
+		if err != nil {
+			log.Printf("failed to find clusters_mgmt cluster for %s: %v", mc.Name(), err)
+			continue
+		}
+
+		awsAccountID := "NON-STS"
+		supportRole := cluster.Body().AWS().STS().SupportRoleARN()
+		if supportRole != "" {
+			supportRoleARN, err := arn.Parse(supportRole)
+			if err != nil {
+				log.Printf("failed to convert %s to an ARN: %v", supportRole, err)
+			}
+			awsAccountID = supportRoleARN.AccountID
+		}
+
+		fmt.Fprintln(w, mc.Name()+"\t"+
+			mc.ClusterManagementReference().ClusterId()+"\t"+
+			mc.Sector()+"\t"+
+			mc.Region()+"\t"+
+			awsAccountID+"\t"+
+			mc.Status())
+	}
+	w.Flush()
+
+	return nil
+}


### PR DESCRIPTION
It's tricky to get a glance of all management clusters - this command is a wrapper mostly around the `/api/osd_fleet_mgmt/v1/management_clusters` API and is not meant to be a replacement. Drilling down to get info via the OCM cli should still be done in some cases, but the goal is to allow users to get an informative glance of the management cluster fleet.

## Sample Output
```
❯ ./osdctl mc list -S
NAME            ID       SECTOR       REGION         ACCOUNT_ID   STATUS
hs-mc-0vfs0e6gg REDACTED perf         us-east-2      NON-STS      ready
hs-mc-bqv8ijpk0 REDACTED main         us-west-2      NON-STS      deprovisioning
hs-mc-89k4jlllg REDACTED main         ap-northeast-1 NON-STS      ready
hs-mc-773jpgko0 REDACTED ibm-infra    us-east-1      NON-STS      ready
hs-mc-ru8d0hcn0 REDACTED podisolation us-west-2      933017423025 ready
                         perf2        us-east-2      NON-STS      cleanup_account
hs-mc-rjgo2l6p0 REDACTED perf3        eu-west-1      122319444825 ready
hs-mc-ii3pahgr0 REDACTED chaos        us-east-1      715742867559 ready
hs-mc-rotopkh2g REDACTED canary       us-west-2      270839633556 ready
hs-mc-pjjl0htq0 REDACTED canary       us-west-2      342394040482 maintenance
hs-mc-jbdapd1ug REDACTED canary       us-west-2      138944827148 deprovisioning
hs-mc-697cv74pg REDACTED main         us-west-2      649891719851 ready
hs-mc-697cv7hbg REDACTED main         us-west-2      103635850749 ready
hs-mc-48fl5pseg REDACTED main         us-west-2      486416053872 ready
hs-mc-fahd026ng REDACTED canary       us-west-2      943513317316 ready
hs-mc-sdjiqigk0 REDACTED canary       us-west-2      874425166238 ready
hs-mc-b4vp09uog REDACTED ibm-infra    us-east-1      NON-STS      ready
hs-mc-cqqsfu580 REDACTED canary       us-west-2      934007959215 failed
hs-mc-do61ntmmg REDACTED perf2        us-east-2      901950378019 maintenance
hs-mc-d37rcl0k0 REDACTED perf2        us-east-2      629522112590 ready
```

[OSD-19727](https://issues.redhat.com//browse/OSD-19727)


fyi another subcommand is planned as a part of this card as well, `osdctl mc logs`