### PR TITLE
Add version flag to verify egress command for osd-network-verifier version

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,8 +2,10 @@ package utils
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"regexp"
+	"runtime/debug"
 	"strings"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -282,4 +284,20 @@ func StreamErrorln(stream genericclioptions.IOStreams, msg string) {
 func StreamRead(stream genericclioptions.IOStreams, delim byte) (string, error) {
 	reader := bufio.NewReader(stream.In)
 	return reader.ReadString(delim)
+}
+
+var ReadBuildInfo = debug.ReadBuildInfo
+
+func GetDependencyVersion(dependencyPath string) (string, error) {
+	buildInfo, ok := ReadBuildInfo()
+	if !ok {
+		return "", errors.New("failed to parse build info")
+	}
+	for _, dep := range buildInfo.Deps {
+		if dep.Path == dependencyPath {
+			return dep.Version, nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to find version for %v", dependencyPath)
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,68 @@
+package utils
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func mockReadBuildInfo(parseBuildInfoError bool) func() (info *debug.BuildInfo, ok bool) {
+	return func() (*debug.BuildInfo, bool) {
+		info := &debug.BuildInfo{
+			Deps: []*debug.Module{
+				{
+					Path:    "foo",
+					Version: "v1.2.3",
+				},
+				{
+					Path:    "bar",
+					Version: "v4.5.6",
+				},
+			},
+		}
+		return info, !parseBuildInfoError
+	}
+}
+
+func TestGetDependencyVersion(t *testing.T) {
+	tests := []struct {
+		name                string
+		dependencyPath      string
+		parseBuildInfoError bool
+		want                string
+		wantErr             bool
+	}{
+		{
+			name:                "Error parsing build info",
+			parseBuildInfoError: true,
+			wantErr:             true,
+		},
+		{
+			name:           "Dependency not found",
+			dependencyPath: "test",
+			wantErr:        true,
+		},
+		{
+			name:           "Finds and returns version successfully (1)",
+			dependencyPath: "foo",
+			want:           "v1.2.3",
+		},
+		{
+			name:           "Finds and returns version successfully (2)",
+			dependencyPath: "bar",
+			want:           "v4.5.6",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ReadBuildInfo = mockReadBuildInfo(tt.parseBuildInfoError)
+			got, err := GetDependencyVersion(tt.dependencyPath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetDependencyVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetDependencyVersion() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a flag, `--version`, to the `network verify-egress` command that will add the version of osd-network-verifier being used to the top of the log output.

```
2024/06/13 11:24:44 Using osd-network-verifier version v0.4.11
...
```

Resolves [OSD-24004](https://issues.redhat.com//browse/OSD-24004)