### PR TITLE
Prompt when putting critical customers into LS

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -251,7 +251,7 @@ func GetRegistryCredentials(connection *sdk.Connection, accountId string) ([]*am
 func ConfirmPrompt() bool {
 	fmt.Print("Continue? (y/N): ")
 
-	var response string = "n"
+	var response = "n"
 	_, _ = fmt.Scanln(&response) // Erroneous input will be handled by the default case below
 
 	switch strings.ToLower(response) {


### PR DESCRIPTION
When putting a cluster into LS that is owned by a critical customer, the following prompt will show first:
```
WARNING: This cluster is owned by a critical customer. Make sure that an SL has been sent and proactive case opened with the customer. Only continue if there has been no customer response for 24 hours.

See: https://source.redhat.com/groups/public/sre/wiki/defining_limited_support_process_for_osdrosa_for_critical_customers
Continue? (y/N):
```

Details in [OSD-23920](https://issues.redhat.com//browse/OSD-23920)