### PR TITLE
avoid nil exception when awsMachine do not have InstanceIds

### DIFF
--- a/cmd/cluster/cleanup_leaked_ec2.go
+++ b/cmd/cluster/cleanup_leaked_ec2.go
@@ -133,7 +133,9 @@ func (c *cleanup) RemediateOCPBUGS23174(ctx context.Context) error {
 
 	expectedInstances := map[string]bool{}
 	for _, awsmachine := range awsmachines.Items {
-		expectedInstances[*awsmachine.Spec.InstanceID] = true
+		if awsmachine.Spec.InstanceID != nil {
+			expectedInstances[*awsmachine.Spec.InstanceID] = true
+		}
 	}
 	log.Printf("expected instances: %v", expectedInstances)
 


### PR DESCRIPTION
In some cases, awsMachines can do not have any InstanceID (seems when they fail to create), and in that case we should just ship those machine to avoid nil pointer exception.