### PR TITLE
OSD-22368: Using the KMS key defined for the cluster instead of 'aws/ebs' when calling osd-network-verifier

### DIFF
--- a/cmd/network/verification.go
+++ b/cmd/network/verification.go
@@ -291,6 +291,16 @@ func (e *EgressVerification) generateAWSValidateEgressInput(ctx context.Context,
 	}
 
 	if e.cluster != nil {
+		// If a KMS key is defined for the cluster, use it as the default aws/ebs key may not exist
+		aws := e.cluster.AWS()
+
+		if aws != nil {
+			if kmsKeyArn, isOk := aws.GetKMSKeyArn(); isOk {
+				e.log.Info(ctx, "using KMS key defined for the cluster: %s", kmsKeyArn)
+				input.AWS.KmsKeyID = kmsKeyArn
+			}
+		}
+
 		// If the cluster has a cluster-wide proxy, configure it
 		if e.cluster.Proxy() != nil && !e.cluster.Proxy().Empty() {
 			input.Proxy.HttpProxy = e.cluster.Proxy().HTTPProxy()


### PR DESCRIPTION
See [OHSS-33098](https://issues.redhat.com/browse/OHSS-33098) for more details.

Essentially the KMS key defined for the cluster needs to be passed to `osd-network-verifier` so the EC2 instance used to test the egresses can boot in case the `aws/ebs` KMS key does not exist.