### PR TITLE
terminate only running and stopped instances when cleaning up leaked ec2 

### DIFF
--- a/cmd/cluster/cleanup_leaked_ec2.go
+++ b/cmd/cluster/cleanup_leaked_ec2.go
@@ -142,8 +142,10 @@ func (c *cleanup) RemediateOCPBUGS23174(ctx context.Context) error {
 	resp, err := c.awsClient.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
 		Filters: []types.Filter{
 			{
+				// We don't want to terminate pending because they would just be started and might not have been picked up by the MC yet.
+				// Importantly we also don't want to count terminated instances as leaked, as it causes confusion.
 				Name:   aws.String("instance-state-name"),
-				Values: []string{"running","stopped"},
+				Values: []string{"running", "stopped"},
 			},
 			{
 				Name:   aws.String("tag:red-hat-managed"),

--- a/cmd/cluster/cleanup_leaked_ec2.go
+++ b/cmd/cluster/cleanup_leaked_ec2.go
@@ -142,6 +142,10 @@ func (c *cleanup) RemediateOCPBUGS23174(ctx context.Context) error {
 	resp, err := c.awsClient.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
 		Filters: []types.Filter{
 			{
+				Name:   aws.String("instance-state-name"),
+				Values: []string{"running","stopped"},
+			},
+			{
 				Name:   aws.String("tag:red-hat-managed"),
 				Values: []string{"true"},
 			},

--- a/cmd/cluster/cleanup_leaked_ec2.go
+++ b/cmd/cluster/cleanup_leaked_ec2.go
@@ -130,7 +130,7 @@ func (c *cleanup) RemediateOCPBUGS23174(ctx context.Context) error {
 				// We don't want to terminate pending because they would just be started and might not have been picked up by the MC yet.
 				// Importantly we also don't want to count terminated instances as leaked, as it causes confusion.
 				Name:   aws.String("instance-state-name"),
-				Values: []string{"running", "stopped"},
+				Values: []string{string(types.InstanceStateNameRunning), string(types.InstanceStateNameStopped)},
 			},
 			{
 				Name:   aws.String("tag:red-hat-managed"),


### PR DESCRIPTION
When runing the cleanup_leaked_ec2 we were not checking the state of the detected leaked instance, so we may detect leaked instances and terminate them, some instance in state terminated or pending (for instance that just have been added - I saw it).

So, in that PR we will just search for instances in running and stopped state. Like that we also exlude stopping and shuting-down states, that we should leave and take...

Also we now get the list of awsMachine after having retrieve the list of Instances to avoid to have an instance created after we have retrieved the list of awsMachines.

ps: replacing #552 which was failing test