### PR TITLE
OSD-24351: permission denied command should also evaluate read-only events

### DIFF
--- a/cmd/cloudtrail/cloudtrail_test.go
+++ b/cmd/cloudtrail/cloudtrail_test.go
@@ -94,9 +94,6 @@ func TestIgnoreListFilter(t *testing.T) {
 
 func TestPermissonDeniedFilter(t *testing.T) {
 
-	var (
-		permissionDeniedErrorStr = ".*Client.UnauthorizedOperation.*"
-	)
 	// Test Case 1 (Ignored)
 	testUsername1 := "RH-SRE-xxx.openshift"
 	testCloudTrailEvent1 := `{"eventVersion": "1.08","userIdentity": {"sessionContext": {"sessionIssuer": {"arn": "arn:aws:iam::123456789012:user/test-12345-6-a7b8-kube-system-capa-controller-manager/RH-SRE-xxx.openshift"}}}, "errorCode": "Client.UnauthorizedOperation"}`
@@ -123,7 +120,7 @@ func TestPermissonDeniedFilter(t *testing.T) {
 
 		filtered, err := ctUtil.ApplyFilters(TestEvents,
 			func(event types.Event) (bool, error) {
-				return isforbiddenEvent(event, permissionDeniedErrorStr)
+				return isforbiddenEvent(event)
 			},
 		)
 		assert.Nil(t, err)
@@ -143,7 +140,7 @@ func TestPermissonDeniedFilter(t *testing.T) {
 
 		filtered, err := ctUtil.ApplyFilters(edgeCaseEvents,
 			func(event types.Event) (bool, error) {
-				return isforbiddenEvent(event, permissionDeniedErrorStr)
+				return isforbiddenEvent(event)
 			},
 		)
 		assert.Nil(t, err)
@@ -162,7 +159,7 @@ func TestPermissonDeniedFilter(t *testing.T) {
 
 		filtered, err := ctUtil.ApplyFilters(edgeCaseEvents,
 			func(event types.Event) (bool, error) {
-				return isforbiddenEvent(event, permissionDeniedErrorStr)
+				return isforbiddenEvent(event)
 			},
 		)
 		assert.Nil(t, err)
@@ -181,7 +178,7 @@ func TestPermissonDeniedFilter(t *testing.T) {
 		expected := []types.Event{}
 		filtered, err := ctUtil.ApplyFilters(edgeCaseEvents,
 			func(event types.Event) (bool, error) {
-				return isforbiddenEvent(event, permissionDeniedErrorStr)
+				return isforbiddenEvent(event)
 			},
 		)
 		assert.EqualErrorf(t, err, "[ERROR] failed to extract raw CloudTrail event details: cannot parse a nil input", "")

--- a/cmd/cloudtrail/pkg/aws/aws.go
+++ b/cmd/cloudtrail/pkg/aws/aws.go
@@ -77,16 +77,19 @@ func Whoami(stsClient sts.Client) (accountArn string, accountId string, err erro
 
 // getWriteEvents retrieves cloudtrail events since the specified time
 // using the provided cloudtrail client and starttime from since flag.
-func GetEvents(cloudtailClient *cloudtrail.Client, startTime time.Time) ([]types.Event, error) {
+func GetEvents(cloudtailClient *cloudtrail.Client, startTime time.Time, writeOnly bool) ([]types.Event, error) {
 
 	alllookupEvents := []types.Event{}
 	input := cloudtrail.LookupEventsInput{
 		StartTime: &startTime,
 		EndTime:   aws.Time(time.Now()),
-		LookupAttributes: []types.LookupAttribute{
+	}
+
+	if writeOnly {
+		input.LookupAttributes = []types.LookupAttribute{
 			{AttributeKey: "ReadOnly",
 				AttributeValue: aws.String("false")},
-		},
+		}
 	}
 
 	paginator := cloudtrail.NewLookupEventsPaginator(cloudtailClient, &input, func(c *cloudtrail.LookupEventsPaginatorOptions) {})

--- a/cmd/cloudtrail/write-events.go
+++ b/cmd/cloudtrail/write-events.go
@@ -149,7 +149,7 @@ func (o *writeEventsOptions) run() error {
 	fmt.Printf("[INFO] Checking write event history since %v for AWS Account %v as %v \n", startTime, accountId, arn)
 	cloudTrailclient := cloudtrail.NewFromConfig(cfg)
 	fmt.Printf("[INFO] Fetching %v Event History...", cfg.Region)
-	queriedEvents, err := ctAws.GetEvents(cloudTrailclient, startTime)
+	queriedEvents, err := ctAws.GetEvents(cloudTrailclient, startTime, true)
 	if err != nil {
 		return err
 	}
@@ -180,7 +180,7 @@ func (o *writeEventsOptions) run() error {
 			HTTPClient:  cfg.HTTPClient,
 		})
 		fmt.Printf("[INFO] Fetching Cloudtrail Global Event History from %v Region...", defaultConfig.Region)
-		lookupOutput, err := ctAws.GetEvents(defaultCloudtrailClient, startTime)
+		lookupOutput, err := ctAws.GetEvents(defaultCloudtrailClient, startTime, true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What?**
Fixes the `osdctl cloudtrail permission-denied-events` command to also evaluate read-only events
Changes the default poll time to 5 minutes, as we are polling significantly more events and are not interested in too much history for this command.

**Why?**
 The idea is that we see any permission denied events, even ready only events being denied is interesting to us. The current functionality only shows write events for which permission was denied.

