### PR TITLE
move control plane resize command under osdctl cluster resize

### DIFF
--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -31,7 +31,6 @@ func NewCmdCluster(streams genericclioptions.IOStreams, client *k8s.LazyClient, 
 	clusterCmd.AddCommand(newCmdContext())
 	clusterCmd.AddCommand(newCmdTransferOwner(streams, globalOpts))
 	clusterCmd.AddCommand(access.NewCmdAccess(streams, client))
-	clusterCmd.AddCommand(newCmdResizeControlPlaneNode(streams, globalOpts))
 	clusterCmd.AddCommand(newCmdCpd())
 	clusterCmd.AddCommand(newCmdCheckBannedUser())
 	clusterCmd.AddCommand(newCmdValidatePullSecret(client))

--- a/cmd/cluster/resize/cmd.go
+++ b/cmd/cluster/resize/cmd.go
@@ -7,12 +7,13 @@ import (
 func NewCmdResize() *cobra.Command {
 	resize := &cobra.Command{
 		Use:   "resize",
-		Short: "resize infra nodes",
+		Short: "resize control-plane/infra nodes",
 		Args:  cobra.NoArgs,
 	}
 
 	resize.AddCommand(
 		newCmdResizeInfra(),
+		newCmdResizeControlPlane(),
 	)
 
 	return resize


### PR DESCRIPTION
In [OSD-23315](https://issues.redhat.com//browse/OSD-23315) the overall plan is to add CPMS-aware control plane resizing to osdctl.

#564 renamed the Resize struct to Infra in preparation to add a ControlPlane struct for resizing control planes, this PR moves the existing resize control plane command underneath osdctl cluster resize, and finally I will be adding a --cpms flag so that we can start gathering (opt-in) data on CPMS-assisted resizes.

At a future date, outside the scope of [OSD-23315](https://issues.redhat.com//browse/OSD-23315), the --cpms flag should be come default behavior and the legacy process of resizing one node at a time can be deprecated and removed.