### PR TITLE
Dynamically set OCM connection client from user config

### DIFF
--- a/pkg/utils/ocm.go
+++ b/pkg/utils/ocm.go
@@ -274,6 +274,8 @@ func CreateConnection() (*sdk.Connection, error) {
 	}
 	connectionBuilder.URL(gatewayURL)
 
+	connectionBuilder.Client(config.ClientID, config.ClientSecret)
+
 	connection, err := connectionBuilder.Build()
 
 	if err != nil {


### PR DESCRIPTION
osdctl currently pulls in the client ID/secret from the target config file, but then drops it on the floor and doesn't use it. Because of this, the client used is always `cloud-services/""`. This was fine for the old OCM token structure, but new tokens have a different audience and so will be rejected with the "cloud-services" client ID.

This change dynamically sets the client information when constructing an OCM client so that we don't need to worry about this going forward.