### PR TITLE
OSD-22635: use elevation for oc execs

### DIFF
--- a/cmd/alerts/list_alerts.go
+++ b/cmd/alerts/list_alerts.go
@@ -14,6 +14,7 @@ import (
 type alertCmd struct {
 	clusterID  string
 	alertLevel string
+	reason     string
 }
 
 // Labels represents a set of labels associated with an alert.
@@ -55,6 +56,8 @@ func NewCmdListAlerts() *cobra.Command {
 	}
 
 	newCmd.Flags().StringVarP(&alertCmd.alertLevel, "level", "l", "all", "Alert level [warning, critical, firing, pending, all]")
+	newCmd.Flags().StringVar(&alertCmd.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)")
+	_ = newCmd.MarkFlagRequired("reason")
 
 	return newCmd
 }
@@ -72,21 +75,25 @@ func ListAlerts(cmd *alertCmd) {
 
 	if alertLevel == "" {
 		log.Printf("No alert level specified. Defaulting to 'all'")
-		getAlertLevel(clusterID, "all")
+		getAlertLevel(clusterID, "all", cmd.reason)
 	} else if alertLevel == "warning" || alertLevel == "critical" || alertLevel == "firing" || alertLevel == "pending" || alertLevel == "info" || alertLevel == "none" || alertLevel == "all" {
-		getAlertLevel(clusterID, alertLevel)
+		getAlertLevel(clusterID, alertLevel, cmd.reason)
 	} else {
 		fmt.Printf("Invalid alert level \"%s\" \n", alertLevel)
 		return
 	}
 }
 
-func getAlertLevel(clusterID, alertLevel string) {
+func getAlertLevel(clusterID, alertLevel, elevationReason string) {
 	var alerts []Alert
 
 	listAlertCmd := []string{"amtool", "--alertmanager.url", silence.LocalHostUrl, "alert", "-o", "json"}
 
-	_, kubeconfig, clientset, err := common.GetKubeConfigAndClient(clusterID)
+	elevationReasons := []string{
+		elevationReason,
+		"Listing active cluster alerts",
+	}
+	_, kubeconfig, clientset, err := common.GetKubeConfigAndClient(clusterID, elevationReasons...)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/alerts/silence/add_silence.go
+++ b/cmd/alerts/silence/add_silence.go
@@ -18,6 +18,7 @@ type addSilenceCmd struct {
 	duration  string
 	comment   string
 	all       bool
+	reason    string
 }
 
 func NewCmdAddSilence() *cobra.Command {
@@ -38,6 +39,8 @@ func NewCmdAddSilence() *cobra.Command {
 	cmd.Flags().StringVarP(&addSilenceCmd.comment, "comment", "c", "", "add comment about silence")
 	cmd.Flags().StringVarP(&addSilenceCmd.duration, "duration", "d", "15d", "add duration for silence") //default duration set to 15 days
 	cmd.Flags().BoolVarP(&addSilenceCmd.all, "all", "a", false, "add silences for all alert")
+	cmd.Flags().StringVar(&addSilenceCmd.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)")
+	_ = cmd.MarkFlagRequired("reason")
 
 	return cmd
 }
@@ -51,7 +54,12 @@ func AddSilence(cmd *addSilenceCmd) {
 
 	username, clustername := GetUserAndClusterInfo(clusterID)
 
-	_, kubeconfig, clientset, err := common.GetKubeConfigAndClient(clusterID)
+	elevationReasons := []string{
+		cmd.reason,
+		"Add alert silence via osdctl",
+	}
+
+	_, kubeconfig, clientset, err := common.GetKubeConfigAndClient(clusterID, elevationReasons...)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/alerts/silence/clear_silence.go
+++ b/cmd/alerts/silence/clear_silence.go
@@ -15,6 +15,7 @@ type silenceCmd struct {
 	clusterID  string
 	silenceIDs []string
 	all        bool
+	reason     string
 }
 
 func NewCmdClearSilence() *cobra.Command {
@@ -33,6 +34,8 @@ func NewCmdClearSilence() *cobra.Command {
 
 	cmd.Flags().StringSliceVar(&silenceCmd.silenceIDs, "silence-id", []string{}, "silence id (comma-separated)")
 	cmd.Flags().BoolVarP(&silenceCmd.all, "all", "a", false, "clear all silences")
+	cmd.Flags().StringVar(&silenceCmd.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)")
+	_ = cmd.MarkFlagRequired("reason")
 
 	return cmd
 }
@@ -42,7 +45,12 @@ func ClearSilence(cmd *silenceCmd) {
 	silenceIDs := cmd.silenceIDs
 	all := cmd.all
 
-	_, kubeconfig, clientset, err := common.GetKubeConfigAndClient(clusterID)
+	elevationReasons := []string{
+		cmd.reason,
+		"Clear alertmanager silence for a cluster via osdctl",
+	}
+
+	_, kubeconfig, clientset, err := common.GetKubeConfigAndClient(clusterID, elevationReasons...)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/alerts/silence/common.go
+++ b/cmd/alerts/silence/common.go
@@ -3,6 +3,7 @@ package silence
 import (
 	"context"
 	"fmt"
+
 	"github.com/openshift/osdctl/cmd/cluster"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"


### PR DESCRIPTION
As part of 
https://issues.redhat.com/browse/OSD-22635 `oc exec` and `oc debug` [have been gated to backplane cluster admin](https://github.com/openshift/managed-cluster-config/pull/2149). We now need to elevate of `oc exec`. 

SOPs have already been updated for the changes ([see here](https://github.com/openshift/ops-sop/pull/3200)). 

https://issues.redhat.com/browse/OSD-22635