### PR TITLE
OSD-23744: make context cmd quicker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/deckarep/golang-set v1.8.0
 	github.com/fatih/color v1.16.0
 	github.com/golang/mock v1.6.0
+	github.com/google/uuid v1.5.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.33.0
@@ -121,7 +122,6 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.5.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect

--- a/pkg/utils/delay_tracker.go
+++ b/pkg/utils/delay_tracker.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+type DelayTracker struct {
+	verbose bool
+	action  string
+	start   time.Time
+}
+
+func StartDelayTracker(verbose bool, action string) *DelayTracker {
+	dt := DelayTracker{
+		verbose: verbose,
+		action:  action,
+	}
+	if dt.verbose {
+		dt.start = time.Now()
+		fmt.Fprintf(os.Stderr, "Getting %s...\n", dt.action)
+	}
+	return &dt
+}
+
+func (dt *DelayTracker) End() {
+	if dt.verbose {
+		fmt.Fprintf(os.Stderr, "Got %s within %s\n", dt.action, time.Since(dt.start))
+	}
+}

--- a/pkg/utils/ocm.go
+++ b/pkg/utils/ocm.go
@@ -147,7 +147,7 @@ func GenerateQuery(clusterIdentifier string) string {
 	// Based on the format of the clusterIdentifier, we can know what it is, so we can simplify ocm query and make it quicker
 	if regexp.MustCompile(`^[0-9a-z]{32}$`).MatchString(clusterIdentifier) {
 		return strings.TrimSpace(fmt.Sprintf("(id = '%[1]s')", clusterIdentifier))
-	} else if regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89aAbB][0-9a-f]{3}-[0-9a-f]{12}$`).MatchString(clusterIdentifier) {
+	} else if regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`).MatchString(clusterIdentifier) {
 		return strings.TrimSpace(fmt.Sprintf("(external_id = '%[1]s')", clusterIdentifier))
 	} else {
 		return strings.TrimSpace(fmt.Sprintf("(display_name like '%[1]s')", clusterIdentifier))

--- a/pkg/utils/ocm.go
+++ b/pkg/utils/ocm.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/google/uuid"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
@@ -147,7 +148,7 @@ func GenerateQuery(clusterIdentifier string) string {
 	// Based on the format of the clusterIdentifier, we can know what it is, so we can simplify ocm query and make it quicker
 	if regexp.MustCompile(`^[0-9a-z]{32}$`).MatchString(clusterIdentifier) {
 		return strings.TrimSpace(fmt.Sprintf("(id = '%[1]s')", clusterIdentifier))
-	} else if regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`).MatchString(clusterIdentifier) {
+	} else if _, err := uuid.Parse(clusterIdentifier); err == nil {
 		return strings.TrimSpace(fmt.Sprintf("(external_id = '%[1]s')", clusterIdentifier))
 	} else {
 		return strings.TrimSpace(fmt.Sprintf("(display_name like '%[1]s')", clusterIdentifier))

--- a/pkg/utils/ocm.go
+++ b/pkg/utils/ocm.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -143,7 +144,14 @@ func ApplyFilters(ocmClient *sdk.Connection, filters []string) ([]*cmv1.Cluster,
 
 // GenerateQuery returns an OCM search query to retrieve all clusters matching an expression (ie- "foo%")
 func GenerateQuery(clusterIdentifier string) string {
-	return strings.TrimSpace(fmt.Sprintf("(id like '%[1]s' or external_id like '%[1]s' or display_name like '%[1]s')", clusterIdentifier))
+	// Based on the format of the clusterIdentifier, we can know what it is, so we can simplify ocm query and make it quicker
+	if regexp.MustCompile(`^[0-9a-z]{32}$`).MatchString(clusterIdentifier) {
+		return strings.TrimSpace(fmt.Sprintf("(id = '%[1]s')", clusterIdentifier))
+	} else if regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89aAbB][0-9a-f]{3}-[0-9a-f]{12}$`).MatchString(clusterIdentifier) {
+		return strings.TrimSpace(fmt.Sprintf("(external_id = '%[1]s')", clusterIdentifier))
+	} else {
+		return strings.TrimSpace(fmt.Sprintf("(display_name like '%[1]s')", clusterIdentifier))
+	}
 }
 
 // Finds the OCM Configuration file and returns the path to it

--- a/pkg/utils/ocm_test.go
+++ b/pkg/utils/ocm_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -132,4 +133,29 @@ func TestGetOCMConfigurationTokenAndUrlAndRefreshTokenEnvVarsSet(t *testing.T) {
 	})
 
 	assertConfigValues(t, config, err, expectedUrl, expectedToken, expectedRefreshToken)
+}
+
+func testGenerateQuery(t *testing.T, clusterIdentifier string, expectedType string) {
+	detectedType := strings.Fields(GenerateQuery(clusterIdentifier))[0][1:]
+	if expectedType != detectedType {
+		t.Errorf("identifier %s of type %s is detected as %s", clusterIdentifier, expectedType, detectedType)
+	}
+}
+
+func TestGenerateQueryInternalId(t *testing.T) {
+	testGenerateQuery(t, "261kalm3uob0vegg1c7h9o7r5k9t64ji", "id")
+	testGenerateQuery(t, "261kalm3uob0vegg1c7h9o7r5k9t64j", "display_name")
+	testGenerateQuery(t, "261kalm3uob0vegg1c7h9o7r5k9t64jix", "display_name")
+	testGenerateQuery(t, "261kalm3uob0vegg1c7h9o7r5k9t64jI", "display_name")
+}
+
+func TestGenerateQueryExternalId(t *testing.T) {
+	testGenerateQuery(t, "c1f562af-fb22-42c5-aa07-6848e1eeee9c", "external_id")
+	testGenerateQuery(t, "c1f562af-fb22-42c5-aa07-6848e1eeee9cc", "display_name")
+	testGenerateQuery(t, "c1f562af-fb22-42c5-aa07-6848e1eeee9", "display_name")
+	testGenerateQuery(t, "C1f562af-fb22-42c5-aa07-6848e1eeee9c", "display_name")
+}
+
+func TestGenerateQueryDisplayName(t *testing.T) {
+	testGenerateQuery(t, "hs-mc-773jpgko0", "display_name")
 }

