### PR TITLE
refactor infra node resizing command to allow moving resize-control-plane-node

### DIFF
--- a/cmd/cluster/resize/cmd.go
+++ b/cmd/cluster/resize/cmd.go
@@ -1,39 +1,14 @@
 package resize
 
 import (
-	"fmt"
-
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/osdctl/pkg/k8s"
-	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
-
-	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
-	hivev1 "github.com/openshift/hive/apis/hive/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-type Resize struct {
-	client    client.Client
-	hive      client.Client
-	hiveAdmin client.Client
-
-	cluster   *cmv1.Cluster
-	clusterId string
-
-	// instanceType is the type of instance being resized to
-	instanceType string
-
-	// reason to provide for elevation (eg: OHHS/PG ticket)
-	reason string
-}
 
 func NewCmdResize() *cobra.Command {
 	resize := &cobra.Command{
-		Use:  "resize",
-		Args: cobra.NoArgs,
+		Use:   "resize",
+		Short: "resize infra nodes",
+		Args:  cobra.NoArgs,
 	}
 
 	resize.AddCommand(
@@ -41,64 +16,4 @@ func NewCmdResize() *cobra.Command {
 	)
 
 	return resize
-}
-
-func (r *Resize) New() error {
-	scheme := runtime.NewScheme()
-
-	// Register machinev1beta1 for Machines
-	if err := machinev1beta1.Install(scheme); err != nil {
-		return err
-	}
-
-	// Register hivev1 for MachinePools
-	if err := hivev1.AddToScheme(scheme); err != nil {
-		return err
-	}
-
-	if err := corev1.AddToScheme(scheme); err != nil {
-		return err
-	}
-
-	ocmClient, err := utils.CreateConnection()
-	if err != nil {
-		return err
-	}
-	defer ocmClient.Close()
-	cluster, err := utils.GetClusterAnyStatus(ocmClient, r.clusterId)
-	if err != nil {
-		return fmt.Errorf("failed to get OCM cluster info for %s: %s", r.clusterId, err)
-	}
-	r.cluster = cluster
-	r.clusterId = cluster.ID()
-
-	hive, err := utils.GetHiveCluster(cluster.ID())
-	if err != nil {
-		return err
-	}
-
-	c, err := k8s.New(cluster.ID(), client.Options{Scheme: scheme})
-	if err != nil {
-		return err
-	}
-
-	hc, err := k8s.New(hive.ID(), client.Options{Scheme: scheme})
-	if err != nil {
-		return err
-	}
-
-	hac, err := k8s.NewAsBackplaneClusterAdmin(hive.ID(), client.Options{Scheme: scheme}, []string{
-		r.reason,
-		fmt.Sprintf("Need elevation for %s cluster in order to resize it to instance type %s", r.clusterId, r.instanceType),
-	}...)
-	if err != nil {
-		return err
-	}
-
-	r.clusterId = cluster.ID()
-	r.client = c
-	r.hive = hc
-	r.hiveAdmin = hac
-
-	return nil
 }

--- a/cmd/cluster/resize/infra_node_test.go
+++ b/cmd/cluster/resize/infra_node_test.go
@@ -78,7 +78,7 @@ func TestResize_embiggenMachinePool(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			r := &Resize{
+			r := &Infra{
 				cluster:      test.cluster,
 				instanceType: test.override,
 			}


### PR DESCRIPTION
In OSD-23315 the overall plan is to add CPMS-aware control plane resizing to osdctl.

First, I would like to bring `osdctl cluster resize-control-plane-node` underneath `osdctl cluster resize control-plane` next to `osdctl cluster resize infra`, but realized that the current infra resize package has a struct named `Resize` which doesn't make too much sense when it's only relevant for infra resizes.

This PR renames the `Resize` struct to `Infra` in preparation to add a `ControlPlane` struct for resizing control planes, the next PR will move the existing resize control plane command underneath `osdctl cluster resize`, and finally I will be adding a `--cpms` flag so that we can start gathering data on CPMS-assisted resizes.