### PR TITLE
Make the version check a warning

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -145,11 +145,6 @@ func versionCheck() {
 	}
 
 	if utils.Version != strings.TrimPrefix(latestVersion, "v") {
-		fmt.Printf("The current version (%s) is different than the latest released version (%s).", utils.Version, latestVersion)
-		fmt.Println("It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.")
-
-		if !utils.ConfirmPrompt() {
-			os.Exit(0)
-		}
+		fmt.Printf("Warning: The current version (%s) is different than the latest released version (%s). It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.\n\n", utils.Version, latestVersion)
 	}
 }


### PR DESCRIPTION
This change removes the blocking prompt in osdctl when the currently running version is not the latest on GitHub. It will print a warning only.