### PR TITLE
OSD-20407: Fix osdctl cluster etcd related commands

### DIFF
--- a/cmd/cluster/etcd_replace.go
+++ b/cmd/cluster/etcd_replace.go
@@ -53,7 +53,7 @@ func newCmdEtcdMemberReplacement() *cobra.Command {
 }
 
 func (opts *etcdOptions) EtcdReplaceMember(clusterId string) error {
-	kubeCli, kconfig, clientset, err := getKubeConfigAndClient(clusterId)
+	kubeCli, kconfig, clientset, err := getKubeConfigAndClient(clusterId, "backplane-cluster-admin", "Replacing unhealthy etcd member using osdctl")
 	if err != nil {
 		return err
 	}

--- a/cmd/cluster/transferowner.go
+++ b/cmd/cluster/transferowner.go
@@ -5,6 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
+	"time"
+
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	hiveapiv1 "github.com/openshift/hive/apis/hive/v1"
 	hiveinternalv1alpha1 "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
@@ -12,10 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
-	"time"
 
 	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -302,7 +303,7 @@ func (o *transferOwnerOptions) run() error {
 
 	// Find and setup all resources that are needed
 	hiveCluster, err := utils.GetHiveCluster(o.clusterID)
-	hiveKubeCli, _, hivecClientset, err := getKubeConfigAndClient(hiveCluster.ID())
+	hiveKubeCli, _, hivecClientset, err := getKubeConfigAndClient(hiveCluster.ID(), "backplane-cluster-admin", "Updating pull secret using osdctl")
 	if err != nil {
 		return fmt.Errorf("failed to retrieve Kubernetes configuration and client for Hive cluster ID %s: %w", hiveCluster.ID(), err)
 	}
@@ -353,7 +354,7 @@ func (o *transferOwnerOptions) run() error {
 		return fmt.Errorf("failed to update pull secret for Hive cluster with ID %s: %w", o.clusterID, err)
 	}
 
-	_, _, clientset, err := getKubeConfigAndClient(o.clusterID)
+	_, _, clientset, err := getKubeConfigAndClient(o.clusterID, "backplane-cluster-admin", "Updating pull secret using osdctl")
 	if err != nil {
 		return fmt.Errorf("failed to retrieve Kubernetes configuration and client for cluster with ID %s: %w", o.clusterID, err)
 	}


### PR DESCRIPTION
Closes - https://issues.redhat.com/browse/OSD-20407

This PR changes
1. `etcd-health-check` is reverted from deprecation
2.  `etcd-health-check` does not elevate to cluster admin
3. `etcd-member-replace` autopopulates the reason for elevation