### PR TITLE
[OSD-24926] wif template generation fixes

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -102,7 +102,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	rootCmd.AddCommand(servicelog.NewCmdServiceLog())
 	rootCmd.AddCommand(setup.NewCmdSetup())
 	rootCmd.AddCommand(swarm.Cmd)
-  rootCmd.AddCommand(iampermissions.NewCmdIamPermissions())
+	rootCmd.AddCommand(iampermissions.NewCmdIamPermissions())
 
 	// Add cost command to use AWS Cost Manager
 	rootCmd.AddCommand(cost.NewCmdCost(streams, globalOpts))

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/osdctl/cmd/cost"
 	"github.com/openshift/osdctl/cmd/env"
 	"github.com/openshift/osdctl/cmd/hive"
+	"github.com/openshift/osdctl/cmd/iampermissions"
 	"github.com/openshift/osdctl/cmd/jira"
 	"github.com/openshift/osdctl/cmd/jumphost"
 	"github.com/openshift/osdctl/cmd/mc"
@@ -101,6 +102,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	rootCmd.AddCommand(servicelog.NewCmdServiceLog())
 	rootCmd.AddCommand(setup.NewCmdSetup())
 	rootCmd.AddCommand(swarm.Cmd)
+  rootCmd.AddCommand(iampermissions.NewCmdIamPermissions())
 
 	// Add cost command to use AWS Cost Manager
 	rootCmd.AddCommand(cost.NewCmdCost(streams, globalOpts))

--- a/pkg/policies/gcp.go
+++ b/pkg/policies/gcp.go
@@ -51,8 +51,10 @@ func CredentialsRequestToWifServiceAccount(credReq *cco.CredentialsRequest) (*Se
 	}
 
 	if len(gcpSpec.Permissions) > 0 {
+		roleId := strings.ReplaceAll(credReq.Name, "-", "_")
+    roleId = roleId[:min(64, len(roleId))]
 		sa.Roles = append(sa.Roles, Role{
-			Id:          credReq.Name,
+			Id:          roleId,
 			Kind:        "Role",
 			Permissions: gcpSpec.Permissions,
 			Predefined:  false,

--- a/pkg/policies/gcp.go
+++ b/pkg/policies/gcp.go
@@ -53,8 +53,8 @@ func CredentialsRequestToWifServiceAccount(credReq *cco.CredentialsRequest) (*Se
 
 	if len(gcpSpec.Permissions) > 0 {
 		roleId := strings.ReplaceAll(credReq.Name, "-", "_")
-    roleId = roleId[:min(64, len(roleId))]
-    slices.Sort(gcpSpec.Permissions)
+		roleId = roleId[:min(64, len(roleId))]
+		slices.Sort(gcpSpec.Permissions)
 		sa.Roles = append(sa.Roles, Role{
 			Id:          roleId,
 			Kind:        "Role",

--- a/pkg/policies/gcp.go
+++ b/pkg/policies/gcp.go
@@ -1,6 +1,7 @@
 package policies
 
 import (
+	"slices"
 	"strings"
 
 	cco "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
@@ -53,6 +54,7 @@ func CredentialsRequestToWifServiceAccount(credReq *cco.CredentialsRequest) (*Se
 	if len(gcpSpec.Permissions) > 0 {
 		roleId := strings.ReplaceAll(credReq.Name, "-", "_")
     roleId = roleId[:min(64, len(roleId))]
+    slices.Sort(gcpSpec.Permissions)
 		sa.Roles = append(sa.Roles, Role{
 			Id:          roleId,
 			Kind:        "Role",

--- a/pkg/policies/gcp_models.go
+++ b/pkg/policies/gcp_models.go
@@ -23,13 +23,13 @@ type ServiceAccount struct {
 }
 
 type CredentialRequest struct {
-	SecretRef           SecretRef
-	ServiceAccountNames []string
+	SecretRef           SecretRef `json:"secret_ref,omitempty"`
+	ServiceAccountNames []string  `json:"service_account_names,omitempty"`
 }
 
 type SecretRef struct {
-	Name      string
-	Namespace string
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (s ServiceAccount) GetId() string {


### PR DESCRIPTION
This PR does some slight fixes to the generation of the wif-template role yamls:
- Custom Role IDs now match the pattern `[a-zA-Z0-9_\.]{3,64}`
- credential_requests keys are now formatted in snake_case
- sort permissions of custom roles

Also, the `iampermissions` command seems to have been accidentally removed from the rootCmd. I've added it again so it can actually be called.

eg:
#### before

```yaml
access_method: wif
credential_request:
  SecretRef:
    Name: cloud-credentials
    Namespace: openshift-ingress-operator
  ServiceAccountNames:
  - ingress-operator
id: openshift-ingress-gcp
kind: ServiceAccount
osd_role: operator-ingress-gcp
roles:
- id: openshift-ingress-gcp
  kind: Role
  permissions:
  - dns.changes.create
  - dns.resourceRecordSets.create
  - dns.resourceRecordSets.update
  - dns.resourceRecordSets.delete
  - dns.resourceRecordSets.list
```

#### after

```yaml
access_method: wif
credential_request:
  secret_ref:
    name: cloud-credentials
    namespace: openshift-ingress-operator
  service_account_names:
  - ingress-operator
id: openshift-ingress-gcp
kind: ServiceAccount
osd_role: operator-ingress-gcp
roles:
- id: openshift_ingress_gcp
  kind: Role
  permissions:
  - dns.changes.create
  - dns.resourceRecordSets.create
  - dns.resourceRecordSets.delete
  - dns.resourceRecordSets.list
  - dns.resourceRecordSets.update
```