### PR TITLE
Fix promote saas command for backplane-api

### DIFF
--- a/cmd/promote/git/app_interface.go
+++ b/cmd/promote/git/app_interface.go
@@ -119,6 +119,15 @@ func GetCurrentGitHashFromAppInterface(saarYamlFile []byte, serviceName string) 
 				}
 			}
 		}
+	} else if strings.Contains(service.Name, "saas-backplane-api") {
+		for _, resourceTemplate := range service.ResourceTemplates {
+			for _, target := range resourceTemplate.Targets {
+				if strings.Contains(target.Namespace["$ref"], "backplanep") {
+					currentGitHash = target.Ref
+					break
+				}
+			}
+		}
 	} else {
 		for _, resourceTemplate := range service.ResourceTemplates {
 			if !strings.Contains(resourceTemplate.Name, "package") {


### PR DESCRIPTION
Fixes the ability to run `osdctl promote saas --serviceName backplane-api --osd`.

Currently, running the above would give the following output:
```
$ osdctl promote saas --serviceName saas-backplane-api --osd
### Checking if service saas-backplane-api exists ###
Service saas-backplane-api found
SAAS Directory: /Users/alexvulaj/Workspace/app-interface/data/services/backplane/cicd/saas/saas-backplane-api.yaml
Error while promoting service: failed to get current git hash or service repo: production namespace not found for service saas-backplane-api
```
This is because none of the if-statements in the affected code match the structure of the backplane saas file in app-interface.

This PR adds a new clause to check for the correct fields.