### PR TITLE
[OSD-22074] Bug Fix for osdctl alerts silence add fails to run pod

### DIFF
--- a/cmd/alerts/silence/add_silence.go
+++ b/cmd/alerts/silence/add_silence.go
@@ -87,7 +87,8 @@ func AddAllSilence(clusterID, duration, comment, username, clustername string, k
 
 	output, err := ExecInPod(kubeconfig, clientset, addCmd)
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal("Exiting the program")
+		return
 	}
 
 	formattedOutput := strings.Replace(output, "\n", " ", -1)
@@ -109,8 +110,8 @@ func AddAlertNameSilence(alertID []string, duration, comment, username string, k
 
 		output, err := ExecInPod(kubeconfig, clientset, addCmd)
 		if err != nil {
-			fmt.Println(err)
-			continue
+			log.Fatal("Exiting the program")
+			return
 		}
 
 		formattedOutput := strings.Replace(output, "\n", " ", -1)

--- a/cmd/alerts/silence/add_silence.go
+++ b/cmd/alerts/silence/add_silence.go
@@ -36,11 +36,9 @@ func NewCmdAddSilence() *cobra.Command {
 	}
 
 	cmd.Flags().StringSliceVar(&addSilenceCmd.alertID, "alertname", []string{}, "alertname (comma-separated)")
-	cmd.Flags().StringVarP(&addSilenceCmd.comment, "comment", "c", "silence alert", "add comment about silence")
-	cmd.Flags().StringVarP(&addSilenceCmd.duration, "duration", "d", "15d", "add duration for silence") //default duration set to 15 days
-	cmd.Flags().BoolVarP(&addSilenceCmd.all, "all", "a", false, "add silences for all alert")
-	cmd.Flags().StringVar(&addSilenceCmd.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)")
-	_ = cmd.MarkFlagRequired("reason")
+	cmd.Flags().StringVarP(&addSilenceCmd.comment, "comment", "c", "Adding silence using the osdctl alert command", "add comment about silence")
+	cmd.Flags().StringVarP(&addSilenceCmd.duration, "duration", "d", "15d", "adding duration for silence") //default duration set to 15 days
+	cmd.Flags().BoolVarP(&addSilenceCmd.all, "all", "a", false, "adding silences for all alert")
 
 	return cmd
 }

--- a/cmd/alerts/silence/add_silence.go
+++ b/cmd/alerts/silence/add_silence.go
@@ -36,7 +36,7 @@ func NewCmdAddSilence() *cobra.Command {
 	}
 
 	cmd.Flags().StringSliceVar(&addSilenceCmd.alertID, "alertname", []string{}, "alertname (comma-separated)")
-	cmd.Flags().StringVarP(&addSilenceCmd.comment, "comment", "c", "", "add comment about silence")
+	cmd.Flags().StringVarP(&addSilenceCmd.comment, "comment", "c", "silence alert", "add comment about silence")
 	cmd.Flags().StringVarP(&addSilenceCmd.duration, "duration", "d", "15d", "add duration for silence") //default duration set to 15 days
 	cmd.Flags().BoolVarP(&addSilenceCmd.all, "all", "a", false, "add silences for all alert")
 	cmd.Flags().StringVar(&addSilenceCmd.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)")
