### PR TITLE
Allow multi-word justifications for resizing control plane service logs

### DIFF
--- a/cmd/cluster/resizecontrolplanenode.go
+++ b/cmd/cluster/resizecontrolplanenode.go
@@ -503,9 +503,17 @@ func promptGenerateResizeSL(clusterID string, newMachineType string) error {
 	fmt.Print("Please enter the JIRA ID that corresponds to this resize: ")
 	_, _ = fmt.Scanln(&jiraID)
 
+	// Use a bufio Scanner since the fmt package cannot read in more than one word
 	var justification string
 	fmt.Print("Please enter a justification for the resize: ")
-	_, _ = fmt.Scanln(&justification)
+	scanner := bufio.NewScanner(os.Stdin)
+	if scanner.Scan() {
+		justification = scanner.Text()
+	} else {
+		errText := "failed to read justification text, send service log manually"
+		_, _ = fmt.Fprintf(os.Stderr, errText)
+		return errors.New(errText)
+	}
 
 	postCmd := servicelog.PostCmdOptions{
 		Template: "https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/controlplane_resized.json",


### PR DESCRIPTION
`fmt.Scanln` doesn't actually... "scan line" like it says. It'll only read the first word until white space. The proper solution is to use `bufio.NewScanner` instead as shown in this PR.