### PR TITLE
Allow reading creds as env var for account mgmt commands

### DIFF
--- a/cmd/account/mgmt/account-assign.go
+++ b/cmd/account/mgmt/account-assign.go
@@ -3,6 +3,7 @@ package mgmt
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
@@ -80,9 +81,6 @@ func (o *accountAssignOptions) complete(cmd *cobra.Command, _ []string) error {
 	if o.username == "" {
 		return cmdutil.UsageErrorf(cmd, "LDAP username was not provided")
 	}
-	if o.payerAccount == "" {
-		return cmdutil.UsageErrorf(cmd, "Payer account was not provided")
-	}
 
 	o.output = o.GlobalOptions.Output
 
@@ -97,10 +95,16 @@ func (o *accountAssignOptions) run() error {
 		rootID          string
 	)
 
-	if o.payerAccount == "osd-staging-1" {
+	const (
+		osdStaging1    = "osd-staging-1"
+		osdStaging2    = "osd-staging-2"
+		awsAccountName = "AWS_ACCOUNT_NAME"
+	)
+
+	if o.payerAccount == osdStaging1 || os.Getenv(awsAccountName) == osdStaging1 {
 		rootID = OSDStaging1RootID
 		destinationOU = OSDStaging1OuID
-	} else if o.payerAccount == "osd-staging-2" {
+	} else if o.payerAccount == osdStaging2 || os.Getenv(awsAccountName) == osdStaging2 {
 		rootID = OSDStaging2RootID
 		destinationOU = OSDStaging2OuID
 	} else {

--- a/cmd/account/mgmt/account-assign.go
+++ b/cmd/account/mgmt/account-assign.go
@@ -95,16 +95,10 @@ func (o *accountAssignOptions) run() error {
 		rootID          string
 	)
 
-	const (
-		osdStaging1    = "osd-staging-1"
-		osdStaging2    = "osd-staging-2"
-		awsAccountName = "AWS_ACCOUNT_NAME"
-	)
-
-	if o.payerAccount == osdStaging1 || os.Getenv(awsAccountName) == osdStaging1 {
+	if o.payerAccount == osdStaging1 || os.Getenv(envKeyAWSAccountName) == osdStaging1 {
 		rootID = OSDStaging1RootID
 		destinationOU = OSDStaging1OuID
-	} else if o.payerAccount == osdStaging2 || os.Getenv(awsAccountName) == osdStaging2 {
+	} else if o.payerAccount == osdStaging2 || os.Getenv(envKeyAWSAccountName) == osdStaging2 {
 		rootID = OSDStaging2RootID
 		destinationOU = OSDStaging2OuID
 	} else {

--- a/cmd/account/mgmt/account-list.go
+++ b/cmd/account/mgmt/account-list.go
@@ -83,21 +83,15 @@ func (o *accountListOptions) run() error {
 		OuID string
 	)
 
-	const (
-		osdStaging1    = "osd-staging-1"
-		osdStaging2    = "osd-staging-2"
-		awsAccountName = "AWS_ACCOUNT_NAME"
-	)
-
 	// Instantiate Aws client
 	awsClient, err := awsprovider.NewAwsClient(o.payerAccount, "us-east-1", "")
 	if err != nil {
 		return err
 	}
 
-	if o.payerAccount == osdStaging2 || os.Getenv(awsAccountName) == osdStaging2 {
+	if o.payerAccount == osdStaging2 || os.Getenv(envKeyAWSAccountName) == osdStaging2 {
 		OuID = "ou-rs3h-ry0hn2l9"
-	} else if o.payerAccount == osdStaging1 || os.Getenv(awsAccountName) == osdStaging1 {
+	} else if o.payerAccount == osdStaging1 || os.Getenv(envKeyAWSAccountName) == osdStaging1 {
 		OuID = "ou-0wd6-z6tzkjek"
 	}
 

--- a/cmd/account/mgmt/account-list.go
+++ b/cmd/account/mgmt/account-list.go
@@ -2,6 +2,7 @@ package mgmt
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
@@ -67,9 +68,6 @@ func newCmdAccountList(streams genericclioptions.IOStreams, globalOpts *globalfl
 }
 
 func (o *accountListOptions) complete(cmd *cobra.Command, _ []string) error {
-	if o.payerAccount == "" {
-		return cmdutil.UsageErrorf(cmd, "Payer account was not provided")
-	}
 	if o.username != "" && o.accountID != "" {
 		return cmdutil.UsageErrorf(cmd, "Cannot provide both username and account ID")
 	}
@@ -84,15 +82,22 @@ func (o *accountListOptions) run() error {
 	var (
 		OuID string
 	)
+
+	const (
+		osdStaging1    = "osd-staging-1"
+		osdStaging2    = "osd-staging-2"
+		awsAccountName = "AWS_ACCOUNT_NAME"
+	)
+
 	// Instantiate Aws client
 	awsClient, err := awsprovider.NewAwsClient(o.payerAccount, "us-east-1", "")
 	if err != nil {
 		return err
 	}
 
-	if o.payerAccount == "osd-staging-2" {
+	if o.payerAccount == osdStaging2 || os.Getenv(awsAccountName) == osdStaging2 {
 		OuID = "ou-rs3h-ry0hn2l9"
-	} else if o.payerAccount == "osd-staging-1" {
+	} else if o.payerAccount == osdStaging1 || os.Getenv(awsAccountName) == osdStaging1 {
 		OuID = "ou-0wd6-z6tzkjek"
 	}
 

--- a/cmd/account/mgmt/account-unassign.go
+++ b/cmd/account/mgmt/account-unassign.go
@@ -70,20 +70,16 @@ func (o *accountUnassignOptions) run() error {
 		assumedRoleAwsClient awsprovider.Client
 		allUsers             []string
 	)
-	const (
-		osdStaging1    = "osd-staging-1"
-		osdStaging2    = "osd-staging-2"
-		awsAccountName = "AWS_ACCOUNT_NAME"
-	)
+
 	// Instantiate Aws client
 	awsClient, err := awsprovider.NewAwsClient(o.payerAccount, "us-east-1", "")
 	if err != nil {
 		return err
 	}
-	if o.payerAccount == osdStaging1 || os.Getenv(awsAccountName) == osdStaging1 {
+	if o.payerAccount == osdStaging1 || os.Getenv(envKeyAWSAccountName) == osdStaging1 {
 		rootID = OSDStaging1RootID
 		destinationOU = OSDStaging1OuID
-	} else if o.payerAccount == osdStaging2 || os.Getenv(awsAccountName) == osdStaging2 {
+	} else if o.payerAccount == osdStaging2 || os.Getenv(envKeyAWSAccountName) == osdStaging2 {
 		rootID = OSDStaging2RootID
 		destinationOU = OSDStaging2OuID
 	} else {

--- a/cmd/account/mgmt/cmd.go
+++ b/cmd/account/mgmt/cmd.go
@@ -8,6 +8,12 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
+const (
+	osdStaging1          = "osd-staging-1"
+	osdStaging2          = "osd-staging-2"
+	envKeyAWSAccountName = "AWS_ACCOUNT_NAME"
+)
+
 // NewCmdMgmt implements the mgmt command to get AWS Account resources
 func NewCmdMgmt(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	mgmtCmd := &cobra.Command{


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-20603

Update osdctl account mgmt commands to use RH SSO credentials generated via https://github.com/app-sre/rh-aws-saml-login which spawns a new shell with the AWS_ACCOUNT_NAME environment variable.