### PR TITLE
Add doc_references field to servicelogs

### DIFF
--- a/internal/servicelog/template.go
+++ b/internal/servicelog/template.go
@@ -7,15 +7,16 @@ import (
 
 // Message is the base template structure
 type Message struct {
-	Severity       string `json:"severity"`
-	ServiceName    string `json:"service_name"`
-	ClusterUUID    string `json:"cluster_uuid,omitempty"`
-	ClusterID      string `json:"cluster_id,omitempty"`
-	Summary        string `json:"summary"`
-	Description    string `json:"description"`
-	InternalOnly   bool   `json:"internal_only"`
-	EventStreamID  string `json:"event_stream_id"`
-	SubscriptionID string `json:"subscription_id,omitempty"`
+	Severity       string   `json:"severity"`
+	ServiceName    string   `json:"service_name"`
+	ClusterUUID    string   `json:"cluster_uuid,omitempty"`
+	ClusterID      string   `json:"cluster_id,omitempty"`
+	Summary        string   `json:"summary"`
+	Description    string   `json:"description"`
+	InternalOnly   bool     `json:"internal_only"`
+	EventStreamID  string   `json:"event_stream_id"`
+	SubscriptionID string   `json:"subscription_id,omitempty"`
+	DocReferences  []string `json:"doc_references"`
 }
 
 func (m *Message) GetSeverity() string {
@@ -52,6 +53,10 @@ func (m *Message) GetEventStreamID() string {
 
 func (m *Message) GetSubscriptionID() string {
 	return m.SubscriptionID
+}
+
+func (m *Message) GetDocReferences() []string {
+	return m.DocReferences
 }
 
 func (m *Message) ReplaceWithFlag(variable, value string) {


### PR DESCRIPTION
Adds doc_references to servicelogs.

This work supports https://issues.redhat.com/browse/SDE-3653

```
$ ./osdctl servicelog post 28idnvi2ijne88a6nof30spvtvd2lrjv -t https://raw.githubusercontent.com/openshift/managed-notifications/62753642c541bab51c27d5724506201b6ac23352/osd/cluster_stuck.json -p STATE=xyz
...
INFO[0002] The following template will be sent:         
{
  "severity":"Error",
  "service_name":"SREManualAction",
  "summary":"Action required: Cluster Stuck",
  "description":"SRE has observed that your cluster is stuck in an xyz state. If you need assistance to fully remove and cleanup your cluster, please open a support case.",
  "internal_only":false,
  "event_stream_id":"",
  "doc_references": [
    "https://access.redhat.com/support/cases/new"
  ]
}
Continue? (y/N): y
...

$ osdctl servicelog list 28idnvi2ijne88a6nof30spvtvd2lrjv
{
  "items": [
  ...
      {
      "cluster_id":"28idnvi2ijne88a6nof30spvtvd2lrjv",
      "cluster_uuid":"4e5b3876-97ee-46c6-8e9a-813b857758a6",
      "created_at":"2024-02-08T05:04:51.454038Z",
      "created_by":"avulaj",
      "description":"SRE has observed that your cluster is stuck in an xyz state. If you need assistance to fully remove and cleanup your cluster, please open a support case.",
      "doc_references": [
        "https://access.redhat.com/support/cases/new"
      ],
      "event_stream_id":"2c4R6rE85UJD5jNV3wpKPvepk7X",
      "href":"/api/service_logs/v1/cluster_logs/2c4R6nQrVsZo96M6ZWeMYfPIXHw",
      "id":"2c4R6nQrVsZo96M6ZWeMYfPIXHw",
      "internal_only":false,
      "kind":"LogEntry",
      "log_type":"General Notification",
      "service_name":"SREManualAction",
      "severity":"Error",
      "summary":"Action required: Cluster Stuck",
      "timestamp":"2024-02-08T05:04:51.453981Z",
      "username":""
    }
  ],
...
}
```