### PR TITLE
OSD-22340: Added unit tests for code in post.go

### DIFF
--- a/cmd/cluster/support/post.go
+++ b/cmd/cluster/support/post.go
@@ -124,11 +124,11 @@ func (p *Post) check() error {
 			return fmt.Errorf("\nIf Template flag is present, --problem, --resolution, --misconfiguration and --evidence flags cannot be used")
 		}
 	} else {
-		if err := validateResolutionString(p.Resolution); err != nil {
-			return err
-		}
 		if p.Problem == "" || p.Resolution == "" || p.Misconfiguration == "" {
 			return fmt.Errorf("\nIn the absence of Template -t flag, --problem, --resolution and --misconfiguration flags are mandatory")
+		}
+		if err := validateResolutionString(p.Resolution); err != nil {
+			return err
 		}
 		if err := p.setup(); err != nil {
 			return err

--- a/cmd/cluster/support/post_test.go
+++ b/cmd/cluster/support/post_test.go
@@ -1,8 +1,15 @@
 package support
 
 import (
+	"crypto/rand"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
@@ -150,4 +157,272 @@ func Test_buildInternalServiceLog(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPostInit(t *testing.T) {
+	p := Post{}
+	p.Init()
+
+	assert.NotNilf(t, userParameterNames, "userParameterNames should not be nil after calling p.Init()")
+	assert.Emptyf(t, userParameterNames, "userParameterNames should have 0 elements after calling p.Init()")
+	assert.NotNilf(t, userParameterValues, "userParameterValues should not be nil after calling p.Init()")
+	assert.Emptyf(t, userParameterValues, "userParameterValues should have 0 elements after calling p.Init()")
+}
+
+func TestPostSetupForProblemValues(t *testing.T) {
+
+	tests := map[string]struct {
+		name, problem string
+		errorExpected bool
+	}{
+		"Valid problem string not ending in punctuation": {problem: "testProblem", errorExpected: false},
+		"Invalid problem string ending in '.'":           {problem: "testProblem.", errorExpected: true},
+		"Invalid problem string ending in '?'":           {problem: "testProblem?", errorExpected: true},
+		"Invalid problem string ending in '!'":           {problem: "testProblem!", errorExpected: true},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			p := Post{Problem: tt.problem, Resolution: "testResolution"}
+			goterr := (p.setup() != nil)
+			assert.Equalf(t, goterr, tt.errorExpected, "Error expected: %v, Got Error: %v", tt.errorExpected, goterr)
+		})
+	}
+}
+func TestPostSetupForResolutionValues(t *testing.T) {
+
+	tests := map[string]struct {
+		problem, resolution string
+		errorExpected       bool
+	}{
+		"Valid resolution string not ending in punctuation": {problem: "testProblem", resolution: "testResolution", errorExpected: false},
+		"Invalid resolution string ending in '.'":           {problem: "testProblem", resolution: "testResolution.", errorExpected: true},
+		"Invalid resolution string ending in '?'":           {problem: "testProblem", resolution: "testResolution?", errorExpected: true},
+		"Invalid resolution string ending in '!'":           {problem: "testProblem", resolution: "testResolution!", errorExpected: true},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			p := Post{Problem: "testProblem", Resolution: tt.resolution}
+			goterr := (p.setup() != nil)
+			assert.Equalf(t, goterr, tt.errorExpected, "Error expected: %v, Got Error: %v", tt.errorExpected, goterr)
+		})
+	}
+}
+
+func TestPostCheckWhenTemplateEmpty(t *testing.T) {
+	tests := []struct {
+		name          string
+		post          Post
+		errorExpected bool
+	}{
+		{
+			name:          "When template is empty, Problem should not empty",
+			post:          Post{Resolution: "test Resolution", Misconfiguration: "test Misconfiguration", Evidence: "test Evidence"},
+			errorExpected: true,
+		},
+		{
+			name:          "When template is empty, Resolution should not be empty",
+			post:          Post{Problem: "test Problem", Misconfiguration: "test Misconfiguration", Evidence: "test Evidence"},
+			errorExpected: true,
+		},
+		{
+			name:          "When template is empty, Misconfiguration should not be empty",
+			post:          Post{Problem: "test Problem", Resolution: "test Resolution", Evidence: "test Evidence"},
+			errorExpected: true,
+		},
+		{
+			name: "When template is empty, Evidence,Misconfiguration,Resolution,Problem are not empty",
+			post: Post{Problem: "test Problem", Resolution: "test Resolution", Misconfiguration: "test Misconfiguration", Evidence: "test Evidence"},
+		},
+		{
+			name:          "When template is empty but Resolution is invalid",
+			post:          Post{Problem: "test Problem", Resolution: "test Resolution.", Misconfiguration: "test Misconfiguration", Evidence: "test Evidence"},
+			errorExpected: true,
+		},
+		{
+			name:          "When template is empty but setup fails",
+			post:          Post{Problem: "test Problem.", Resolution: "test Resolution", Misconfiguration: "test Misconfiguration", Evidence: "test Evidence"},
+			errorExpected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			goterr := (tt.post.check() != nil)
+			assert.Equalf(t, goterr, tt.errorExpected, "Error expected: %v, Got Error: %v", tt.errorExpected, goterr)
+		})
+	}
+
+}
+func TestPostCheckWhenTemplateNotEmpty(t *testing.T) {
+	tests := []struct {
+		name          string
+		post          Post
+		errorExpected bool
+	}{
+		{
+			name:          "When template is not empty, Problem should be empty",
+			post:          Post{Template: "test", Problem: "test Problem"},
+			errorExpected: true,
+		},
+		{
+			name:          "When template is not empty, Resolution should be empty",
+			post:          Post{Template: "test", Resolution: "test Resolution"},
+			errorExpected: true,
+		},
+		{
+			name:          "When template is not empty, Misconfiguration should be empty",
+			post:          Post{Template: "test", Misconfiguration: "test Misconfiguration"},
+			errorExpected: true,
+		},
+		{
+			name:          "When template is not empty, Evidence should be empty",
+			post:          Post{Template: "test", Evidence: "test Evidence"},
+			errorExpected: true,
+		},
+		{
+			name: "When template is not empty, Evidence,Misconfiguration,Resolution,Problem are empty",
+			post: Post{Template: "test"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			goterr := (tt.post.check() != nil)
+			assert.Equalf(t, goterr, tt.errorExpected, "Error expected: %v, Got Error: %v", tt.errorExpected, goterr)
+		})
+	}
+}
+
+func TestPostRunCheckFails(t *testing.T) {
+	post := Post{
+		Template: "test",
+		Problem:  "test",
+	}
+
+	err := post.Run("testclusterid")
+
+	assert.NotNilf(t, err, "Should get error in post.check()")
+}
+
+func TestPostRunClusterKeyInvalidFails(t *testing.T) {
+	post := Post{
+		Template: "test",
+	}
+
+	err := post.Run("testclusterid?")
+
+	assert.NotNilf(t, err, "Should get error in post.check()")
+}
+
+func TestPostBuildLimitedSupportTemplate(t *testing.T) {
+	templateFile, err := createTemplateFile(t)
+
+	if err != nil {
+		t.Fatal("Could not create temperory Template File")
+	}
+
+	post := Post{
+		Template:       templateFile,
+		TemplateParams: []string{"severity=medium"},
+	}
+
+	lsr, err := post.buildLimitedSupportTemplate()
+	assert.NotNil(t, lsr)
+	assert.Nil(t, err)
+
+}
+
+func TestPostParseUserParameters(t *testing.T) {
+	post := Post{
+		TemplateParams: []string{"severity=medium"},
+	}
+	post.parseUserParameters()
+	assert.Contains(t, userParameterNames, "${severity}")
+	assert.Contains(t, userParameterValues, "medium")
+}
+
+func TestPostReadTemplate(t *testing.T) {
+	templateFile, err := createTemplateFile(t)
+
+	if err != nil {
+		t.Fatal("Could not create temperory Template File")
+	}
+
+	post := Post{
+		Template:       templateFile,
+		TemplateParams: []string{"severity=medium"},
+	}
+
+	tf := post.readTemplate()
+	assert.NotNil(t, tf)
+	assert.Equal(t, tf.Details, "Severity is ${severity}")
+
+}
+
+func TestPostAccessFile_Url(t *testing.T) {
+	post := Post{}
+
+	res := "Hello, client"
+	want := []byte(res)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, res)
+	}))
+	defer ts.Close()
+
+	got, err := post.accessFile(ts.URL)
+	assert.Nil(t, err)
+	assert.NotNil(t, got)
+	assert.Equal(t, want, got)
+
+}
+
+func TestPostAccessFile_File(t *testing.T) {
+	templateFile, err := createTemplateFile(t)
+
+	if err != nil {
+		t.Fatal("Could not create temperory Template File")
+	}
+
+	post := Post{
+		Template: templateFile,
+	}
+
+	b, err := post.accessFile(templateFile)
+	assert.Nil(t, err)
+	assert.NotNil(t, b)
+
+	b, err = post.accessFile(templateFile + ".invalid")
+	assert.Nil(t, b)
+	assert.NotNil(t, err)
+
+	dir := t.TempDir()
+	b, err = post.accessFile(dir)
+	assert.Nil(t, b)
+	assert.NotNil(t, err)
+}
+
+func TestPrintLimitedSupportReason(t *testing.T) {
+	post := Post{
+		Misconfiguration: cloud,
+		Problem:          "test problem cloud",
+		Resolution:       "test resolution cloud",
+	}
+
+	limitedSupport, err := post.buildLimitedSupport()
+	if assert.NoError(t, err) {
+		err = printLimitedSupportReason(limitedSupport)
+		assert.NoError(t, err)
+	}
+}
+
+func createTemplateFile(t *testing.T) (path string, err error) {
+	dir := t.TempDir()
+	path = filepath.Join(dir, "tempFile")
+	content := `{"details": "Severity is ${severity}"}`
+	a := make([]byte, 10)
+	rand.Read(a)
+	err = os.WriteFile(path, []byte(content), 0644)
+	return
 }


### PR DESCRIPTION
I have added as many unit tests I could with minimal changes to the code for `post.go`. 
`common.go` has only one function and could not write tests for it without changing the code.