### PR TITLE
Improve messaging around cluster uninstallation expectations

### DIFF
--- a/cmd/cluster/cleanup_leaked_ec2.go
+++ b/cmd/cluster/cleanup_leaked_ec2.go
@@ -173,7 +173,14 @@ func (c *cleanup) RemediateOCPBUGS23174(ctx context.Context) error {
 				return fmt.Errorf("failed to automatically cleanup EC2 instances: %v", err)
 			}
 
-			log.Printf("success - the cluster should be uninstalled soon")
+			switch c.cluster.State() {
+			case cmv1.ClusterStateError:
+				fallthrough
+			case cmv1.ClusterStateUninstalling:
+				log.Printf("success - cluster was in state: %s and should be uninstalled soon", c.cluster.State())
+			default:
+				log.Printf("success - cluster is in state: %s", c.cluster.State())
+			}
 			return nil
 		}
 	}


### PR DESCRIPTION
The cluster will only be uninstalled if it already was in an error/uninstalling state. The command does not initiate uninstalls by itself, so this is mostly to clear up any confusion that may arise.

[OHSS-34009](https://issues.redhat.com//browse/OHSS-34009)