### PR TITLE
OSD-24614 : Update osdctl to add justification arguement for infranode resize

### DIFF
--- a/cmd/cluster/resize/infra_node.go
+++ b/cmd/cluster/resize/infra_node.go
@@ -147,6 +147,7 @@ func (r *Infra) New() error {
 		return err
 	}
 
+
 	r.clusterId = cluster.ID()
 	r.client = c
 	r.hive = hc
@@ -437,7 +438,7 @@ func (r *Infra) RunInfra(ctx context.Context) error {
 		}
 	}
 
-	postCmd := generateServiceLog(tempMp, r.instanceType, r.clusterId)
+	postCmd := generateServiceLog(tempMp, r.instanceType, r.justification, r.clusterId)
 	if err := postCmd.Run(); err != nil {
 		fmt.Println("Failed to generate service log. Please manually send a service log to the customer for the blocked egresses with:")
 		fmt.Printf("osdctl servicelog post %v -t %v -p %v\n",
@@ -541,18 +542,18 @@ func getInstanceType(mp *hivev1.MachinePool) (string, error) {
 }
 
 // Adding change in serviceLog as per the cloud provider.
-func generateServiceLog(mp *hivev1.MachinePool, instanceType, clusterId string) servicelog.PostCmdOptions {
+func generateServiceLog(mp *hivev1.MachinePool, instanceType, justification, clusterId string) servicelog.PostCmdOptions {
 	if mp.Spec.Platform.AWS != nil {
 		return servicelog.PostCmdOptions{
 			Template:       resizedInfraNodeServiceLogTemplate,
 			ClusterId:      clusterId,
-			TemplateParams: []string{fmt.Sprintf("INSTANCE_TYPE=%s", instanceType)},
+			TemplateParams: []string{fmt.Sprintf("INSTANCE_TYPE=%s", instanceType),fmt.Sprintf("JUSTIFICATION=%s", justification)},
 		}
 	} else if mp.Spec.Platform.GCP != nil {
 		return servicelog.PostCmdOptions{
 			Template:       GCPresizedInfraNodeServiceLogTemplate,
 			ClusterId:      clusterId,
-			TemplateParams: []string{fmt.Sprintf("INSTANCE_TYPE=%s", instanceType)},
+			TemplateParams: []string{fmt.Sprintf("INSTANCE_TYPE=%s", instanceType),fmt.Sprintf("JUSTIFICATION=%s", justification)},
 		}
 	}
 	return servicelog.PostCmdOptions{}

--- a/cmd/cluster/resize/infra_node.go
+++ b/cmd/cluster/resize/infra_node.go
@@ -32,7 +32,7 @@ import (
 const (
 	twentyMinuteTimeout                   = 20 * time.Minute
 	twentySecondIncrement                 = 20 * time.Second
-	resizedInfraNodeServiceLogTemplate    = "https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/infranode_resized_auto.json"
+	resizedInfraNodeServiceLogTemplate    = "https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/infranode_resized.json"
 	GCPresizedInfraNodeServiceLogTemplate = "https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/gcp/GCP_infranode_resized_auto.json"
 	infraNodeLabel                        = "node-role.kubernetes.io/infra"
 	temporaryInfraNodeLabel               = "osdctl.openshift.io/infra-resize-temporary-machinepool"
@@ -51,6 +51,9 @@ type Infra struct {
 
 	// reason to provide for elevation (eg: OHSS/PG ticket)
 	reason string
+
+	// reason to provide for resize
+	justification string
 }
 
 func newCmdResizeInfra() *cobra.Command {
@@ -83,8 +86,10 @@ func newCmdResizeInfra() *cobra.Command {
 	infraResizeCmd.Flags().StringVarP(&r.clusterId, "cluster-id", "C", "", "OCM internal/external cluster id or cluster name to resize infra nodes for.")
 	infraResizeCmd.Flags().StringVar(&r.instanceType, "instance-type", "", "(optional) Override for an AWS or GCP instance type to resize the infra nodes to, by default supported instance types are automatically selected.")
 	infraResizeCmd.Flags().StringVar(&r.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)")
+	infraResizeCmd.Flags().StringVar(&r.justification, "justification", "", "The justification behind resize")
 
 	infraResizeCmd.MarkFlagRequired("cluster-id")
+	infraResizeCmd.MarkFlagRequired("justification")
 	infraResizeCmd.MarkFlagRequired("reason")
 
 	return infraResizeCmd

--- a/cmd/cluster/resize/infra_node.go
+++ b/cmd/cluster/resize/infra_node.go
@@ -547,13 +547,13 @@ func generateServiceLog(mp *hivev1.MachinePool, instanceType, justification, clu
 		return servicelog.PostCmdOptions{
 			Template:       resizedInfraNodeServiceLogTemplate,
 			ClusterId:      clusterId,
-			TemplateParams: []string{fmt.Sprintf("INSTANCE_TYPE=%s", instanceType),fmt.Sprintf("JUSTIFICATION=%s", justification)},
+			TemplateParams: []string{fmt.Sprintf("INSTANCE_TYPE=%s", instanceType), fmt.Sprintf("JUSTIFICATION=%s", justification)},
 		}
 	} else if mp.Spec.Platform.GCP != nil {
 		return servicelog.PostCmdOptions{
 			Template:       GCPresizedInfraNodeServiceLogTemplate,
 			ClusterId:      clusterId,
-			TemplateParams: []string{fmt.Sprintf("INSTANCE_TYPE=%s", instanceType),fmt.Sprintf("JUSTIFICATION=%s", justification)},
+			TemplateParams: []string{fmt.Sprintf("INSTANCE_TYPE=%s", instanceType), fmt.Sprintf("JUSTIFICATION=%s", justification)},
 		}
 	}
 	return servicelog.PostCmdOptions{}

--- a/cmd/cluster/resize/infra_node.go
+++ b/cmd/cluster/resize/infra_node.go
@@ -147,7 +147,6 @@ func (r *Infra) New() error {
 		return err
 	}
 
-
 	r.clusterId = cluster.ID()
 	r.client = c
 	r.hive = hc


### PR DESCRIPTION
Our current infra node resize [SL](https://github.com/openshift/managed-notifications/blob/master/osd/infranode_resized.json) does mention about the justification of the resize, . However, in our [SOP] (https://github.com/openshift/ops-sop/blob/master/v4/alerts/InfraNodesNeedResizingSRE.md) , the command mentioned doesn't mention about the justification arguement as osdctl refers to other SL that doesn't have the justification arguement. https://github.com/openshift/osdctl/blob/master/cmd/cluster/resize/infra_node.go#L35C43-L35C147
This PR incorporates for :
1. osdctl to point to the SL that has justification arguement 
2. Add changes accordingly to incorporate the justification arguement 