### PR TITLE
[OSD-24377] Add new osdctl command to allow silencing alert(s) across a specific org

### DIFF
--- a/cmd/alerts/silence/add_silence.go
+++ b/cmd/alerts/silence/add_silence.go
@@ -69,12 +69,12 @@ func AddSilence(cmd *addSilenceCmd) {
 	if all {
 		err := AddAllSilence(clusterID, duration, comment, username, clustername, kubeconfig, clientset)
 		if err != nil {
-			fmt.Printf("Failed to add silence: %w", err)
+			fmt.Printf("Failed to add silence: %s", err)
 		}
 	} else if len(alertID) > 0 {
 		err := AddAlertNameSilence(alertID, duration, comment, username, kubeconfig, clientset)
 		if err != nil {
-			fmt.Printf("Failed to add silence: %w", err)
+			fmt.Printf("Failed to add silence: %s", err)
 		}
 	} else {
 		fmt.Println("No valid option specified. Use --all or --alertname.")

--- a/cmd/alerts/silence/add_silence.go
+++ b/cmd/alerts/silence/add_silence.go
@@ -69,12 +69,12 @@ func AddSilence(cmd *addSilenceCmd) {
 	if all {
 		err := AddAllSilence(clusterID, duration, comment, username, clustername, kubeconfig, clientset)
 		if err != nil {
-			fmt.Errorf("Failed to add silence: %w", err)
+			fmt.Printf("Failed to add silence: %w", err)
 		}
 	} else if len(alertID) > 0 {
 		err := AddAlertNameSilence(alertID, duration, comment, username, kubeconfig, clientset)
 		if err != nil {
-			fmt.Errorf("Failed to add silence: %w", err)
+			fmt.Printf("Failed to add silence: %w", err)
 		}
 	} else {
 		fmt.Println("No valid option specified. Use --all or --alertname.")

--- a/cmd/alerts/silence/add_silence.go
+++ b/cmd/alerts/silence/add_silence.go
@@ -75,7 +75,7 @@ func AddSilence(cmd *addSilenceCmd) {
 	}
 
 }
-func AddAllSilence(clusterID, duration, comment, username, clustername string, kubeconfig *rest.Config, clientset *kubernetes.Clientset) {
+func AddAllSilence(clusterID, duration, comment, username, clustername string, kubeconfig *rest.Config, clientset *kubernetes.Clientset) error {
 	alerts := fetchAllAlerts(kubeconfig, clientset)
 	for _, alert := range alerts {
 		addCmd := []string{
@@ -91,13 +91,15 @@ func AddAllSilence(clusterID, duration, comment, username, clustername string, k
 		output, err := utils.ExecInAlertManagerPod(kubeconfig, clientset, addCmd)
 		if err != nil {
 			log.Fatal("Exiting the program")
-			return
+			return fmt.Errorf("Failed to exec in AlertManager pod: %w", err)
 		}
 
 		formattedOutput := strings.Replace(output, "\n", "", -1)
 
 		fmt.Printf("Alert %s has been silenced with id \"%s\" for a duration of %s by user \"%s\" \n", alert.Labels.Alertname, formattedOutput, duration, username)
 	}
+
+	return nil
 }
 
 func fetchAllAlerts(kubeconfig *rest.Config, clientset *kubernetes.Clientset) []utils.Alert {
@@ -117,7 +119,7 @@ func fetchAllAlerts(kubeconfig *rest.Config, clientset *kubernetes.Clientset) []
 	return fetchedAlerts
 }
 
-func AddAlertNameSilence(alertID []string, duration, comment, username string, kubeconfig *rest.Config, clientset *kubernetes.Clientset) {
+func AddAlertNameSilence(alertID []string, duration, comment, username string, kubeconfig *rest.Config, clientset *kubernetes.Clientset) error {
 	for _, alertname := range alertID {
 		addCmd := []string{
 			"amtool",
@@ -131,14 +133,15 @@ func AddAlertNameSilence(alertID []string, duration, comment, username string, k
 
 		output, err := utils.ExecInAlertManagerPod(kubeconfig, clientset, addCmd)
 		if err != nil {
-			log.Fatal("Exiting the program")
-			return
+			return fmt.Errorf("Failed to exec in AlertManager pod: %w", err)
 		}
 
 		formattedOutput := strings.Replace(output, "\n", "", -1)
 
 		fmt.Printf("Alert %s has been silenced with id \"%s\" for duration of %s by user \"%s\" \n", alertname, formattedOutput, duration, username)
 	}
+
+	return nil
 }
 
 // Get User name and clustername

--- a/cmd/alerts/silence/add_silence.go
+++ b/cmd/alerts/silence/add_silence.go
@@ -67,9 +67,15 @@ func AddSilence(cmd *addSilenceCmd) {
 	}
 
 	if all {
-		AddAllSilence(clusterID, duration, comment, username, clustername, kubeconfig, clientset)
+		err := AddAllSilence(clusterID, duration, comment, username, clustername, kubeconfig, clientset)
+		if err != nil {
+			fmt.Errorf("Failed to add silence: %w", err)
+		}
 	} else if len(alertID) > 0 {
-		AddAlertNameSilence(alertID, duration, comment, username, kubeconfig, clientset)
+		err := AddAlertNameSilence(alertID, duration, comment, username, kubeconfig, clientset)
+		if err != nil {
+			fmt.Errorf("Failed to add silence: %w", err)
+		}
 	} else {
 		fmt.Println("No valid option specified. Use --all or --alertname.")
 	}

--- a/cmd/alerts/silence/cmd.go
+++ b/cmd/alerts/silence/cmd.go
@@ -16,6 +16,7 @@ func NewCmdSilence() *cobra.Command {
 	silenceCmd.AddCommand(NewCmdAddSilence())
 	silenceCmd.AddCommand(NewCmdClearSilence())
 	silenceCmd.AddCommand(NewCmdListSilence())
+	silenceCmd.AddCommand(NewCmdAddOrgSilence())
 
 	return silenceCmd
 }

--- a/cmd/alerts/silence/silence_org.go
+++ b/cmd/alerts/silence/silence_org.go
@@ -52,6 +52,8 @@ func AddOrgSilence(cmd *AddOrgSilenceCmd) {
 	subscriptions, err := orgutils.SearchSubscriptions(organizationID, orgutils.StatusActive)
 	if err != nil {
 		log.Fatal(err)
+	} else if len(subscriptions) == 0 {
+		log.Fatal("No subscriptions found with that organization ID")
 	}
 
 	//Start ocm connection
@@ -82,13 +84,20 @@ func AddOrgSilence(cmd *AddOrgSilenceCmd) {
 
 		_, kubeconfig, clientset, err := common.GetKubeConfigAndClient(clusterID)
 		if err != nil {
-			log.Fatal(err)
+			log.Print(err)
+			continue //Skip if cluster is not in supported state
 		}
 
 		if all {
-			AddAllSilence(clusterID, duration, comment, username, clustername, kubeconfig, clientset)
+			err := AddAllSilence(clusterID, duration, comment, username, clustername, kubeconfig, clientset)
+			if err != nil {
+				log.Print(err)
+			}
 		} else if len(alertID) > 0 {
-			AddAlertNameSilence(alertID, duration, comment, username, kubeconfig, clientset)
+			err := AddAlertNameSilence(alertID, duration, comment, username, kubeconfig, clientset)
+			if err != nil {
+				log.Print(err)
+			}
 		} else {
 			fmt.Println("No valid option specified. Use --all or --alertname.")
 		}

--- a/cmd/alerts/silence/silence_org.go
+++ b/cmd/alerts/silence/silence_org.go
@@ -1,0 +1,96 @@
+package silence
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/openshift/osdctl/cmd/common"
+	orgutils "github.com/openshift/osdctl/cmd/org"
+	ocmutils "github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type AddOrgSilenceCmd struct {
+	organization string
+	alertID      []string
+	duration     string
+	comment      string
+	all          bool
+}
+
+func NewCmdAddOrgSilence() *cobra.Command {
+	AddOrgSilenceCmd := &AddOrgSilenceCmd{}
+	cmd := &cobra.Command{
+		Use:               "org <org-id> [--all --duration --comment | --alertname --duration --comment]",
+		Short:             "Add new silence for alert for org",
+		Long:              `add new silence for specfic or all alerts with comment and duration of alert for an organization`,
+		Args:              cobra.ExactArgs(1),
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			AddOrgSilenceCmd.organization = args[0]
+			AddOrgSilence(AddOrgSilenceCmd)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&AddOrgSilenceCmd.alertID, "alertname", []string{}, "alertname (comma-separated)")
+	cmd.Flags().StringVarP(&AddOrgSilenceCmd.comment, "comment", "c", "", "add comment about silence")
+	cmd.Flags().StringVarP(&AddOrgSilenceCmd.duration, "duration", "d", "15d", "add duration for silence") //default duration set to 15 days
+	cmd.Flags().BoolVarP(&AddOrgSilenceCmd.all, "all", "a", false, "add silences for all alert")
+
+	return cmd
+}
+
+// Add alert silences to organization's clusters
+func AddOrgSilence(cmd *AddOrgSilenceCmd) {
+	alertID := cmd.alertID
+	comment := cmd.comment
+	duration := cmd.duration
+	all := cmd.all
+	organizationID := cmd.organization
+
+	//Retrieve v1.Subscriptions list
+	subscriptions, err := orgutils.SearchSubscriptions(organizationID, orgutils.StatusActive)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	//Start ocm connection
+	connection, err := ocmutils.CreateConnection()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	//Retrieve organization
+	organization, err := ocmutils.GetOrganization(connection, subscriptions[0].ClusterID())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Are you sure you want silence alerts for %d clusters for this organization: %s", len(subscriptions), organization.Name())
+	ocmutils.ConfirmPrompt()
+
+	for _, subscription := range subscriptions {
+		clusterID := subscription.ClusterID()
+		if len(clusterID) == 0 {
+			log.Print("Cluster ID invalid, skipping: %s", clusterID)
+			continue //Skip invalid clusters
+		} else {
+			log.Print("Silencing alert(s) on cluster: %s", clusterID)
+		}
+
+		username, clustername := GetUserAndClusterInfo(clusterID)
+
+		_, kubeconfig, clientset, err := common.GetKubeConfigAndClient(clusterID)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if all {
+			AddAllSilence(clusterID, duration, comment, username, clustername, kubeconfig, clientset)
+		} else if len(alertID) > 0 {
+			AddAlertNameSilence(alertID, duration, comment, username, kubeconfig, clientset)
+		} else {
+			fmt.Println("No valid option specified. Use --all or --alertname.")
+		}
+	}
+}

--- a/cmd/alerts/silence/silence_org.go
+++ b/cmd/alerts/silence/silence_org.go
@@ -72,10 +72,10 @@ func AddOrgSilence(cmd *AddOrgSilenceCmd) {
 	for _, subscription := range subscriptions {
 		clusterID := subscription.ClusterID()
 		if len(clusterID) == 0 {
-			log.Print("Cluster ID invalid, skipping: %s", clusterID)
+			log.Printf("Cluster ID invalid, skipping: %s", clusterID)
 			continue //Skip invalid clusters
 		} else {
-			log.Print("Silencing alert(s) on cluster: %s", clusterID)
+			log.Printf("Silencing alert(s) on cluster: %s", clusterID)
 		}
 
 		username, clustername := GetUserAndClusterInfo(clusterID)

--- a/cmd/org/clusters.go
+++ b/cmd/org/clusters.go
@@ -2,8 +2,9 @@ package org
 
 import (
 	"fmt"
-	accountsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	"os"
+
+	accountsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	"github.com/openshift/osdctl/pkg/printer"
@@ -41,7 +42,7 @@ osdctl org clusters --aws-profile my-aws-profile --aws-account-id 123456789
 
 			status := ""
 			if !allClustersFlag {
-				status = statusActive
+				status = StatusActive
 			}
 
 			clusters, err := SearchSubscriptions(orgId, status)

--- a/cmd/org/common.go
+++ b/cmd/org/common.go
@@ -3,9 +3,10 @@ package org
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+
 	accountsv1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	"github.com/openshift/osdctl/pkg/utils"
-	"os"
 
 	"github.com/openshift-online/ocm-cli/pkg/dump"
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -20,7 +21,7 @@ const (
 	accountsAPIPath       = "/api/accounts_mgmt/v1/accounts"
 	currentAccountApiPath = "/api/accounts_mgmt/v1/current_account"
 
-	statusActive = "Active"
+	StatusActive = "Active"
 )
 
 var (

--- a/cmd/org/context.go
+++ b/cmd/org/context.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	v1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 	"os"
 	"strconv"
 	"sync"
@@ -15,6 +14,7 @@ import (
 	"github.com/andygrunwald/go-jira"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	v1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 	"github.com/openshift/osdctl/cmd/servicelog"
 	"github.com/openshift/osdctl/pkg/printer"
 	pdProvider "github.com/openshift/osdctl/pkg/provider/pagerduty"
@@ -179,7 +179,7 @@ func getPlanDisplayText(plan string) string {
 }
 
 func Context(orgId string) ([]ClusterInfo, error) {
-	clusterSubscriptions, err := SearchAllSubscriptionsByOrg(orgId, statusActive, true)
+	clusterSubscriptions, err := SearchAllSubscriptionsByOrg(orgId, StatusActive, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch cluster subscriptions for org with ID %s: %w", orgId, err)
 	}


### PR DESCRIPTION
Add a new command that allows SRE to silence all or a list of specific alerts across all clusters belonging to a specific organization.

Usage:
`Usage:
  osdctl alert silence org <org-id> [--all --duration --comment | --alertname --duration --comment] [flags]

Flags:
      --alertname strings   alertname (comma-separated)
  -a, --all                 add silences for all alert
  -c, --comment string      add comment about silence
  -d, --duration string     add duration for silence (default "15d")
  -h, --help                help for org
`