### PR TITLE
[OSD-22777]Update ami lookup filter for jumphost creation

### DIFF
--- a/cmd/jumphost/create.go
+++ b/cmd/jumphost/create.go
@@ -364,7 +364,7 @@ func (j *jumphostConfig) findLatestJumphostAMI(ctx context.Context) (string, err
 			},
 			{
 				Name:   aws.String("creation-date"),
-				Values: []string{"2023-*"},
+				Values: []string{"2024-*"},
 			},
 			{
 				Name:   aws.String("description"),

--- a/cmd/jumphost/create.go
+++ b/cmd/jumphost/create.go
@@ -363,10 +363,6 @@ func (j *jumphostConfig) findLatestJumphostAMI(ctx context.Context) (string, err
 				Values: []string{string(types.VolumeTypeGp3)},
 			},
 			{
-				Name:   aws.String("creation-date"),
-				Values: []string{"2024-*"},
-			},
-			{
 				Name:   aws.String("description"),
 				Values: []string{"Amazon Linux 2023 AMI*"},
 			},


### PR DESCRIPTION
This PR fixes an issue in the jumphost creation. Currently, we're limiting the search for AMIs to those that were created in 2023. As we're now a couple of months into 2024, the images that matched that creation date seemed to have all been deprecated and therefore don't show up in the result list anymore.

To make sure that this doesn't cause an issue again in a year, I removed the filter for the creation date. Filtering for non-deprecated images seems to basically behave the same.
