### PR TITLE
Sort service logs by timestamp descending

### DIFF
--- a/cmd/servicelog/common.go
+++ b/cmd/servicelog/common.go
@@ -112,7 +112,8 @@ func FetchServiceLogs(clusterID string, allMessages bool, internalOnly bool) (*v
 func sendClusterLogsListRequest(ocmClient *sdk.Connection, cluster *cmv1.Cluster, allMessages bool, internalMessages bool) (*v1.ClustersClusterLogsListResponse, error) {
 	request := ocmClient.ServiceLogs().V1().Clusters().ClusterLogs().List().
 		Parameter("cluster_id", cluster.ID()).
-		Parameter("cluster_uuid", cluster.ExternalID())
+		Parameter("cluster_uuid", cluster.ExternalID()).
+		Parameter("orderBy", "timestamp desc")
 
 	var searchQuery string
 	if !allMessages {

--- a/cmd/servicelog/list.go
+++ b/cmd/servicelog/list.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	slv1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
@@ -60,6 +61,7 @@ func ListServiceLogs(clusterID string, allMessages bool, internalOnly bool) erro
 
 func printServiceLogResponse(response *slv1.ClustersClusterLogsListResponse) error {
 	entryViews := logEntryToView(response.Items().Slice())
+	slices.Reverse(entryViews)
 	view := LogEntryResponseView{
 		Items: entryViews,
 		Kind:  "ClusterLogList",


### PR DESCRIPTION
[OSD-21624](https://issues.redhat.com/browse/OSD-21624)

Currently, osdctl servicelog list will output results from oldest to newest. This is great when there are only a few service logs for a cluster, as the most recent messages will be at the bottom of the console output.

Where we run into a problem is when a cluster has a large number of service logs to the point where they don't all fit on one page. In these instances, the newest service logs will not be output at all.

This PR updates the command to return the service logs from OCM ordered by descending timestamp, but still output the results such that the newest service logs are at the bottom of the output.