--- a/pkg/utils/ocm_test.go
+++ b/pkg/utils/ocm_test.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"os"
-	"strings"
 	"testing"
 )
 
@@ -135,27 +134,48 @@ func TestGetOCMConfigurationTokenAndUrlAndRefreshTokenEnvVarsSet(t *testing.T) {
 	assertConfigValues(t, config, err, expectedUrl, expectedToken, expectedRefreshToken)
 }
 
-func testGenerateQuery(t *testing.T, clusterIdentifier string, expectedType string) {
-	detectedType := strings.Fields(GenerateQuery(clusterIdentifier))[0][1:]
-	if expectedType != detectedType {
-		t.Errorf("identifier %s of type %s is detected as %s", clusterIdentifier, expectedType, detectedType)
+func TestGenerateQuery(t *testing.T) {
+	tests := []struct {
+		name              string
+		clusterIdentifier string
+		want              string
+	}{
+		{
+			name:              "valid internal ID",
+			clusterIdentifier: "261kalm3uob0vegg1c7h9o7r5k9t64ji",
+			want:              "(id = '261kalm3uob0vegg1c7h9o7r5k9t64ji')",
+		},
+		{
+			name:              "valid wrong internal ID with upper case",
+			clusterIdentifier: "261kalm3uob0vegg1c7h9o7r5k9t64jI",
+			want:              "(display_name like '261kalm3uob0vegg1c7h9o7r5k9t64jI')",
+		},
+		{
+			name:              "valid wrong internal ID too short",
+			clusterIdentifier: "261kalm3uob0vegg1c7h9o7r5k9t64j",
+			want:              "(display_name like '261kalm3uob0vegg1c7h9o7r5k9t64j')",
+		},
+		{
+			name:              "valid wrong internal ID too long",
+			clusterIdentifier: "261kalm3uob0vegg1c7h9o7r5k9t64jix",
+			want:              "(display_name like '261kalm3uob0vegg1c7h9o7r5k9t64jix')",
+		},
+		{
+			name:              "valid external ID",
+			clusterIdentifier: "c1f562af-fb22-42c5-aa07-6848e1eeee9c",
+			want:              "(external_id = 'c1f562af-fb22-42c5-aa07-6848e1eeee9c')",
+		},
+		{
+			name:              "valid display name",
+			clusterIdentifier: "hs-mc-773jpgko0",
+			want:              "(display_name like 'hs-mc-773jpgko0')",
+		},
 	}
-}
-
-func TestGenerateQueryInternalId(t *testing.T) {
-	testGenerateQuery(t, "261kalm3uob0vegg1c7h9o7r5k9t64ji", "id")
-	testGenerateQuery(t, "261kalm3uob0vegg1c7h9o7r5k9t64j", "display_name")
-	testGenerateQuery(t, "261kalm3uob0vegg1c7h9o7r5k9t64jix", "display_name")
-	testGenerateQuery(t, "261kalm3uob0vegg1c7h9o7r5k9t64jI", "display_name")
-}
-
-func TestGenerateQueryExternalId(t *testing.T) {
-	testGenerateQuery(t, "c1f562af-fb22-42c5-aa07-6848e1eeee9c", "external_id")
-	testGenerateQuery(t, "c1f562af-fb22-42c5-aa07-6848e1eeee9cc", "display_name")
-	testGenerateQuery(t, "c1f562af-fb22-42c5-aa07-6848e1eeee9", "display_name")
-	testGenerateQuery(t, "C1f562af-fb22-42c5-aa07-6848e1eeee9c", "display_name")
-}
-
-func TestGenerateQueryDisplayName(t *testing.T) {
-	testGenerateQuery(t, "hs-mc-773jpgko0", "display_name")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GenerateQuery(tt.clusterIdentifier); got != tt.want {
+				t.Errorf("GenerateQuery(%s) = %v, want %v", tt.clusterIdentifier, got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/utils/print.go
+++ b/pkg/utils/print.go
@@ -88,9 +88,8 @@ func PrintJiraIssues(issues []jira.Issue) {
 	fmt.Println(delimiter + name)
 
 	for _, i := range issues {
-		fmt.Printf("[%s](%s/%s): %+v\n", i.Key, i.Fields.Type.Name, i.Fields.Priority.Name, i.Fields.Summary)
+		fmt.Printf("[%s|%s/browse/%s](%s/%s): %+v\n", i.Key, JiraBaseURL, i.Key, i.Fields.Type.Name, i.Fields.Priority.Name, i.Fields.Summary)
 		fmt.Printf("- Created: %s\tStatus: %s\n", time.Time(i.Fields.Created).Format("2006-01-02 15:04"), i.Fields.Status.Name)
-		fmt.Printf("- Link: %s/browse/%s\n\n", JiraBaseURL, i.Key)
 	}
 
 	if len(issues) == 0 {


### PR DESCRIPTION
- Some actions which were done in sequence are now done in parallel
- We are now retrieving the cluster from OCM only one time in the process while it was done twice
- before running the OCM query to retrieve cluster, we now detect first what is the cluster identifier, in order to make the query quicker
- Add verbose output with delay for each action in order to be able to troubleshoot easily when command is taking time

With those changes we move from a frequent context of more than 10s (and sometime much more) to a context of less than 5s most of the time ;)