### PR TITLE
Remove missed use of deprecated SecurityGroupId in verifier test

### DIFF
--- a/cmd/network/verification_test.go
+++ b/cmd/network/verification_test.go
@@ -548,7 +548,7 @@ func compareValidateEgressInput(expected, actual *onv.ValidateEgressInput) bool 
 	}
 
 	if expected.SubnetID != actual.SubnetID ||
-		expected.AWS.SecurityGroupId != actual.AWS.SecurityGroupId {
+		!reflect.DeepEqual(expected.AWS.SecurityGroupIDs, actual.AWS.SecurityGroupIDs) {
 		return false
 	}
 


### PR DESCRIPTION
This was missed in https://github.com/openshift/osdctl/pull/592