### PR TITLE
Fix bug to allow posting bulk servicelogs

### DIFF
--- a/cmd/servicelog/common.go
+++ b/cmd/servicelog/common.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	userParameterNames, userParameterValues, filterParams []string
+	userParameterNames, userParameterValues []string
 )
 
 const (


### PR DESCRIPTION
* Don't append cluster-id searches to ocm filter searches
* Added examples and documentation to the command
* Adjusted the command to return errors instead of relying on log.Fatal
* Only check for recent servicelogs when there's only one cluster

Current state:
```bash
❯ osdctl servicelog post -q "cloud_provider.id is 'gcp' and ccs.enabled is 'true' and managed='true' and state is 'ready'" -t tmp.json                           
error: no cluster identifier has been found 
```
which was happening because the command was attempting to `CheckServiceLogsLastHour()` even though no cluster id was supplied to the command. So I moved this check to after the list of clusters have been identified and only check if we're sending servicelogs to one cluster because the output would be too much for bulk service logs.

After:
```bash
❯ ~/git/openshift/osdctl/osdctl servicelog post -q "cloud_provider.id is 'gcp' and ccs.enabled is 'true' and managed='true' and state is 'ready'" -t tmp.json
The current version () is different than the latest released version (v0.24.0).It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.
Continue? (y/N): y
INFO[0003] The following clusters match the given parameters: 
Name                ID                                 State               Version             Cloud Provider      Region
${CLUSTERS}

INFO[0003] The following template will be sent:
${TEMPLATE}      
```

Noticed while working on [OSD-20579](https://issues.redhat.com//browse/OSD-20579)