### PR TITLE
OSD-16588: Added Logic to Warn when Documentation does not matches Product type

### DIFF
--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -195,8 +195,8 @@ func (o *PostCmdOptions) Run() error {
 		log.Fatal("servicelog post command terminated")
 	}()
 
-	// cluster type for which documentation link is provided in servicelog description 
-	docClusterType := getDocClusterType(o.Message.Description) 
+	// cluster type for which documentation link is provided in servicelog description
+	docClusterType := getDocClusterType(o.Message.Description)
 
 	for _, cluster := range clusters {
 		request, err := o.createPostRequest(ocmClient, cluster)
@@ -205,18 +205,18 @@ func (o *PostCmdOptions) Run() error {
 			continue
 		}
 
-		// if servicelog description contains a documentation link, verify that  
+		// if servicelog description contains a documentation link, verify that
 		// documentation link matches the cluster product (rosa, dedicated)
-		if  !o.skipPrompts && docClusterType != "" {  			
+		if !o.skipPrompts && docClusterType != "" {
 			clusterType := cluster.Product().ID()
 
-			if(docClusterType != clusterType){
+			if docClusterType != clusterType {
 				log.Info("The documentation link in the servicelog is for '", docClusterType, "' while the servicelog itself is for cluster type '", clusterType, "'.")
 				if !ocmutils.ConfirmPrompt() {
-					log.Info("Skipping cluster ID: ", cluster.ID() , ", Name: ", cluster.Name())
+					log.Info("Skipping cluster ID: ", cluster.ID(), ", Name: ", cluster.Name())
 					continue
 				}
-			} 
+			}
 		}
 
 		response, err := ocmutils.SendRequest(request)
@@ -231,20 +231,19 @@ func (o *PostCmdOptions) Run() error {
 	o.printPostOutput()
 	return nil
 }
- 
 
 // if servicelog description contains documentation link, parse and return the cluster type from the url
-func getDocClusterType(message string) string{
+func getDocClusterType(message string) string {
 	descSubstrings := strings.Split(message, " ")
 
 	for _, s := range descSubstrings {
-		if strings.Contains(s, documentationBaseURL) { 
+		if strings.Contains(s, documentationBaseURL) {
 			t := strings.Split(s, "/")
 			p := t[3]
 			if p == "dedicated" {
-				// the documentation urls for osd use "dedicated" as the differentiator 
+				// the documentation urls for osd use "dedicated" as the differentiator
 				// e.g. https://docs.openshift.com/dedicated/welcome/index.html
-				// for proper comparison with cluster product types, return "osd" 
+				// for proper comparison with cluster product types, return "osd"
 				// where "dedicated" is used in the documentation urls
 				p = "osd"
 			}

--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -211,7 +211,7 @@ func (o *PostCmdOptions) Run() error {
 			clusterType := cluster.Product().ID()
 
 			if docClusterType != clusterType {
-				log.Info("The documentation link in the servicelog is for '", docClusterType, "' while the servicelog itself is for cluster type '", clusterType, "'.")
+				log.Warn("The documentation mentioned in the servicelog is for '", docClusterType, "' while the product is '", clusterType, "'.")
 				if !ocmutils.ConfirmPrompt() {
 					log.Info("Skipping cluster ID: ", cluster.ID(), ", Name: ", cluster.Name())
 					continue
@@ -234,23 +234,23 @@ func (o *PostCmdOptions) Run() error {
 
 // if servicelog description contains documentation link, parse and return the cluster type from the url
 func getDocClusterType(message string) string {
-	descSubstrings := strings.Split(message, " ")
 
-	for _, s := range descSubstrings {
-		if strings.Contains(s, documentationBaseURL) {
-			t := strings.Split(s, "/")
-			p := t[3]
-			if p == "dedicated" {
+	if strings.Contains(message, documentationBaseURL) {
+		pattern := `https://docs.openshift.com/([^/]+)/`
+		re := regexp.MustCompile(pattern)
+		match := re.FindStringSubmatch(message)
+		if len(match) >= 2 {
+			productType := match[1]
+			if productType == "dedicated" {
 				// the documentation urls for osd use "dedicated" as the differentiator
 				// e.g. https://docs.openshift.com/dedicated/welcome/index.html
 				// for proper comparison with cluster product types, return "osd"
 				// where "dedicated" is used in the documentation urls
-				p = "osd"
+				productType = "osd"
 			}
-			return p
+			return productType
 		}
 	}
-
 	return ""
 }
 

--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -242,8 +242,10 @@ func getDocClusterType(message string) string{
 			t := strings.Split(s, "/")
 			p := t[3]
 			if p == "dedicated" {
-				// the documentation urls for osd use "dedicated" as the differentiator e.g. https://docs.openshift.com/dedicated/welcome/index.html
-				// for proper comparison with cluster product types, return "osd" where "dedicated" is used in the documentation urls
+				// the documentation urls for osd use "dedicated" as the differentiator 
+				// e.g. https://docs.openshift.com/dedicated/welcome/index.html
+				// for proper comparison with cluster product types, return "osd" 
+				// where "dedicated" is used in the documentation urls
 				p = "osd"
 			}
 			return p


### PR DESCRIPTION
This PR closes [OSD-16588](https://issues.redhat.com//browse/OSD-16588). This adds a check to servicelog to check whether documentation link sent with the SL is correct or not!