### PR TITLE
Add email addresses to osdctl org users

### DIFF
--- a/cmd/org/users.go
+++ b/cmd/org/users.go
@@ -32,6 +32,7 @@ type UserItems struct {
 
 type userModel struct {
 	UserName string   `json:"user-name"`
+	Email    string   `json:"email"`
 	UserID   string   `json:"user-id"`
 	Roles    []string `json:"roles"`
 }
@@ -98,6 +99,7 @@ func getUsers(orgID string) error {
 		usersResponse.Items().Each(func(account *amv1.Account) bool {
 			accountList = append(accountList, account)
 			accountMap[account] = &userModel{
+				Email:    account.Email(),
 				UserName: account.Username(),
 				UserID:   account.ID(),
 			}


### PR DESCRIPTION
This lets us do
```bash
osdctl org users ${ORG_ID} -ojson -S | jq -r '.items[].email'
```

To get a list of all email addresses of users in an OCM org