### PR TITLE
OSD-20024: Add mandatory reason argument when elevation is required for osdctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ osdctl federatedrole apply -f <yaml file>
 #### Access cluster
 ```bash
 # Login to the cluster's hive shard
-osdctl cluster break-glass <cluster identifier> --as backplane-cluster-admin
+osdctl cluster break-glass <cluster identifier> --reason <ticket ref>
 ```
 
 #### Drop cluster access

--- a/cmd/account/cmd.go
+++ b/cmd/account/cmd.go
@@ -5,17 +5,17 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/osdctl/cmd/account/get"
 	"github.com/openshift/osdctl/cmd/account/list"
 	"github.com/openshift/osdctl/cmd/account/mgmt"
 	"github.com/openshift/osdctl/cmd/account/servicequotas"
 	"github.com/openshift/osdctl/internal/utils/globalflags"
+	"github.com/openshift/osdctl/pkg/k8s"
 )
 
 // NewCmdAccount implements the base account command
-func NewCmdAccount(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+func NewCmdAccount(streams genericclioptions.IOStreams, client *k8s.LazyClient, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	accountCmd := &cobra.Command{
 		Use:               "account",
 		Short:             "AWS Account related utilities",
@@ -23,18 +23,18 @@ func NewCmdAccount(streams genericclioptions.IOStreams, flags *genericclioptions
 		DisableAutoGenTag: true,
 	}
 
-	accountCmd.AddCommand(get.NewCmdGet(streams, flags, client, globalOpts))
-	accountCmd.AddCommand(list.NewCmdList(streams, flags, client, globalOpts))
-	accountCmd.AddCommand(servicequotas.NewCmdServiceQuotas(streams, flags))
-	accountCmd.AddCommand(mgmt.NewCmdMgmt(streams, flags, globalOpts))
-	accountCmd.AddCommand(newCmdReset(streams, flags, client))
-	accountCmd.AddCommand(newCmdSet(streams, flags, client))
+	accountCmd.AddCommand(get.NewCmdGet(streams, client, globalOpts))
+	accountCmd.AddCommand(list.NewCmdList(streams, client, globalOpts))
+	accountCmd.AddCommand(servicequotas.NewCmdServiceQuotas(streams))
+	accountCmd.AddCommand(mgmt.NewCmdMgmt(streams, globalOpts))
+	accountCmd.AddCommand(newCmdReset(streams, client))
+	accountCmd.AddCommand(newCmdSet(streams, client))
 	accountCmd.AddCommand(newCmdConsole())
 	accountCmd.AddCommand(newCmdCli())
 	accountCmd.AddCommand(newCmdCleanVeleroSnapshots(streams))
-	accountCmd.AddCommand(newCmdVerifySecrets(streams, flags, client))
-	accountCmd.AddCommand(newCmdRotateSecret(streams, flags, client))
-	accountCmd.AddCommand(newCmdGenerateSecret(streams, flags, client))
+	accountCmd.AddCommand(newCmdVerifySecrets(streams, client))
+	accountCmd.AddCommand(newCmdRotateSecret(streams, client))
+	accountCmd.AddCommand(newCmdGenerateSecret(streams, client))
 
 	return accountCmd
 }

--- a/cmd/account/generate-secret.go
+++ b/cmd/account/generate-secret.go
@@ -23,8 +23,8 @@ import (
 )
 
 // newCmdGenerateSecret implements the generate-secret command which generates an new set of IAM User credentials
-func newCmdGenerateSecret(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
-	ops := newGenerateSecretOptions(streams, flags, client)
+func newCmdGenerateSecret(streams genericclioptions.IOStreams, client client.Client) *cobra.Command {
+	ops := newGenerateSecretOptions(streams, client)
 	generateSecretCmd := &cobra.Command{
 		Use:               "generate-secret <IAM User name>",
 		Short:             "Generates IAM credentials secret",
@@ -69,14 +69,12 @@ type generateSecretOptions struct {
 	cfgFile           string
 	awsAccountTimeout *int32
 
-	flags *genericclioptions.ConfigFlags
 	genericclioptions.IOStreams
 	kubeCli client.Client
 }
 
-func newGenerateSecretOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *generateSecretOptions {
+func newGenerateSecretOptions(streams genericclioptions.IOStreams, client client.Client) *generateSecretOptions {
 	return &generateSecretOptions{
-		flags:     flags,
 		IOStreams: streams,
 		kubeCli:   client,
 	}
@@ -325,9 +323,6 @@ func (o *generateSecretOptions) generateCcsSecret() error {
 	if err != nil {
 		return err
 	}
-
-	// Escalte to backplane cluster admin
-	o.flags.Impersonate = awsSdk.String("backplane-cluster-admin")
 
 	secret := k8s.NewAWSSecret(
 		o.secretName,

--- a/cmd/account/get/account-claim.go
+++ b/cmd/account/get/account-claim.go
@@ -17,8 +17,8 @@ import (
 
 // newCmdGetAccountClaim implements the get account-claim command which get
 // the Account Claim CR related to the specified AWS Account ID
-func newCmdGetAccountClaim(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
-	ops := newGetAccountClaimOptions(streams, flags, client, globalOpts)
+func newCmdGetAccountClaim(streams genericclioptions.IOStreams, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newGetAccountClaimOptions(streams, client, globalOpts)
 	getAccountClaimCmd := &cobra.Command{
 		Use:               "account-claim",
 		Short:             "Get AWS Account Claim CR",
@@ -47,16 +47,14 @@ type getAccountClaimOptions struct {
 
 	output string
 
-	flags      *genericclioptions.ConfigFlags
 	printFlags *printer.PrintFlags
 	genericclioptions.IOStreams
 	kubeCli       client.Client
 	GlobalOptions *globalflags.GlobalOptions
 }
 
-func newGetAccountClaimOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *getAccountClaimOptions {
+func newGetAccountClaimOptions(streams genericclioptions.IOStreams, client client.Client, globalOpts *globalflags.GlobalOptions) *getAccountClaimOptions {
 	return &getAccountClaimOptions{
-		flags:         flags,
 		printFlags:    printer.NewPrintFlags(),
 		IOStreams:     streams,
 		kubeCli:       client,

--- a/cmd/account/get/account-claim_test.go
+++ b/cmd/account/get/account-claim_test.go
@@ -17,7 +17,6 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mockCtrl := gomock.NewController(t)
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-	kubeFlags := genericclioptions.NewConfigFlags(false)
 	globalFlags := globalflags.GlobalOptions{Output: ""}
 	testCases := []struct {
 		title       string
@@ -30,7 +29,6 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 			option: &getAccountClaimOptions{
 				accountID:     "",
 				accountName:   "",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
@@ -41,7 +39,6 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 			option: &getAccountClaimOptions{
 				accountID:     "foo",
 				accountName:   "bar",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
@@ -51,7 +48,6 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 			title: "succeed",
 			option: &getAccountClaimOptions{
 				accountID:     "foo",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
@@ -60,7 +56,7 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			cmd := newCmdGetAccountClaim(streams, kubeFlags, mockk8s.NewMockClient(mockCtrl), &globalFlags)
+			cmd := newCmdGetAccountClaim(streams, mockk8s.NewMockClient(mockCtrl), &globalFlags)
 			err := tc.option.complete(cmd, nil)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())

--- a/cmd/account/get/account.go
+++ b/cmd/account/get/account.go
@@ -19,8 +19,8 @@ import (
 
 // newCmdGetAccount implements the get account command which get the Account CR
 // related to the specified AWS Account ID or the specified Account Claim CR
-func newCmdGetAccount(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
-	ops := newGetAccountOptions(streams, flags, client, globalOpts)
+func newCmdGetAccount(streams genericclioptions.IOStreams, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newGetAccountOptions(streams, client, globalOpts)
 	getAccountCmd := &cobra.Command{
 		Use:               "account",
 		Short:             "Get AWS Account CR",
@@ -51,16 +51,14 @@ type getAccountOptions struct {
 
 	output string
 
-	flags      *genericclioptions.ConfigFlags
 	printFlags *printer.PrintFlags
 	genericclioptions.IOStreams
 	kubeCli       client.Client
 	GlobalOptions *globalflags.GlobalOptions
 }
 
-func newGetAccountOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *getAccountOptions {
+func newGetAccountOptions(streams genericclioptions.IOStreams, client client.Client, globalOpts *globalflags.GlobalOptions) *getAccountOptions {
 	return &getAccountOptions{
-		flags:         flags,
 		printFlags:    printer.NewPrintFlags(),
 		IOStreams:     streams,
 		kubeCli:       client,

--- a/cmd/account/get/account_test.go
+++ b/cmd/account/get/account_test.go
@@ -17,7 +17,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mockCtrl := gomock.NewController(t)
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-	kubeFlags := genericclioptions.NewConfigFlags(false)
 	globalFlags := globalflags.GlobalOptions{Output: ""}
 	testCases := []struct {
 		title       string
@@ -30,7 +29,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			option: &getAccountOptions{
 				accountID:        "",
 				accountClaimName: "",
-				flags:            kubeFlags,
 				GlobalOptions:    &globalFlags,
 			},
 			errExpected: true,
@@ -41,7 +39,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			option: &getAccountOptions{
 				accountID:        "foo",
 				accountClaimName: "bar",
-				flags:            kubeFlags,
 				GlobalOptions:    &globalFlags,
 			},
 			errExpected: true,
@@ -51,7 +48,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			title: "succeed",
 			option: &getAccountOptions{
 				accountID:     "foo",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
@@ -60,7 +56,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			title: "succeed with account claim",
 			option: &getAccountOptions{
 				accountClaimName: "foo",
-				flags:            kubeFlags,
 				GlobalOptions:    &globalFlags,
 			},
 			errExpected: false,
@@ -69,7 +64,7 @@ func TestGetAccountCmdComplete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			cmd := newCmdGetAccount(streams, kubeFlags, mockk8s.NewMockClient(mockCtrl), &globalFlags)
+			cmd := newCmdGetAccount(streams, mockk8s.NewMockClient(mockCtrl), &globalFlags)
 			err := tc.option.complete(cmd, nil)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())

--- a/cmd/account/get/cmd.go
+++ b/cmd/account/get/cmd.go
@@ -14,7 +14,7 @@ const (
 )
 
 // NewCmdGet implements the get command to get AWS Account related resources
-func NewCmdGet(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+func NewCmdGet(streams genericclioptions.IOStreams, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	getCmd := &cobra.Command{
 		Use:               "get",
 		Short:             "Get resources",
@@ -22,11 +22,11 @@ func NewCmdGet(streams genericclioptions.IOStreams, flags *genericclioptions.Con
 		DisableAutoGenTag: true,
 	}
 
-	getCmd.AddCommand(newCmdGetAccount(streams, flags, client, globalOpts))
-	getCmd.AddCommand(newCmdGetAccountClaim(streams, flags, client, globalOpts))
-	getCmd.AddCommand(newCmdGetLegalEntity(streams, flags, client, globalOpts))
-	getCmd.AddCommand(newCmdGetSecrets(streams, flags, client, globalOpts))
-	getCmd.AddCommand(newCmdGetAWSAccount(streams, flags, client))
+	getCmd.AddCommand(newCmdGetAccount(streams, client, globalOpts))
+	getCmd.AddCommand(newCmdGetAccountClaim(streams, client, globalOpts))
+	getCmd.AddCommand(newCmdGetLegalEntity(streams, client, globalOpts))
+	getCmd.AddCommand(newCmdGetSecrets(streams, client, globalOpts))
+	getCmd.AddCommand(newCmdGetAWSAccount(streams, client))
 
 	return getCmd
 }

--- a/cmd/account/get/id.go
+++ b/cmd/account/get/id.go
@@ -17,8 +17,8 @@ import (
 )
 
 // newCmdGetAWSAccount implements the reset command which resets the specified account cr
-func newCmdGetAWSAccount(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
-	ops := newGetAWSAccountOptions(streams, flags, client)
+func newCmdGetAWSAccount(streams genericclioptions.IOStreams, client client.Client) *cobra.Command {
+	ops := newGetAWSAccountOptions(streams, client)
 	getAWSAccountCmd := &cobra.Command{
 		Use:               "aws-account",
 		Short:             "Get AWS Account ID",
@@ -46,14 +46,12 @@ type getAWSAccountOptions struct {
 	accountClaimName      string
 	accountClaimNamespace string
 
-	flags *genericclioptions.ConfigFlags
 	genericclioptions.IOStreams
 	kubeCli client.Client
 }
 
-func newGetAWSAccountOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *getAWSAccountOptions {
+func newGetAWSAccountOptions(streams genericclioptions.IOStreams, client client.Client) *getAWSAccountOptions {
 	return &getAWSAccountOptions{
-		flags:     flags,
 		IOStreams: streams,
 		kubeCli:   client,
 	}

--- a/cmd/account/get/id_test.go
+++ b/cmd/account/get/id_test.go
@@ -16,7 +16,6 @@ func TestGetAWSAccountCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mockCtrl := gomock.NewController(t)
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-	kubeFlags := genericclioptions.NewConfigFlags(false)
 	testCases := []struct {
 		title       string
 		option      *getAWSAccountOptions
@@ -46,7 +45,6 @@ func TestGetAWSAccountCmdComplete(t *testing.T) {
 			title: "succeed",
 			option: &getAWSAccountOptions{
 				accountName: "foo",
-				flags:       kubeFlags,
 			},
 			errExpected: false,
 		},
@@ -54,7 +52,6 @@ func TestGetAWSAccountCmdComplete(t *testing.T) {
 			title: "succeed with account claim name",
 			option: &getAWSAccountOptions{
 				accountClaimName: "foo",
-				flags:            kubeFlags,
 			},
 			errExpected: false,
 		},
@@ -62,7 +59,7 @@ func TestGetAWSAccountCmdComplete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			cmd := newCmdGetAWSAccount(streams, kubeFlags, mockk8s.NewMockClient(mockCtrl))
+			cmd := newCmdGetAWSAccount(streams, mockk8s.NewMockClient(mockCtrl))
 			err := tc.option.complete(cmd, tc.args)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())

--- a/cmd/account/get/legal-entity.go
+++ b/cmd/account/get/legal-entity.go
@@ -19,8 +19,8 @@ import (
 
 // newCmdGetLegalEntity implements the get legal-entity command which get
 // the legal entity information related to the specified AWS Account ID
-func newCmdGetLegalEntity(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
-	ops := newGetLegalEntityOptions(streams, flags, client, globalOpts)
+func newCmdGetLegalEntity(streams genericclioptions.IOStreams, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newGetLegalEntityOptions(streams, client, globalOpts)
 	getLegalEntityCmd := &cobra.Command{
 		Use:               "legal-entity",
 		Short:             "Get AWS Account Legal Entity",
@@ -45,7 +45,6 @@ type getLegalEntityOptions struct {
 	accountNamespace string
 	output           string
 
-	flags *genericclioptions.ConfigFlags
 	genericclioptions.IOStreams
 	kubeCli       client.Client
 	GlobalOptions *globalflags.GlobalOptions
@@ -62,9 +61,8 @@ func (f legalEntityResponse) String() string {
 
 }
 
-func newGetLegalEntityOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *getLegalEntityOptions {
+func newGetLegalEntityOptions(streams genericclioptions.IOStreams, client client.Client, globalOpts *globalflags.GlobalOptions) *getLegalEntityOptions {
 	return &getLegalEntityOptions{
-		flags:         flags,
 		IOStreams:     streams,
 		kubeCli:       client,
 		GlobalOptions: globalOpts,

--- a/cmd/account/get/legal-entity_test.go
+++ b/cmd/account/get/legal-entity_test.go
@@ -17,7 +17,7 @@ func TestGetLegalEntityCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mockCtrl := gomock.NewController(t)
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-	kubeFlags := genericclioptions.NewConfigFlags(false)
+
 	globalFlags := globalflags.GlobalOptions{Output: ""}
 	testCases := []struct {
 		title       string
@@ -29,7 +29,6 @@ func TestGetLegalEntityCmdComplete(t *testing.T) {
 			title: "empty account id",
 			option: &getSecretsOptions{
 				accountID:     "",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
@@ -39,7 +38,6 @@ func TestGetLegalEntityCmdComplete(t *testing.T) {
 			title: "succeed",
 			option: &getSecretsOptions{
 				accountID:     "foo",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
@@ -48,7 +46,7 @@ func TestGetLegalEntityCmdComplete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			cmd := newCmdGetLegalEntity(streams, kubeFlags, mockk8s.NewMockClient(mockCtrl), &globalFlags)
+			cmd := newCmdGetLegalEntity(streams, mockk8s.NewMockClient(mockCtrl), &globalFlags)
 			err := tc.option.complete(cmd, nil)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())

--- a/cmd/account/get/secrets.go
+++ b/cmd/account/get/secrets.go
@@ -24,8 +24,8 @@ const (
 
 // newCmdGetSecrets implements the get secrets command which get
 // the name of secrets related to the specified AWS Account ID
-func newCmdGetSecrets(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
-	ops := newGetSecretsOptions(streams, flags, client, globalOpts)
+func newCmdGetSecrets(streams genericclioptions.IOStreams, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newGetSecretsOptions(streams, client, globalOpts)
 	getSecretsCmd := &cobra.Command{
 		Use:               "secrets",
 		Short:             "Get AWS Account CR related secrets",
@@ -50,16 +50,14 @@ type getSecretsOptions struct {
 	accountNamespace string
 	output           string
 
-	flags      *genericclioptions.ConfigFlags
 	printFlags *printer.PrintFlags
 	genericclioptions.IOStreams
 	kubeCli       client.Client
 	GlobalOptions *globalflags.GlobalOptions
 }
 
-func newGetSecretsOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *getSecretsOptions {
+func newGetSecretsOptions(streams genericclioptions.IOStreams, client client.Client, globalOpts *globalflags.GlobalOptions) *getSecretsOptions {
 	return &getSecretsOptions{
-		flags:         flags,
 		IOStreams:     streams,
 		kubeCli:       client,
 		GlobalOptions: globalOpts,

--- a/cmd/account/get/secrets_test.go
+++ b/cmd/account/get/secrets_test.go
@@ -17,7 +17,6 @@ func TestGetSecretsCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mockCtrl := gomock.NewController(t)
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-	kubeFlags := genericclioptions.NewConfigFlags(false)
 	globalFlags := globalflags.GlobalOptions{Output: ""}
 	testCases := []struct {
 		title       string
@@ -29,7 +28,6 @@ func TestGetSecretsCmdComplete(t *testing.T) {
 			title: "empty account id",
 			option: &getSecretsOptions{
 				accountID:     "",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
@@ -39,7 +37,6 @@ func TestGetSecretsCmdComplete(t *testing.T) {
 			title: "succeed",
 			option: &getSecretsOptions{
 				accountID:     "foo",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
@@ -48,7 +45,7 @@ func TestGetSecretsCmdComplete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			cmd := newCmdGetSecrets(streams, kubeFlags, mockk8s.NewMockClient(mockCtrl), &globalFlags)
+			cmd := newCmdGetSecrets(streams, mockk8s.NewMockClient(mockCtrl), &globalFlags)
 			err := tc.option.complete(cmd, nil)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())

--- a/cmd/account/list/account-claim.go
+++ b/cmd/account/list/account-claim.go
@@ -15,8 +15,8 @@ import (
 )
 
 // newCmdListAccount implements the list account command to list account claim crs
-func newCmdListAccountClaim(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
-	ops := newListAccountClaimOptions(streams, flags, client, globalOpts)
+func newCmdListAccountClaim(streams genericclioptions.IOStreams, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newListAccountClaimOptions(streams, client, globalOpts)
 	listAccountClaimCmd := &cobra.Command{
 		Use:               "account-claim",
 		Short:             "List AWS Account Claim CR",
@@ -38,16 +38,14 @@ type listAccountClaimOptions struct {
 	state  string
 	output string
 
-	flags      *genericclioptions.ConfigFlags
 	printFlags *printer.PrintFlags
 	genericclioptions.IOStreams
 	kubeCli       client.Client
 	GlobalOptions *globalflags.GlobalOptions
 }
 
-func newListAccountClaimOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *listAccountClaimOptions {
+func newListAccountClaimOptions(streams genericclioptions.IOStreams, client client.Client, globalOpts *globalflags.GlobalOptions) *listAccountClaimOptions {
 	return &listAccountClaimOptions{
-		flags:         flags,
 		IOStreams:     streams,
 		kubeCli:       client,
 		GlobalOptions: globalOpts,

--- a/cmd/account/list/account-claim_test.go
+++ b/cmd/account/list/account-claim_test.go
@@ -17,7 +17,6 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mockCtrl := gomock.NewController(t)
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-	kubeFlags := genericclioptions.NewConfigFlags(false)
 	globalFlags := globalflags.GlobalOptions{Output: ""}
 	testCases := []struct {
 		title       string
@@ -29,7 +28,6 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 			title: "incorrect state",
 			option: &listAccountClaimOptions{
 				state:         "foo",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
@@ -39,7 +37,6 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 			title: "empty state",
 			option: &listAccountClaimOptions{
 				state:         "",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
@@ -48,7 +45,6 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 			title: "error state",
 			option: &listAccountClaimOptions{
 				state:         "Error",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
@@ -57,7 +53,6 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 			title: "pending state",
 			option: &listAccountClaimOptions{
 				state:         "Pending",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
@@ -66,7 +61,6 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 			title: "ready state",
 			option: &listAccountClaimOptions{
 				state:         "Ready",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
@@ -75,7 +69,7 @@ func TestGetAccountClaimCmdComplete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			cmd := newCmdListAccountClaim(streams, kubeFlags, mockk8s.NewMockClient(mockCtrl), &globalFlags)
+			cmd := newCmdListAccountClaim(streams, mockk8s.NewMockClient(mockCtrl), &globalFlags)
 			err := tc.option.complete(cmd, nil)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())

--- a/cmd/account/list/account.go
+++ b/cmd/account/list/account.go
@@ -18,8 +18,8 @@ import (
 )
 
 // newCmdListAccount implements the list account command to list account crs
-func newCmdListAccount(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
-	ops := newListAccountOptions(streams, flags, client, globalOpts)
+func newCmdListAccount(streams genericclioptions.IOStreams, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newListAccountOptions(streams, client, globalOpts)
 	listAccountCmd := &cobra.Command{
 		Use:               "account",
 		Short:             "List AWS Account CR",
@@ -53,16 +53,14 @@ type listAccountOptions struct {
 
 	output string
 
-	flags      *genericclioptions.ConfigFlags
 	printFlags *printer.PrintFlags
 	genericclioptions.IOStreams
 	kubeCli       client.Client
 	GlobalOptions *globalflags.GlobalOptions
 }
 
-func newListAccountOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *listAccountOptions {
+func newListAccountOptions(streams genericclioptions.IOStreams, client client.Client, globalOpts *globalflags.GlobalOptions) *listAccountOptions {
 	return &listAccountOptions{
-		flags:         flags,
 		printFlags:    printer.NewPrintFlags(),
 		IOStreams:     streams,
 		kubeCli:       client,

--- a/cmd/account/list/account_test.go
+++ b/cmd/account/list/account_test.go
@@ -17,7 +17,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mockCtrl := gomock.NewController(t)
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-	kubeFlags := genericclioptions.NewConfigFlags(false)
 	globalFlags := globalflags.GlobalOptions{Output: ""}
 	testCases := []struct {
 		title       string
@@ -29,7 +28,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			title: "incorrect state",
 			option: &listAccountOptions{
 				state:         "foo",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
@@ -39,7 +37,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			title: "empty state",
 			option: &listAccountOptions{
 				state:         "",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
@@ -48,7 +45,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			title: "all state",
 			option: &listAccountOptions{
 				state:         "all",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
@@ -57,7 +53,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			title: "Ready state",
 			option: &listAccountOptions{
 				state:         "Ready",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
@@ -66,7 +61,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			title: "bad reuse",
 			option: &listAccountOptions{
 				reused:        "foo",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
@@ -76,7 +70,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			title: "bad reused status",
 			option: &listAccountOptions{
 				reused:        "foo",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
@@ -86,7 +79,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			title: "bad claimed status",
 			option: &listAccountOptions{
 				claimed:       "foo",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: true,
@@ -96,7 +88,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			title: "good reused true",
 			option: &listAccountOptions{
 				reused:        "true",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
@@ -105,7 +96,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 			title: "good claim",
 			option: &listAccountOptions{
 				claimed:       "false",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
@@ -116,7 +106,6 @@ func TestGetAccountCmdComplete(t *testing.T) {
 				state:         "Ready",
 				reused:        "true",
 				claimed:       "false",
-				flags:         kubeFlags,
 				GlobalOptions: &globalFlags,
 			},
 			errExpected: false,
@@ -125,7 +114,7 @@ func TestGetAccountCmdComplete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			cmd := newCmdListAccount(streams, tc.option.flags, mockk8s.NewMockClient(mockCtrl), &globalFlags)
+			cmd := newCmdListAccount(streams, mockk8s.NewMockClient(mockCtrl), &globalFlags)
 			err := tc.option.complete(cmd, nil)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())

--- a/cmd/account/list/cmd.go
+++ b/cmd/account/list/cmd.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewCmdList implements the list command
-func NewCmdList(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+func NewCmdList(streams genericclioptions.IOStreams, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	listCmd := &cobra.Command{
 		Use:               "list",
 		Short:             "List resources",
@@ -17,8 +17,8 @@ func NewCmdList(streams genericclioptions.IOStreams, flags *genericclioptions.Co
 		DisableAutoGenTag: true,
 	}
 
-	listCmd.AddCommand(newCmdListAccount(streams, flags, client, globalOpts))
-	listCmd.AddCommand(newCmdListAccountClaim(streams, flags, client, globalOpts))
+	listCmd.AddCommand(newCmdListAccount(streams, client, globalOpts))
+	listCmd.AddCommand(newCmdListAccountClaim(streams, client, globalOpts))
 
 	return listCmd
 }

--- a/cmd/account/mgmt/account-assign.go
+++ b/cmd/account/mgmt/account-assign.go
@@ -33,7 +33,6 @@ type accountAssignOptions struct {
 	output       string
 	iamUser      bool
 
-	flags      *genericclioptions.ConfigFlags
 	printFlags *printer.PrintFlags
 	genericclioptions.IOStreams
 	GlobalOptions *globalflags.GlobalOptions
@@ -48,9 +47,8 @@ func (f assignResponse) String() string {
 	return fmt.Sprintf("  Username: %s\n  Account: %s\n", f.Username, f.Id)
 }
 
-func newAccountAssignOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *accountAssignOptions {
+func newAccountAssignOptions(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *accountAssignOptions {
 	return &accountAssignOptions{
-		flags:         flags,
 		printFlags:    printer.NewPrintFlags(),
 		IOStreams:     streams,
 		GlobalOptions: globalOpts,
@@ -58,8 +56,8 @@ func newAccountAssignOptions(streams genericclioptions.IOStreams, flags *generic
 }
 
 // assignCmd assigns an aws account to user under osd-staging-2 by default unless osd-staging-1 is specified
-func newCmdAccountAssign(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
-	ops := newAccountAssignOptions(streams, flags, globalOpts)
+func newCmdAccountAssign(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newAccountAssignOptions(streams, globalOpts)
 	accountAssignCmd := &cobra.Command{
 		Use:               "assign",
 		Short:             "Assign account to user",

--- a/cmd/account/mgmt/account-iam.go
+++ b/cmd/account/mgmt/account-iam.go
@@ -25,7 +25,7 @@ type iamOptions struct {
 var arnPolicy = "arn:aws:iam::aws:policy/AdministratorAccess"
 
 // accountIamCmd implements the accountIam command which creates an IAM user for a given account
-func newCmdAccountIAM(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+func newCmdAccountIAM(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	ops := &iamOptions{}
 	iamCmd := &cobra.Command{
 		Use:               "iam",

--- a/cmd/account/mgmt/account-list.go
+++ b/cmd/account/mgmt/account-list.go
@@ -23,7 +23,6 @@ type accountListOptions struct {
 	accountID    string
 	output       string
 
-	flags      *genericclioptions.ConfigFlags
 	printFlags *printer.PrintFlags
 	genericclioptions.IOStreams
 	GlobalOptions *globalflags.GlobalOptions
@@ -40,17 +39,16 @@ func (f listResponse) String() string {
 
 }
 
-func newAccountListOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *accountListOptions {
+func newAccountListOptions(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *accountListOptions {
 	return &accountListOptions{
-		flags:         flags,
 		printFlags:    printer.NewPrintFlags(),
 		IOStreams:     streams,
 		GlobalOptions: globalOpts,
 	}
 }
 
-func newCmdAccountList(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
-	ops := newAccountListOptions(streams, flags, globalOpts)
+func newCmdAccountList(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newAccountListOptions(streams, globalOpts)
 	accountListCmd := &cobra.Command{
 		Use:               "list",
 		Short:             "List out accounts for username",

--- a/cmd/account/mgmt/account-unassign.go
+++ b/cmd/account/mgmt/account-unassign.go
@@ -19,8 +19,8 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
-func newCmdAccountUnassign(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
-	ops := newAccountUnassignOptions(streams, flags)
+func newCmdAccountUnassign(streams genericclioptions.IOStreams) *cobra.Command {
+	ops := newAccountUnassignOptions(streams)
 	accountUnassignCmd := &cobra.Command{
 		Use:               "unassign",
 		Short:             "Unassign account to user",
@@ -42,14 +42,12 @@ type accountUnassignOptions struct {
 	username     string
 	payerAccount string
 	accountID    string
-	flags        *genericclioptions.ConfigFlags
 	printFlags   *printer.PrintFlags
 	genericclioptions.IOStreams
 }
 
-func newAccountUnassignOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *accountUnassignOptions {
+func newAccountUnassignOptions(streams genericclioptions.IOStreams) *accountUnassignOptions {
 	return &accountUnassignOptions{
-		flags:      flags,
 		printFlags: printer.NewPrintFlags(),
 		IOStreams:  streams,
 	}

--- a/cmd/account/mgmt/account-unassign_test.go
+++ b/cmd/account/mgmt/account-unassign_test.go
@@ -609,9 +609,8 @@ func TestUntagAccount(t *testing.T) {
 
 func TestConflictingOptions(t *testing.T) {
 	s := genericclioptions.IOStreams{}
-	f := genericclioptions.ConfigFlags{}
 	g := globalflags.GlobalOptions{}
-	cmd := newCmdAccountAssign(s, &f, &g)
+	cmd := newCmdAccountAssign(s, &g)
 	o := &accountUnassignOptions{}
 	o.payerAccount = "fake account"
 	o.accountID = "123456"

--- a/cmd/account/mgmt/cmd.go
+++ b/cmd/account/mgmt/cmd.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewCmdMgmt implements the mgmt command to get AWS Account resources
-func NewCmdMgmt(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+func NewCmdMgmt(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	mgmtCmd := &cobra.Command{
 		Use:               "mgmt",
 		Short:             "AWS Account Management",
@@ -17,10 +17,10 @@ func NewCmdMgmt(streams genericclioptions.IOStreams, flags *genericclioptions.Co
 		DisableAutoGenTag: true,
 	}
 
-	mgmtCmd.AddCommand(newCmdAccountList(streams, flags, globalOpts))
-	mgmtCmd.AddCommand(newCmdAccountAssign(streams, flags, globalOpts))
-	mgmtCmd.AddCommand(newCmdAccountUnassign(streams, flags))
-	mgmtCmd.AddCommand(newCmdAccountIAM(streams, flags, globalOpts))
+	mgmtCmd.AddCommand(newCmdAccountList(streams, globalOpts))
+	mgmtCmd.AddCommand(newCmdAccountAssign(streams, globalOpts))
+	mgmtCmd.AddCommand(newCmdAccountUnassign(streams))
+	mgmtCmd.AddCommand(newCmdAccountIAM(streams, globalOpts))
 
 	return mgmtCmd
 }

--- a/cmd/account/reset.go
+++ b/cmd/account/reset.go
@@ -24,8 +24,8 @@ import (
 )
 
 // newCmdReset implements the reset command which resets the specified account cr
-func newCmdReset(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
-	ops := newResetOptions(streams, flags, client)
+func newCmdReset(streams genericclioptions.IOStreams, client client.Client) *cobra.Command {
+	ops := newResetOptions(streams, client)
 	resetCmd := &cobra.Command{
 		Use:               "reset <account name>",
 		Short:             "Reset AWS Account CR",
@@ -56,14 +56,12 @@ type resetOptions struct {
 	skipCheck        bool
 	resetLegalEntity bool
 
-	flags *genericclioptions.ConfigFlags
 	genericclioptions.IOStreams
 	kubeCli client.Client
 }
 
-func newResetOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *resetOptions {
+func newResetOptions(streams genericclioptions.IOStreams, client client.Client) *resetOptions {
 	return &resetOptions{
-		flags:     flags,
 		IOStreams: streams,
 		kubeCli:   client,
 	}

--- a/cmd/account/reset_test.go
+++ b/cmd/account/reset_test.go
@@ -16,7 +16,6 @@ func TestResetCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mockCtrl := gomock.NewController(t)
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-	kubeFlags := genericclioptions.NewConfigFlags(false)
 	testCases := []struct {
 		title       string
 		option      *resetOptions
@@ -37,10 +36,8 @@ func TestResetCmdComplete(t *testing.T) {
 			errContent:  "The name of Account CR is required for reset command",
 		},
 		{
-			title: "succeed",
-			option: &resetOptions{
-				flags: kubeFlags,
-			},
+			title:       "succeed",
+			option:      &resetOptions{},
 			args:        []string{"foo"},
 			errExpected: false,
 		},
@@ -48,7 +45,7 @@ func TestResetCmdComplete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			cmd := newCmdReset(streams, kubeFlags, mockk8s.NewMockClient(mockCtrl))
+			cmd := newCmdReset(streams, mockk8s.NewMockClient(mockCtrl))
 			err := tc.option.complete(cmd, tc.args)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())

--- a/cmd/account/servicequotas/cmd.go
+++ b/cmd/account/servicequotas/cmd.go
@@ -8,7 +8,7 @@ import (
 )
 
 // NewCmdServiceQuotas implements commands related to AWS service-quotas
-func NewCmdServiceQuotas(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+func NewCmdServiceQuotas(streams genericclioptions.IOStreams) *cobra.Command {
 	baseCmd := &cobra.Command{
 		Use:               "servicequotas",
 		Short:             "Interact with AWS service-quotas",

--- a/cmd/account/set.go
+++ b/cmd/account/set.go
@@ -18,8 +18,8 @@ import (
 )
 
 // newCmdSet implements the set command which sets fields in account cr status
-func newCmdSet(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
-	ops := newSetOptions(streams, flags, client)
+func newCmdSet(streams genericclioptions.IOStreams, client client.Client) *cobra.Command {
+	ops := newSetOptions(streams, client)
 	setCmd := &cobra.Command{
 		Use:               "set <account name>",
 		Short:             "Set AWS Account CR status",
@@ -57,14 +57,12 @@ type setOptions struct {
 	patchPayload string
 	patchType    string
 
-	flags *genericclioptions.ConfigFlags
 	genericclioptions.IOStreams
 	kubeCli client.Client
 }
 
-func newSetOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *setOptions {
+func newSetOptions(streams genericclioptions.IOStreams, client client.Client) *setOptions {
 	return &setOptions{
-		flags:     flags,
 		IOStreams: streams,
 		kubeCli:   client,
 	}

--- a/cmd/account/set_test.go
+++ b/cmd/account/set_test.go
@@ -16,7 +16,6 @@ func TestSetCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mockCtrl := gomock.NewController(t)
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-	kubeFlags := genericclioptions.NewConfigFlags(false)
 	testCases := []struct {
 		title       string
 		option      *setOptions
@@ -49,7 +48,6 @@ func TestSetCmdComplete(t *testing.T) {
 			title: "succeed",
 			option: &setOptions{
 				state: "Creating",
-				flags: kubeFlags,
 			},
 			args:        []string{"foo"},
 			errExpected: false,
@@ -58,7 +56,7 @@ func TestSetCmdComplete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			cmd := newCmdSet(streams, kubeFlags, mockk8s.NewMockClient(mockCtrl))
+			cmd := newCmdSet(streams, mockk8s.NewMockClient(mockCtrl))
 			err := tc.option.complete(cmd, tc.args)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())

--- a/cmd/account/verify-secrets.go
+++ b/cmd/account/verify-secrets.go
@@ -23,8 +23,8 @@ const (
 
 // newCmdVerifySecrets implements the verify-secrets command
 // which verifies AWS credentials managed by AWS Account Operator
-func newCmdVerifySecrets(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
-	ops := newVerifySecretsOptions(streams, flags, client)
+func newCmdVerifySecrets(streams genericclioptions.IOStreams, client client.Client) *cobra.Command {
+	ops := newVerifySecretsOptions(streams, client)
 	verifySecretsCmd := &cobra.Command{
 		Use:               "verify-secrets [<account name>]",
 		Short:             "Verify AWS Account CR IAM User credentials",
@@ -52,14 +52,12 @@ type verifySecretsOptions struct {
 	verbose bool
 	all     bool
 
-	flags *genericclioptions.ConfigFlags
 	genericclioptions.IOStreams
 	kubeCli client.Client
 }
 
-func newVerifySecretsOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *verifySecretsOptions {
+func newVerifySecretsOptions(streams genericclioptions.IOStreams, client client.Client) *verifySecretsOptions {
 	return &verifySecretsOptions{
-		flags:     flags,
 		IOStreams: streams,
 		kubeCli:   client,
 	}

--- a/cmd/account/verify-secrets_test.go
+++ b/cmd/account/verify-secrets_test.go
@@ -16,7 +16,6 @@ func TestCheckSecretsCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mockCtrl := gomock.NewController(t)
 	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
-	kubeFlags := genericclioptions.NewConfigFlags(false)
 	testCases := []struct {
 		title       string
 		option      *verifySecretsOptions
@@ -34,16 +33,13 @@ func TestCheckSecretsCmdComplete(t *testing.T) {
 			title: "succeed with one arg",
 			option: &verifySecretsOptions{
 				accountName: "foo",
-				flags:       kubeFlags,
 			},
 			args:        []string{"foo"},
 			errExpected: false,
 		},
 		{
-			title: "succeed with one arg",
-			option: &verifySecretsOptions{
-				flags: kubeFlags,
-			},
+			title:       "succeed with one arg",
+			option:      &verifySecretsOptions{},
 			args:        []string{},
 			errExpected: false,
 		},
@@ -51,7 +47,7 @@ func TestCheckSecretsCmdComplete(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.title, func(t *testing.T) {
-			cmd := newCmdVerifySecrets(streams, kubeFlags, mockk8s.NewMockClient(mockCtrl))
+			cmd := newCmdVerifySecrets(streams, mockk8s.NewMockClient(mockCtrl))
 			err := tc.option.complete(cmd, tc.args)
 			if tc.errExpected {
 				g.Expect(err).Should(HaveOccurred())

--- a/cmd/cluster/access/access.go
+++ b/cmd/cluster/access/access.go
@@ -52,7 +52,7 @@ var (
 func NewCmdAccess(streams genericclioptions.IOStreams, client *k8s.LazyClient) *cobra.Command {
 	ops := newClusterAccessOptions(client, streams)
 	accessCmd := &cobra.Command{
-		Use:               "break-glass <cluster identifier> --reason <OHSS or PD ticket>",
+		Use:               "break-glass <cluster identifier>",
 		Short:             "Emergency access to a cluster",
 		Long:              "Obtain emergency credentials to access the given cluster. You must be logged into the cluster's hive shard",
 		Args:              cobra.ExactArgs(1),

--- a/cmd/cluster/access/access.go
+++ b/cmd/cluster/access/access.go
@@ -49,23 +49,22 @@ var (
 )
 
 // NewCmdCluster implements the 'cluster access' subcommand
-func NewCmdAccess(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) *cobra.Command {
+func NewCmdAccess(streams genericclioptions.IOStreams, client *k8s.LazyClient) *cobra.Command {
+	ops := newClusterAccessOptions(client, streams)
 	accessCmd := &cobra.Command{
-		Use:               "break-glass <cluster identifier>",
+		Use:               "break-glass <cluster identifier> --reason <OHSS or PD ticket>",
 		Short:             "Emergency access to a cluster",
 		Long:              "Obtain emergency credentials to access the given cluster. You must be logged into the cluster's hive shard",
 		Args:              cobra.ExactArgs(1),
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(accessCmdComplete(cmd, args))
-			// Prior to creating k8s client, verify the user has elevated permissions
-			cmdutil.CheckErr(verifyPermissions(streams, flags))
-			client := k8s.NewClient(flags)
-			clusterAccess := newClusterAccessOptions(client, streams, flags)
-			cmdutil.CheckErr(clusterAccess.Run(cmd, args))
+			cmdutil.CheckErr(ops.Run(cmd, args))
 		},
 	}
-	accessCmd.AddCommand(newCmdCleanup(streams, flags))
+	accessCmd.AddCommand(newCmdCleanup(client, streams))
+	accessCmd.Flags().StringVar(&ops.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)")
+	_ = accessCmd.MarkFlagRequired("reason")
 
 	return accessCmd
 }
@@ -78,47 +77,19 @@ func accessCmdComplete(cmd *cobra.Command, args []string) error {
 	return osdctlutil.IsValidClusterKey(args[0])
 }
 
-// verifyPermissions determines if the user has supplied the correct permissions in order to retrieve a KubeConfig secret from hive.
-// If the user attempts to impersonate an unexpected account, an error is returned.
-// If the user hasn't attempted to impersonate anyone, it prompts whether they would like to do so automatically.
-func verifyPermissions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) error {
-	if flags.Impersonate != nil && *flags.Impersonate != "" {
-		if *flags.Impersonate != impersonateUser {
-			osdctlutil.StreamPrintln(streams, "")
-			return fmt.Errorf("Unauthorized impersonation as user '%s'. Only requests to impersonate '%s' are allowed.", *flags.Impersonate, impersonateUser)
-		}
-	} else {
-		osdctlutil.StreamPrintln(streams, "")
-		osdctlutil.StreamPrintln(streams, fmt.Sprintf("No impersonation request detected. By design, SREs do not have sufficient permission to retrieve a cluster Kubeconfig from hive, and should impersonate '%s' to do so.", impersonateUser))
-		osdctlutil.StreamPrint(streams, fmt.Sprintf("Would you like to continue as '%s'? (You can disable this prompt in the future by rerunning this command with '--as %s') [y/N] ", impersonateUser, impersonateUser))
-
-		input, err := osdctlutil.StreamRead(streams, '\n')
-		if err != nil {
-			return err
-		}
-		if !isAffirmative(strings.TrimSpace(input)) {
-			return fmt.Errorf("Did not impersonate '%s'", impersonateUser)
-		}
-		*flags.Impersonate = impersonateUser
-		osdctlutil.StreamPrintln(streams, fmt.Sprintf("Continuing as '%s'", impersonateUser))
-		osdctlutil.StreamPrintln(streams, "")
-	}
-	return nil
-}
-
 // clusterAccessOptions contains the objects and information required to access a cluster
 type clusterAccessOptions struct {
-	*genericclioptions.ConfigFlags
+	reason string
+
 	genericclioptions.IOStreams
-	kclient.Client
+	kubeCli *k8s.LazyClient
 }
 
 // newAccessOptions creates a clusterAccessOptions object
-func newClusterAccessOptions(client kclient.Client, streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags) clusterAccessOptions {
+func newClusterAccessOptions(client *k8s.LazyClient, streams genericclioptions.IOStreams) clusterAccessOptions {
 	a := clusterAccessOptions{
-		IOStreams:   streams,
-		ConfigFlags: flags,
-		Client:      client,
+		IOStreams: streams,
+		kubeCli:   client,
 	}
 	return a
 }
@@ -147,7 +118,10 @@ func (c *clusterAccessOptions) Readln() (string, error) {
 
 // Run executes the 'cluster' access subcommand
 func (c *clusterAccessOptions) Run(cmd *cobra.Command, args []string) error {
-	clusterIdentifier := args[0]
+	clusterIdentifier := args[0] // This action requires elevation
+
+	c.kubeCli.Impersonate("backplane-cluster-admin", c.reason, fmt.Sprintf("Elevation required to break-glass on %s cluster", clusterIdentifier))
+
 	c.Println(fmt.Sprintf("Retrieving Kubeconfig for cluster '%s'", clusterIdentifier))
 
 	// Connect to ocm
@@ -166,7 +140,7 @@ func (c *clusterAccessOptions) Run(cmd *cobra.Command, args []string) error {
 	c.Println(fmt.Sprintf("Internal Cluster ID: %s", cluster.ID()))
 
 	// Retrieve the kubeconfig secret from the cluster's namespace on hive
-	ns, err := getClusterNamespace(c.Client, cluster.ID())
+	ns, err := getClusterNamespace(c.kubeCli, cluster.ID())
 	if err != nil {
 		return err
 	}
@@ -372,7 +346,7 @@ func (c *clusterAccessOptions) getKubeConfigSecret(ns corev1.Namespace) (corev1.
 	if err != nil {
 		return corev1.Secret{}, err
 	}
-	err = c.Client.List(context.TODO(), &secretList, &kclient.ListOptions{Namespace: ns.Name, LabelSelector: selector})
+	err = c.kubeCli.List(context.TODO(), &secretList, &kclient.ListOptions{Namespace: ns.Name, LabelSelector: selector})
 	if err != nil {
 		return corev1.Secret{}, err
 	}
@@ -437,7 +411,7 @@ func (c *clusterAccessOptions) createJumpPod(kubeconfigSecret corev1.Secret, clu
 			},
 		},
 	}
-	err := c.Client.Create(context.TODO(), &deploy)
+	err := c.kubeCli.Create(context.TODO(), &deploy)
 	return deploy, err
 }
 
@@ -448,7 +422,7 @@ func (c *clusterAccessOptions) waitForJumpPod(pod corev1.Pod, interval time.Dura
 		Namespace: pod.Namespace,
 	}
 	return wait.PollImmediate(interval, timeout, func() (done bool, err error) {
-		err = c.Client.Get(context.TODO(), key, &pod)
+		err = c.kubeCli.Get(context.TODO(), key, &pod)
 		if kerr.IsNotFound(err) {
 			return false, nil
 		} else if err != nil {

--- a/cmd/cluster/access/common.go
+++ b/cmd/cluster/access/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/openshift/osdctl/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -12,6 +13,12 @@ import (
 const (
 	hiveNSLabelKey = "api.openshift.com/id"
 )
+
+// accessOptions defines the struct for running accessOwner command
+type access struct {
+	reason  string
+	kubeCli *k8s.LazyClient
+}
 
 // isAffirmative returns true if the provided input indicates user agreement ("y" or "Y")
 func isAffirmative(input string) bool {

--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -7,13 +7,13 @@ import (
 	"github.com/openshift/osdctl/cmd/cluster/resize"
 	"github.com/openshift/osdctl/cmd/cluster/support"
 	"github.com/openshift/osdctl/internal/utils/globalflags"
+	"github.com/openshift/osdctl/pkg/k8s"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewCmdCluster implements the cluster utility
-func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+func NewCmdCluster(streams genericclioptions.IOStreams, client *k8s.LazyClient, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	clusterCmd := &cobra.Command{
 		Use:               "cluster",
 		Short:             "Provides information for a specified cluster",
@@ -22,18 +22,18 @@ func NewCmdCluster(streams genericclioptions.IOStreams, flags *genericclioptions
 	}
 
 	clusterCmd.AddCommand(newCmdHealth())
-	clusterCmd.AddCommand(newCmdLoggingCheck(streams, flags, globalOpts))
-	clusterCmd.AddCommand(newCmdOwner(streams, flags, globalOpts))
-	clusterCmd.AddCommand(support.NewCmdSupport(streams, flags, client, globalOpts))
+	clusterCmd.AddCommand(newCmdLoggingCheck(streams, globalOpts))
+	clusterCmd.AddCommand(newCmdOwner(streams, globalOpts))
+	clusterCmd.AddCommand(support.NewCmdSupport(streams, client, globalOpts))
 	clusterCmd.AddCommand(resize.NewCmdResize())
 	clusterCmd.AddCommand(newCmdResync())
 	clusterCmd.AddCommand(newCmdContext())
 	clusterCmd.AddCommand(newCmdTransferOwner(streams, globalOpts))
-	clusterCmd.AddCommand(access.NewCmdAccess(streams, flags))
-	clusterCmd.AddCommand(newCmdResizeControlPlaneNode(streams, flags, globalOpts))
+	clusterCmd.AddCommand(access.NewCmdAccess(streams, client))
+	clusterCmd.AddCommand(newCmdResizeControlPlaneNode(streams, globalOpts))
 	clusterCmd.AddCommand(newCmdCpd())
 	clusterCmd.AddCommand(newCmdCheckBannedUser())
-	clusterCmd.AddCommand(newCmdValidatePullSecret(client, flags))
+	clusterCmd.AddCommand(newCmdValidatePullSecret(client))
 	clusterCmd.AddCommand(newCmdEtcdHealthCheck())
 	clusterCmd.AddCommand(newCmdEtcdMemberReplacement())
 	clusterCmd.AddCommand(newCmdFromInfraId(globalOpts))

--- a/cmd/cluster/cpd.go
+++ b/cmd/cluster/cpd.go
@@ -79,7 +79,7 @@ func (o *cpdOptions) run() error {
 	// Check if DNS is ready, exit out if not
 	if !cluster.Status().DNSReady() {
 		fmt.Println("DNS not ready. Investigate reasons using the dnszones CR in the cluster namespace:")
-		fmt.Printf("oc get dnszones -n uhc-production-%s -o yaml --as backplane-cluster-admin\n", o.clusterID)
+		fmt.Printf("ocm-backplane elevate \"$(read -p 'Enter reason for elevation:' REASON && echo $REASON)\" -- get dnszones -n uhc-production-%s -o yaml\n", o.clusterID)
 		return nil
 	}
 

--- a/cmd/cluster/loggingcheck.go
+++ b/cmd/cluster/loggingcheck.go
@@ -27,8 +27,8 @@ type loggingCheckOptions struct {
 }
 
 // newCmdLoggingCheck implements the loggingCheck command to show the logging support status of a cluster
-func newCmdLoggingCheck(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
-	ops := newloggingCheckOptions(streams, flags, globalOpts)
+func newCmdLoggingCheck(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newloggingCheckOptions(streams, globalOpts)
 	loggingCheckCmd := &cobra.Command{
 		Use:               "logging-check",
 		Short:             "Shows the logging support status of a specified cluster",
@@ -44,7 +44,7 @@ func newCmdLoggingCheck(streams genericclioptions.IOStreams, flags *genericcliop
 	return loggingCheckCmd
 }
 
-func newloggingCheckOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *loggingCheckOptions {
+func newloggingCheckOptions(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *loggingCheckOptions {
 	return &loggingCheckOptions{
 		IOStreams:     streams,
 		GlobalOptions: globalOpts,

--- a/cmd/cluster/owner.go
+++ b/cmd/cluster/owner.go
@@ -27,8 +27,8 @@ type ownerOptions struct {
 }
 
 // newCmdOwner return a new command
-func newCmdOwner(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
-	ops := newOwnerOptions(streams, flags, globalOpts)
+func newCmdOwner(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newOwnerOptions(streams, globalOpts)
 	ownerCmd := &cobra.Command{
 		Use:               "owner",
 		Short:             "List the clusters owned by the user (can be specified to any user, not only yourself)",
@@ -44,7 +44,7 @@ func newCmdOwner(streams genericclioptions.IOStreams, flags *genericclioptions.C
 	return ownerCmd
 }
 
-func newOwnerOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *ownerOptions {
+func newOwnerOptions(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *ownerOptions {
 	return &ownerOptions{
 		IOStreams:     streams,
 		GlobalOptions: globalOpts,

--- a/cmd/cluster/resize/cmd.go
+++ b/cmd/cluster/resize/cmd.go
@@ -25,6 +25,9 @@ type Resize struct {
 
 	// instanceType is the type of instance being resized to
 	instanceType string
+
+	// reason to provide for elevation (eg: OHHS/PG ticket)
+	reason string
 }
 
 func NewCmdResize() *cobra.Command {
@@ -84,7 +87,10 @@ func (r *Resize) New() error {
 		return err
 	}
 
-	hac, err := k8s.NewAsBackplaneClusterAdmin(hive.ID(), client.Options{Scheme: scheme})
+	hac, err := k8s.NewAsBackplaneClusterAdmin(hive.ID(), client.Options{Scheme: scheme}, []string{
+		r.reason,
+		fmt.Sprintf("Need elevation for %s cluster in order to resize it to instance type %s", r.clusterId, r.instanceType),
+	}...)
 	if err != nil {
 		return err
 	}

--- a/cmd/cluster/resizecontrolplanenode.go
+++ b/cmd/cluster/resizecontrolplanenode.go
@@ -21,22 +21,27 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	bpelevate "github.com/openshift/backplane-cli/pkg/elevate"
 )
 
 // resizeControlPlaneNodeOptions defines the struct for running resizeControlPlaneNode command
 type resizeControlPlaneNodeOptions struct {
-	clusterID      string
-	node           string
-	newMachineType string
-	cluster        *cmv1.Cluster
+	clusterID         string
+	node              string
+	newMachineType    string
+	reason            string
+	cluster           *cmv1.Cluster
+	kubeconfig        string
+	kubeconfigDefined bool
 
 	genericclioptions.IOStreams
 	GlobalOptions *globalflags.GlobalOptions
 }
 
 // This command requires to previously be logged in via `ocm login`
-func newCmdResizeControlPlaneNode(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *cobra.Command {
-	ops := newResizeControlPlaneNodeOptions(streams, flags, globalOpts)
+func newCmdResizeControlPlaneNode(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newResizeControlPlaneNodeOptions(streams, globalOpts)
 	resizeControlPlaneNodeCmd := &cobra.Command{
 		Use:               "resize-control-plane-node",
 		Short:             "Resize a control plane node. Requires previous login to the api server via `ocm login` and being tunneled to the backplane.",
@@ -47,17 +52,19 @@ func newCmdResizeControlPlaneNode(streams genericclioptions.IOStreams, flags *ge
 			cmdutil.CheckErr(ops.run())
 		},
 	}
-	resizeControlPlaneNodeCmd.Flags().StringVar(&ops.node, "node", "", "The control plane node to resize (e.g. ip-127.0.0.1.eu-west-2.compute.internal)")
-	resizeControlPlaneNodeCmd.Flags().StringVar(&ops.newMachineType, "machine-type", "", "The target AWS machine type to resize to (e.g. m5.2xlarge)")
 	resizeControlPlaneNodeCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "c", "", "The internal ID of the cluster to perform actions on")
+	resizeControlPlaneNodeCmd.Flags().StringVar(&ops.newMachineType, "machine-type", "", "The target AWS machine type to resize to (e.g. m5.2xlarge)")
+	resizeControlPlaneNodeCmd.Flags().StringVar(&ops.node, "node", "", "The control plane node to resize (e.g. ip-127.0.0.1.eu-west-2.compute.internal)")
+	resizeControlPlaneNodeCmd.Flags().StringVar(&ops.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)")
 	resizeControlPlaneNodeCmd.MarkFlagRequired("cluster-id")
-	resizeControlPlaneNodeCmd.MarkFlagRequired("node")
 	resizeControlPlaneNodeCmd.MarkFlagRequired("machine-type")
+	resizeControlPlaneNodeCmd.MarkFlagRequired("node")
+	resizeControlPlaneNodeCmd.MarkFlagRequired("reason")
 
 	return resizeControlPlaneNodeCmd
 }
 
-func newResizeControlPlaneNodeOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, globalOpts *globalflags.GlobalOptions) *resizeControlPlaneNodeOptions {
+func newResizeControlPlaneNodeOptions(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *resizeControlPlaneNodeOptions {
 	return &resizeControlPlaneNodeOptions{
 		IOStreams:     streams,
 		GlobalOptions: globalOpts,
@@ -97,6 +104,9 @@ func (o *resizeControlPlaneNodeOptions) complete(cmd *cobra.Command, _ []string)
 		As this command is idempotent, it will just fail on a later stage if e.g. the
 		machine type doesn't exist and can be re-run.
 	*/
+
+	// As RunElevate is unsetting KUBECONFIG, we need to store its value in order to redefine it if it was defined
+	o.kubeconfig, o.kubeconfigDefined = os.LookupEnv("KUBECONFIG")
 
 	return nil
 }
@@ -187,6 +197,7 @@ func withRetrySkipCancelOption(fn func() error, procedure string) (err error) {
 	if err == nil {
 		return nil
 	}
+	fmt.Println(err)
 	dialogResponse, err := retrySkipCancelDialog(procedure)
 	if err != nil {
 		return err
@@ -233,26 +244,39 @@ func retrySkipForceCancelDialog(procedure string) (optionsDialogResponse, error)
 	}
 }
 
-func forceDrainNode(nodeID string) error {
+func (o *resizeControlPlaneNodeOptions) forceDrainNode(nodeID string, reason string) error {
 	printer.PrintlnGreen("Force draining node... This might take a minute or two...")
-	cmd := fmt.Sprintf("oc adm drain %s --ignore-daemonsets --delete-emptydir-data --force --as backplane-cluster-admin", nodeID)
-	output, err := exec.Command("bash", "-c", cmd).CombinedOutput()
+	err := bpelevate.RunElevate([]string{
+		fmt.Sprintf("%s - Elevate required to force drain node for resizecontroleplanenode", reason),
+		"adm drain --ignore-daemonsets --delete-emptydir-data --force", nodeID,
+	})
+	// As RunElevate is unsetting KUBECONFIG, we need to redefined it if it was defined
+	if o.kubeconfigDefined {
+		os.Setenv("KUBECONFIG", o.kubeconfig)
+	}
+
 	if err != nil {
-		return fmt.Errorf("failed to force drain:\n%s", strings.TrimSpace(string(output)))
+		return fmt.Errorf("failed to force drain:\n%s", err)
 	}
 	return nil
 }
 
-func drainNode(nodeID string) error {
+func (o *resizeControlPlaneNodeOptions) drainNode(nodeID string, reason string) error {
 	printer.PrintlnGreen("Draining node", nodeID)
 
 	// TODO: replace subprocess call with API call
-	cmd := fmt.Sprintf("oc adm drain %s --ignore-daemonsets --delete-emptydir-data --as backplane-cluster-admin", nodeID)
-	output, err := exec.Command("bash", "-c", cmd).CombinedOutput()
+	err := bpelevate.RunElevate([]string{
+		fmt.Sprintf("%s - Elevate required to drain node for resizecontroleplanenode", reason),
+		"adm drain --ignore-daemonsets --delete-emptydir-data", nodeID,
+	})
+	// As RunElevate is unsetting KUBECONFIG, we need to redefined it if it was defined
+	if o.kubeconfigDefined {
+		os.Setenv("KUBECONFIG", o.kubeconfig)
+	}
 
 	if err != nil {
 		fmt.Println("Failed to drain node:")
-		fmt.Println(strings.TrimSpace(string(output)))
+		fmt.Println(err)
 
 		dialogResponse, err := retrySkipForceCancelDialog("draining node")
 		if err != nil {
@@ -261,11 +285,11 @@ func drainNode(nodeID string) error {
 
 		switch dialogResponse {
 		case Retry:
-			return drainNode(nodeID)
+			return o.drainNode(nodeID, reason)
 		case Skip:
 			fmt.Println("Skipping node drain")
 		case Force:
-			err = withRetrySkipCancelOption(func() error { return forceDrainNode(nodeID) }, "force draining")
+			err = withRetrySkipCancelOption(func() error { return o.forceDrainNode(nodeID, reason) }, "force draining")
 			if err != nil {
 				return err
 			}
@@ -380,12 +404,18 @@ func getNodeAwsInstanceData(ctx context.Context, node string, awsClient resizeCo
 	return machineName, awsInstanceID, nil
 }
 
-func patchMachineType(machine string, machineType string) error {
+func (o *resizeControlPlaneNodeOptions) patchMachineType(machine string, machineType string, reason string) error {
 	printer.PrintlnGreen("Patching machine type of machine", machine, "to", machineType)
-	cmd := `oc -n openshift-machine-api patch machine ` + machine + ` --patch "{\"spec\":{\"providerSpec\":{\"value\":{\"instanceType\":\"` + machineType + `\"}}}}" --type merge --as backplane-cluster-admin`
-	output, err := exec.Command("bash", "-c", cmd).CombinedOutput()
+	err := bpelevate.RunElevate([]string{
+		fmt.Sprintf("%s - Elevate required to patch machine type of machine %s to %s", reason, machine, machineType),
+		`-n openshift-machine-api patch machine`, machine, `--patch "{\"spec\":{\"providerSpec\":{\"value\":{\"instanceType\":\"` + machineType + `\"}}}}" --type merge`,
+	})
+	// As RunElevate is unsetting KUBECONFIG, we need to redefined it if it was defined
+	if o.kubeconfigDefined {
+		os.Setenv("KUBECONFIG", o.kubeconfig)
+	}
 	if err != nil {
-		return fmt.Errorf("Could not patch machine type:\n%s", strings.TrimSpace(string(output)))
+		return fmt.Errorf("Could not patch machine type:\n%s", err)
 	}
 	return nil
 }
@@ -418,7 +448,7 @@ func (o *resizeControlPlaneNodeOptions) run() error {
 
 	// drain node with oc adm drain <node> --ignore-daemonsets --delete-emptydir-data
 	// drainNode has its own retry dialog.
-	err = drainNode(o.node)
+	err = o.drainNode(o.node, o.reason)
 	if err != nil {
 		return err
 	}
@@ -466,7 +496,7 @@ func (o *resizeControlPlaneNodeOptions) run() error {
 	fmt.Println() // Add an empty line for better output formatting
 
 	// Patch node machine to update .spec
-	err = withRetryCancelOption(func() error { return patchMachineType(machineName, o.newMachineType) }, "patch machine type")
+	err = withRetryCancelOption(func() error { return o.patchMachineType(machineName, o.newMachineType, o.reason) }, "patch machine type")
 	if err != nil {
 		fmt.Println("Control plane node resized but could not patch machine .spec.")
 		return err

--- a/cmd/cluster/support/cmd.go
+++ b/cmd/cluster/support/cmd.go
@@ -12,7 +12,7 @@ import (
 // osdctl cluster support status
 // osdctl cluster support create --summary="" --reason=""
 // osdctl cluster support delete --reason=""
-func NewCmdSupport(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+func NewCmdSupport(streams genericclioptions.IOStreams, client client.Client, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	supportCmd := &cobra.Command{
 		Use:               "support",
 		Short:             "Cluster Support",

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -83,14 +83,14 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 
 	// add sub commands
 	rootCmd.AddCommand(aao.NewCmdAao(kubeClient))
-	rootCmd.AddCommand(account.NewCmdAccount(streams, kubeFlags, kubeClient, globalOpts))
-	rootCmd.AddCommand(cluster.NewCmdCluster(streams, kubeFlags, kubeClient, globalOpts))
-	rootCmd.AddCommand(hive.NewCmdHive(streams, kubeFlags, kubeClient))
+	rootCmd.AddCommand(account.NewCmdAccount(streams, kubeClient, globalOpts))
+	rootCmd.AddCommand(cluster.NewCmdCluster(streams, kubeClient, globalOpts))
+	rootCmd.AddCommand(hive.NewCmdHive(streams, kubeClient))
 	rootCmd.AddCommand(newCmdCompletion())
 	rootCmd.AddCommand(env.NewCmdEnv())
 	rootCmd.AddCommand(jumphost.NewCmdJumphost())
 	rootCmd.AddCommand(mc.NewCmdMC())
-	rootCmd.AddCommand(network.NewCmdNetwork(streams, kubeFlags, kubeClient))
+	rootCmd.AddCommand(network.NewCmdNetwork(streams, kubeClient))
 	rootCmd.AddCommand(servicelog.NewCmdServiceLog())
 	rootCmd.AddCommand(org.NewCmdOrg())
 	rootCmd.AddCommand(sts.NewCmdSts())

--- a/cmd/common/helpers.go
+++ b/cmd/common/helpers.go
@@ -2,9 +2,14 @@ package common
 
 import (
 	"context"
+	"fmt"
 
+	bplogin "github.com/openshift/backplane-cli/cmd/ocm-backplane/login"
+	bpconfig "github.com/openshift/backplane-cli/pkg/cli/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -26,4 +31,31 @@ func UpdateSecret(kubeClient client.Client, secretName string, secretNamespace s
 	}
 
 	return nil
+}
+
+// If some elevationReasons are provided, then the config will be elevated with user backplane-cluster-admin
+func GetKubeConfigAndClient(clusterID string, elevationReasons ...string) (client.Client, *rest.Config, *kubernetes.Clientset, error) {
+	bp, err := bpconfig.GetBackplaneConfiguration()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to load backplane-cli config: %v", err)
+	}
+	var kubeconfig *rest.Config
+	if len(elevationReasons) == 0 {
+		kubeconfig, err = bplogin.GetRestConfig(bp, clusterID)
+	} else {
+		kubeconfig, err = bplogin.GetRestConfigAsUser(bp, clusterID, "backplane-cluster-admin", elevationReasons...)
+	}
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	// create the clientset
+	clientset, err := kubernetes.NewForConfig(kubeconfig)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	kubeCli, err := client.New(kubeconfig, client.Options{})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return kubeCli, kubeconfig, clientset, err
 }

--- a/cmd/hive/clusterdeployment/cmd.go
+++ b/cmd/hive/clusterdeployment/cmd.go
@@ -8,7 +8,7 @@ import (
 )
 
 // NewCmdClusterDeployment implements the base cluster deployment command
-func NewCmdClusterDeployment(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
+func NewCmdClusterDeployment(streams genericclioptions.IOStreams, client client.Client) *cobra.Command {
 	cdCmd := &cobra.Command{
 		Use:               "clusterdeployment",
 		Short:             "cluster deployment related utilities",
@@ -17,8 +17,8 @@ func NewCmdClusterDeployment(streams genericclioptions.IOStreams, flags *generic
 		DisableAutoGenTag: true,
 	}
 
-	cdCmd.AddCommand(newCmdList(streams, flags, client))
-	cdCmd.AddCommand(newCmdListResources(streams, flags, client))
+	cdCmd.AddCommand(newCmdList(streams, client))
+	cdCmd.AddCommand(newCmdListResources(streams, client))
 	return cdCmd
 }
 

--- a/cmd/hive/clusterdeployment/list.go
+++ b/cmd/hive/clusterdeployment/list.go
@@ -16,8 +16,8 @@ import (
 const hiveVersionMajorMinorPatchLabel string = "hive.openshift.io/version-major-minor-patch"
 
 // newCmdList implements the list command to list cluster deployment crs
-func newCmdList(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
-	ops := newListOptions(streams, flags, client)
+func newCmdList(streams genericclioptions.IOStreams, client client.Client) *cobra.Command {
+	ops := newListOptions(streams, client)
 	listCmd := &cobra.Command{
 		Use:               "list",
 		Short:             "List cluster deployment crs",
@@ -34,14 +34,12 @@ func newCmdList(streams genericclioptions.IOStreams, flags *genericclioptions.Co
 
 // listOptions defines the struct for running list command
 type listOptions struct {
-	flags *genericclioptions.ConfigFlags
 	genericclioptions.IOStreams
 	kubeCli client.Client
 }
 
-func newListOptions(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *listOptions {
+func newListOptions(streams genericclioptions.IOStreams, client client.Client) *listOptions {
 	return &listOptions{
-		flags:     flags,
 		IOStreams: streams,
 		kubeCli:   client,
 	}

--- a/cmd/hive/clusterdeployment/list_test.go
+++ b/cmd/hive/clusterdeployment/list_test.go
@@ -7,13 +7,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	mockk8s "github.com/openshift/osdctl/cmd/hive/clusterdeployment/mock/k8s"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 func TestListCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
 	mockCtrl := gomock.NewController(t)
-	kubeFlags := genericclioptions.NewConfigFlags(false)
 	testCases := []struct {
 		title       string
 		option      *listOptions
@@ -22,7 +20,6 @@ func TestListCmdComplete(t *testing.T) {
 		{
 			title: "succeed",
 			option: &listOptions{
-				flags:   kubeFlags,
 				kubeCli: mockk8s.NewMockClient(mockCtrl),
 			},
 			errExpected: false,

--- a/cmd/hive/clusterdeployment/listresources.go
+++ b/cmd/hive/clusterdeployment/listresources.go
@@ -19,8 +19,8 @@ import (
 )
 
 // newCmdList implements the list command to list
-func newCmdListResources(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
-	l := newListResources(streams, flags, client)
+func newCmdListResources(streams genericclioptions.IOStreams, client client.Client) *cobra.Command {
+	l := newListResources(streams, client)
 	lrCmd := &cobra.Command{
 		Use:               "listresources",
 		Short:             "List all resources on a hive cluster related to a given cluster",
@@ -38,7 +38,6 @@ func newCmdListResources(streams genericclioptions.IOStreams, flags *genericclio
 
 // listOptions defines the struct for running list command
 type ListResources struct {
-	flags *genericclioptions.ConfigFlags
 	genericclioptions.IOStreams
 
 	ClusterDeployment     hivev1.ClusterDeployment
@@ -56,9 +55,8 @@ type Printer interface {
 	Flush() error
 }
 
-func newListResources(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *ListResources {
+func newListResources(streams genericclioptions.IOStreams, client client.Client) *ListResources {
 	return &ListResources{
-		flags:     flags,
 		IOStreams: streams,
 		P:         printer.NewTablePrinter(streams.Out, 20, 1, 3, ' '),
 		KubeCli:   client,

--- a/cmd/hive/clustersync.go
+++ b/cmd/hive/clustersync.go
@@ -77,7 +77,7 @@ const (
 )
 
 // NewCmdList implements the list command to list cluster deployment crs
-func NewCmdClusterSyncFailures(streams genericclioptions.IOStreams, _ *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
+func NewCmdClusterSyncFailures(streams genericclioptions.IOStreams, client client.Client) *cobra.Command {
 	opts := &clusterSyncFailuresOptions{
 		IOStreams: streams,
 		kubeCli:   client,

--- a/cmd/hive/cmd.go
+++ b/cmd/hive/cmd.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewCmdHive implements the base hive command
-func NewCmdHive(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
+func NewCmdHive(streams genericclioptions.IOStreams, client client.Client) *cobra.Command {
 	hiveCmd := &cobra.Command{
 		Use:               "hive",
 		Short:             "hive related utilities",
@@ -17,8 +17,8 @@ func NewCmdHive(streams genericclioptions.IOStreams, flags *genericclioptions.Co
 		DisableAutoGenTag: true,
 	}
 
-	hiveCmd.AddCommand(NewCmdClusterSyncFailures(streams, flags, client))
-	hiveCmd.AddCommand(cd.NewCmdClusterDeployment(streams, flags, client))
+	hiveCmd.AddCommand(NewCmdClusterSyncFailures(streams, client))
+	hiveCmd.AddCommand(cd.NewCmdClusterDeployment(streams, client))
 	return hiveCmd
 }
 

--- a/cmd/network/cmd.go
+++ b/cmd/network/cmd.go
@@ -2,13 +2,14 @@ package network
 
 import (
 	"fmt"
+
+	"github.com/openshift/osdctl/pkg/k8s"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewCmdNetwork implements the base cluster deployment command
-func NewCmdNetwork(streams genericclioptions.IOStreams, flags *genericclioptions.ConfigFlags, client client.Client) *cobra.Command {
+func NewCmdNetwork(streams genericclioptions.IOStreams, client *k8s.LazyClient) *cobra.Command {
 	netCmd := &cobra.Command{
 		Use:               "network",
 		Short:             "network related utilities",
@@ -16,7 +17,7 @@ func NewCmdNetwork(streams genericclioptions.IOStreams, flags *genericclioptions
 		DisableAutoGenTag: true,
 	}
 
-	netCmd.AddCommand(newCmdPacketCapture(streams, flags, client))
+	netCmd.AddCommand(newCmdPacketCapture(streams, client))
 	netCmd.AddCommand(NewCmdValidateEgress())
 	return netCmd
 }

--- a/cmd/network/packet-capture_test.go
+++ b/cmd/network/packet-capture_test.go
@@ -4,23 +4,18 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 func TestPacketCaptureCmdComplete(t *testing.T) {
 	g := NewGomegaWithT(t)
-	kubeFlags := genericclioptions.NewConfigFlags(false)
 	testCases := []struct {
 		title       string
 		option      *packetCaptureOptions
 		errExpected bool
 	}{
 		{
-			title: "succeed",
-			option: &packetCaptureOptions{
-				flags: kubeFlags,
-			},
+			title:       "succeed",
+			option:      &packetCaptureOptions{},
 			errExpected: false,
 		},
 	}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -10,12 +10,51 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type lazyClientInitializerInterface interface {
+	initialize(s *LazyClient)
+}
+
+type lazyClientInitializer struct {
+	lazyClientInitializerInterface
+}
+
+func (b *lazyClientInitializer) initialize(s *LazyClient) {
+	configLoader := s.flags.ToRawKubeConfigLoader()
+	cfg, err := configLoader.ClientConfig()
+	if err != nil {
+		//The stub is to allow commands that don't need a connection to a Kubernetes cluster.
+		//We'll produce a warning and the stub itself will error when a command is trying to use it.
+		panic(s.err())
+	}
+	if len(s.userName) > 0 || len(s.elevationReasons) > 0 {
+		if len(s.userName) == 0 {
+			s.userName = "backplane-cluster-admin"
+		}
+		impersonationConfig := rest.ImpersonationConfig{
+			UserName: s.userName,
+		}
+		if len(s.elevationReasons) > 0 {
+			impersonationConfig.Extra = map[string][]string{"reason": s.elevationReasons}
+		}
+		cfg.Impersonate = impersonationConfig
+	}
+
+	s.client, err = client.New(cfg, client.Options{})
+	if err != nil {
+		panic(s.err())
+	}
+}
+
 type LazyClient struct {
-	client client.Client
-	flags  *genericclioptions.ConfigFlags
+	lazyClientInitializer lazyClientInitializerInterface
+	client                client.Client
+	flags                 *genericclioptions.ConfigFlags
+	userName              string
+	elevationReasons      []string
 }
 
 // GroupVersionKindFor implements client.Client.
@@ -76,30 +115,23 @@ func (s *LazyClient) SubResource(subResource string) client.SubResourceClient {
 	return s.getClient().SubResource(subResource)
 }
 
-func NewClient(flags *genericclioptions.ConfigFlags) client.Client {
-	return &LazyClient{nil, flags}
+func (s *LazyClient) Impersonate(userName string, elevationReasons ...string) {
+	if s.client != nil {
+		panic("cannot impersonate a client which has been already initialized")
+	}
+	s.userName = userName
+	s.elevationReasons = elevationReasons
+}
+
+func NewClient(flags *genericclioptions.ConfigFlags) *LazyClient {
+	return &LazyClient{&lazyClientInitializer{}, nil, flags, "", nil}
 }
 
 func (s *LazyClient) getClient() client.Client {
 	if s.client == nil {
-		s.initialize()
+		s.lazyClientInitializer.initialize(s)
 	}
 	return s.client
-}
-
-func (s *LazyClient) initialize() {
-	configLoader := s.flags.ToRawKubeConfigLoader()
-	cfg, err := configLoader.ClientConfig()
-	if err != nil {
-		//The stub is to allow commands that don't need a connection to a Kubernetes cluster.
-		//We'll produce a warning and the stub itself will error when a command is trying to use it.
-		panic(s.err())
-	}
-
-	s.client, err = client.New(cfg, client.Options{})
-	if err != nil {
-		panic(s.err())
-	}
 }
 
 func New(clusterID string, options client.Options) (client.Client, error) {
@@ -116,13 +148,13 @@ func New(clusterID string, options client.Options) (client.Client, error) {
 	return client.New(cfg, options)
 }
 
-func NewAsBackplaneClusterAdmin(clusterID string, options client.Options) (client.Client, error) {
+func NewAsBackplaneClusterAdmin(clusterID string, options client.Options, elevationReasons ...string) (client.Client, error) {
 	bp, err := bpconfig.GetBackplaneConfiguration()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load backplane-cli config: %v", err)
 	}
 
-	cfg, err := bplogin.GetRestConfigAsUser(bp, clusterID, "backplane-cluster-admin")
+	cfg, err := bplogin.GetRestConfigAsUser(bp, clusterID, "backplane-cluster-admin", elevationReasons...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/k8s/fakeClient.go
+++ b/pkg/k8s/fakeClient.go
@@ -1,0 +1,18 @@
+package k8s
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type fakeLazyClientInitializer struct {
+	lazyClientInitializerInterface
+	fakeClientBuilder *fake.ClientBuilder
+}
+
+func (b *fakeLazyClientInitializer) initialize(s *LazyClient) {
+	s.client = b.fakeClientBuilder.Build()
+}
+
+func NewFakeClient(clientBuilder *fake.ClientBuilder) *LazyClient {
+	return &LazyClient{&fakeLazyClientInitializer{fakeClientBuilder: clientBuilder}, nil, nil, "", nil}
+}


### PR DESCRIPTION
The goal of this PR is to add reason argument to commands that require elevation.
--as backplane-cluster-admin will not be required in that case as is part of elevation procedure
When osdctl is just displaying comand oc with --as backplane-cluster-admin, those commands are replaced by ocm-backplane elevate.
On top of that this PR will do some cleanup to not propagate flags to commands, as this is not used anymore and could end in "dirty" usage.
Finally, cluster resize infra will now display proper old instance type