@@ -110,6 +110,7 @@ func AddAlertNameSilence(alertID []string, duration, comment, username string, k
 		output, err := ExecInPod(kubeconfig, clientset, addCmd)
 		if err != nil {
 			fmt.Println(err)
+			continue
 		}
 
 		formattedOutput := strings.Replace(output, "\n", " ", -1)

--- a/cmd/alerts/silence/common.go
+++ b/cmd/alerts/silence/common.go
@@ -25,20 +25,22 @@ func ExecInPod(kubeconfig *rest.Config, clientset *kubernetes.Clientset, cmd []s
 	var cmdOutput string
 	var err error
 
-	// Attempt to execute with the primary pod
 	cmdOutput, err = ExecWithPod(kubeconfig, clientset, PrimaryPod, cmd)
 	if err == nil {
-		return cmdOutput, nil // Successfully executed
+		return cmdOutput, nil
 	}
 
-	// If execution with primary pod fails, try with the secondary pod
+	fmt.Printf("Execution with alertmanager-main-0 failed: %v\n", err)
+
+	fmt.Println("Attempting with alertmanger-main-1")
 	cmdOutput, err = ExecWithPod(kubeconfig, clientset, SecondaryPod, cmd)
 	if err == nil {
-		return cmdOutput, nil // Successfully executed
+		return cmdOutput, nil
 	}
 
-	// If execution with both pods fails, print error message
-	fmt.Println("Exec Failed. Please put silence manually")
+	fmt.Printf("Execution with alertmanager-main-1 failed: %v\n", err)
+
+	fmt.Println("Execution Failed with alertmanager-main-0 and alertmanager-main-1. Please put silence manually")
 	return "", err
 }
 

--- a/cmd/alerts/silence/common.go
+++ b/cmd/alerts/silence/common.go
@@ -16,16 +16,35 @@ const (
 	AccountNamespace = "openshift-monitoring"
 	ContainerName    = "alertmanager"
 	LocalHostUrl     = "http://localhost:9093"
-	PodName          = "alertmanager-main-0"
+	PrimaryPod       = "alertmanager-main-0"
+	SecondaryPod     = "alertmanager-main-1"
 )
 
 // ExecInPod is designed to execute a command inside a Kubernetes pod and capture its output.
 func ExecInPod(kubeconfig *rest.Config, clientset *kubernetes.Clientset, cmd []string) (string, error) {
-	// request is constructed using the Kubernetes clientset to interact with the Kubernetes API.
-	// It specifies that the request is for executing a command inside a pod (SubResource("exec")).
-	req := clientset.CoreV1().RESTClient().Post().Resource("pods").Name(PodName).
+	var cmdOutput string
+	var err error
+
+	// Attempt to execute with the primary pod
+	cmdOutput, err = ExecWithPod(kubeconfig, clientset, PrimaryPod, cmd)
+	if err == nil {
+		return cmdOutput, nil // Successfully executed
+	}
+
+	// If execution with primary pod fails, try with the secondary pod
+	cmdOutput, err = ExecWithPod(kubeconfig, clientset, SecondaryPod, cmd)
+	if err == nil {
+		return cmdOutput, nil // Successfully executed
+	}
+
+	// If execution with both pods fails, print error message
+	fmt.Println("Exec Failed. Please put silence manually")
+	return "", err
+}
+
+func ExecWithPod(kubeconfig *rest.Config, clientset *kubernetes.Clientset, podName string, cmd []string) (string, error) {
+	req := clientset.CoreV1().RESTClient().Post().Resource("pods").Name(podName).
 		Namespace(AccountNamespace).SubResource("exec")
-	//various options for executing the command inside the pod
 	option := &corev1.PodExecOptions{
 		Container: ContainerName,
 		Command:   cmd,
@@ -36,30 +55,23 @@ func ExecInPod(kubeconfig *rest.Config, clientset *kubernetes.Clientset, cmd []s
 	}
 
 	req.VersionedParams(option, scheme.ParameterCodec)
-	//SPDY executor is created using the Kubernetes configuration and the request URL.
-	//This executor will be responsible for executing the command inside the pod.
 
 	exec, err := remotecommand.NewSPDYExecutor(kubeconfig, "POST", req.URL())
 	if err != nil {
-		return "", fmt.Errorf("failed to create SPDY executor: %w", err)
+		return "", fmt.Errorf("failed to create executor: %w", err)
 	}
 
 	capture := &cluster.LogCapture{}
 	errorCapture := &cluster.LogCapture{}
-	//capture and errorCapture are instances of cluster.LogCapture,
-	//which are used to capture the stdout and stderr output of the executed command.
-
 	err = exec.StreamWithContext(context.TODO(), remotecommand.StreamOptions{
 		Stdin:  nil,
 		Stdout: capture,
 		Stderr: errorCapture,
 		Tty:    false,
 	})
-
 	if err != nil {
 		return "", fmt.Errorf("failed to stream with context: %w", err)
 	}
 
-	cmdOutput := capture.GetStdOut()
-	return cmdOutput, nil
+	return capture.GetStdOut(), nil
 }

--- a/cmd/alerts/silence/common.go
+++ b/cmd/alerts/silence/common.go
@@ -19,11 +19,13 @@ const (
 	PodName          = "alertmanager-main-0"
 )
 
+// ExecInPod is designed to execute a command inside a Kubernetes pod and capture its output.
 func ExecInPod(kubeconfig *rest.Config, clientset *kubernetes.Clientset, cmd []string) (string, error) {
-
+	// request is constructed using the Kubernetes clientset to interact with the Kubernetes API.
+	// It specifies that the request is for executing a command inside a pod (SubResource("exec")).
 	req := clientset.CoreV1().RESTClient().Post().Resource("pods").Name(PodName).
 		Namespace(AccountNamespace).SubResource("exec")
-
+	//various options for executing the command inside the pod
 	option := &corev1.PodExecOptions{
 		Container: ContainerName,
 		Command:   cmd,
@@ -34,6 +36,8 @@ func ExecInPod(kubeconfig *rest.Config, clientset *kubernetes.Clientset, cmd []s
 	}
 
 	req.VersionedParams(option, scheme.ParameterCodec)
+	//SPDY executor is created using the Kubernetes configuration and the request URL.
+	//This executor will be responsible for executing the command inside the pod.
 
 	exec, err := remotecommand.NewSPDYExecutor(kubeconfig, "POST", req.URL())
 	if err != nil {
@@ -42,6 +46,8 @@ func ExecInPod(kubeconfig *rest.Config, clientset *kubernetes.Clientset, cmd []s
 
 	capture := &cluster.LogCapture{}
 	errorCapture := &cluster.LogCapture{}
+	//capture and errorCapture are instances of cluster.LogCapture,
+	//which are used to capture the stdout and stderr output of the executed command.
 
 	err = exec.StreamWithContext(context.TODO(), remotecommand.StreamOptions{
 		Stdin:  nil,


### PR DESCRIPTION

```
$osdctl alert silence add 2axxxxx --alertname Watchdog --duration 1d 
 
Alert Watchdog has been silenced with id "9a1e660c-817f-4e72-a158-3d2780ee66ca " for duration of 1d by user "mixxxx_rh_sre_xxxx" 

$ osdctl alert silence list 2axxxx   

Silence Information:
  SilenceID:		9a1e660c-817f-4e72-a158-3d2780ee66ca
  Status:		active
  Created By:		nobody
  Starts At:		2024-04-10T12:04:06.191Z
  Ends At:		2024-04-11T12:04:06.180Z
  Comment:		silence alert
  AlertName:		Watchdog
```

