### PR TITLE
Removes requirement that '--problem' strings cannot end in punctuation

### DIFF
--- a/cmd/cluster/support/post.go
+++ b/cmd/cluster/support/post.go
@@ -100,10 +100,6 @@ func (p *Post) Init() error {
 }
 
 func (p *Post) setup() error {
-	switch p.Problem[len(p.Problem)-1:] {
-	case ".", "?", "!":
-		return errors.New("--problem should not end in punctuation")
-	}
 	switch p.Resolution[len(p.Resolution)-1:] {
 	case ".", "?", "!":
 		return errors.New("--resolution should not end in punctuation")


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-24217

---

Allows `--problem` statements in `osdctl cluster support post` to end in punctuation. This is necessary, as, otherwise, the message is formatted like:

```
$ osdctl cluster support post <cluster id> --misconfiguration cloud --problem="Example problem description" --resolution="To fix the problem, follow these instructions" --evidence=linkToEvidence
The following limited support reason will be sent to 2adnr11vlangn9hcrne5r8cr25c9i3u4:
{
  "kind":"LimitedSupportReason",
  "details":"Example problem description To fix the problem, follow these instructions",
  "detection_type":"manual",
  "summary":"Cluster is in Limited Support due to unsupported cloud provider configuration"
}
Continue? (y/N): 
```

rather than 
```
$ osdctl cluster support post <cluster id> --misconfiguration cloud --problem="Example problem description." --resolution="To fix the problem, follow these instructions" --evidence=linkToEvidence
The following limited support reason will be sent to 2adnr11vlangn9hcrne5r8cr25c9i3u4:
{
  "kind":"LimitedSupportReason",
  "details":"Example problem description. To fix the problem, follow these instructions",
  "detection_type":"manual",
  "summary":"Cluster is in Limited Support due to unsupported cloud provider configuration"
}
Continue? (y/N): 
```