### PR TITLE
OSD-24259: osdctl network verify should prompt putting clusters into LS if DMS/PD is blocked

### DIFF
--- a/cmd/cluster/support/post.go
+++ b/cmd/cluster/support/post.go
@@ -212,7 +212,7 @@ See: https://source.redhat.com/groups/public/sre/wiki/defining_limited_support_p
 	}
 
 	fmt.Printf("The following limited support reason will be sent to %s:\n", clusterID)
-	if err = printLimitedSupportReason(limitedSupport); err != nil {
+	if err = PrintLimitedSupportReason(limitedSupport); err != nil {
 		return fmt.Errorf("failed to print limited support reason template: %w", err)
 	}
 
@@ -220,7 +220,7 @@ See: https://source.redhat.com/groups/public/sre/wiki/defining_limited_support_p
 		return nil
 	}
 
-	postLimitedSupportResponse, err := sendLimitedSupportPostRequest(connection, p.cluster.ID(), limitedSupport)
+	postLimitedSupportResponse, err := SendLimitedSupportPostRequest(connection, p.cluster.ID(), limitedSupport)
 	if err != nil {
 		return fmt.Errorf("failed to post limited support reason: %w", err)
 	}
@@ -388,7 +388,7 @@ func (p *Post) checkLeftovers(template *TemplateFile) {
 	}
 }
 
-func printLimitedSupportReason(limitedSupport *cmv1.LimitedSupportReason) error {
+func PrintLimitedSupportReason(limitedSupport *cmv1.LimitedSupportReason) error {
 	buf := bytes.Buffer{}
 	err := cmv1.MarshalLimitedSupportReason(limitedSupport, &buf)
 	if err != nil {
@@ -398,7 +398,7 @@ func printLimitedSupportReason(limitedSupport *cmv1.LimitedSupportReason) error 
 	return dump.Pretty(os.Stdout, buf.Bytes())
 }
 
-func sendLimitedSupportPostRequest(ocmClient *sdk.Connection, clusterID string, limitedSupport *cmv1.LimitedSupportReason) (*cmv1.LimitedSupportReasonsAddResponse, error) {
+func SendLimitedSupportPostRequest(ocmClient *sdk.Connection, clusterID string, limitedSupport *cmv1.LimitedSupportReason) (*cmv1.LimitedSupportReasonsAddResponse, error) {
 	response, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(clusterID).LimitedSupportReasons().Add().Body(limitedSupport).Send()
 	if err != nil {
 		return nil, fmt.Errorf("failed to post new limited support reason: %w", err)

--- a/cmd/cluster/support/post.go
+++ b/cmd/cluster/support/post.go
@@ -212,7 +212,7 @@ See: https://source.redhat.com/groups/public/sre/wiki/defining_limited_support_p
 	}
 
 	fmt.Printf("The following limited support reason will be sent to %s:\n", clusterID)
-	if err = PrintLimitedSupportReason(limitedSupport); err != nil {
+	if err = printLimitedSupportReason(limitedSupport); err != nil {
 		return fmt.Errorf("failed to print limited support reason template: %w", err)
 	}
 
@@ -220,7 +220,7 @@ See: https://source.redhat.com/groups/public/sre/wiki/defining_limited_support_p
 		return nil
 	}
 
-	postLimitedSupportResponse, err := SendLimitedSupportPostRequest(connection, p.cluster.ID(), limitedSupport)
+	postLimitedSupportResponse, err := sendLimitedSupportPostRequest(connection, p.cluster.ID(), limitedSupport)
 	if err != nil {
 		return fmt.Errorf("failed to post limited support reason: %w", err)
 	}
@@ -388,7 +388,7 @@ func (p *Post) checkLeftovers(template *TemplateFile) {
 	}
 }
 
-func PrintLimitedSupportReason(limitedSupport *cmv1.LimitedSupportReason) error {
+func printLimitedSupportReason(limitedSupport *cmv1.LimitedSupportReason) error {
 	buf := bytes.Buffer{}
 	err := cmv1.MarshalLimitedSupportReason(limitedSupport, &buf)
 	if err != nil {
@@ -398,7 +398,7 @@ func PrintLimitedSupportReason(limitedSupport *cmv1.LimitedSupportReason) error 
 	return dump.Pretty(os.Stdout, buf.Bytes())
 }
 
-func SendLimitedSupportPostRequest(ocmClient *sdk.Connection, clusterID string, limitedSupport *cmv1.LimitedSupportReason) (*cmv1.LimitedSupportReasonsAddResponse, error) {
+func sendLimitedSupportPostRequest(ocmClient *sdk.Connection, clusterID string, limitedSupport *cmv1.LimitedSupportReason) (*cmv1.LimitedSupportReasonsAddResponse, error) {
 	response, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(clusterID).LimitedSupportReasons().Add().Body(limitedSupport).Send()
 	if err != nil {
 		return nil, fmt.Errorf("failed to post new limited support reason: %w", err)

--- a/cmd/network/verification.go
+++ b/cmd/network/verification.go
@@ -184,12 +184,10 @@ func (e *EgressVerification) Run(ctx context.Context) {
 			blockedUrl := strings.Join(postCmd.TemplateParams, ",")
 			if strings.Contains(blockedUrl, "deadmanssnitch") || strings.Contains(blockedUrl, "pagerduty") {
 				fmt.Println("PagerDuty and/or DMS outgoing traffic is blocked, resulting in a loss of observability. As a result, Red Hat can no longer guarantee SLAs and the cluster should be put in limited support")
-				pCmd := generateLimitedSupportTemplate(out)
+				pCmd := lsupport.Post{Template: LimitedSupportTemplate}
 				if err := pCmd.Run(e.ClusterId); err != nil {
 					fmt.Printf("failed to post limited support reason: %v", err)
-
 				}
-
 			} else if err := postCmd.Run(); err != nil {
 				fmt.Println("Failed to generate service log. Please manually send a service log to the customer for the blocked egresses with:")
 				fmt.Printf("osdctl servicelog post %v -t %v -p %v\n", e.ClusterId, blockedEgressTemplateUrl, strings.Join(postCmd.TemplateParams, " -p "))

--- a/cmd/network/verification.go
+++ b/cmd/network/verification.go
@@ -798,14 +798,3 @@ func printVersion() {
 	}
 	log.Println(fmt.Sprintf("Using osd-network-verifier version %v", version))
 }
-
-// Generate LimitedSupportTemplate
-func generateLimitedSupportTemplate(out *output.Output) lsupport.Post {
-	failures := out.GetEgressURLFailures()
-	if len(failures) > 0 {
-		return lsupport.Post{
-			Template: LimitedSupportTemplate,
-		}
-	}
-	return lsupport.Post{}
-}

--- a/cmd/network/verification.go
+++ b/cmd/network/verification.go
@@ -43,7 +43,7 @@ const (
 	blockedEgressTemplateUrl     = "https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/required_network_egresses_are_blocked.json"
 	caBundleConfigMapKey         = "ca-bundle.crt"
 	networkVerifierDepPath       = "github.com/openshift/osd-network-verifier"
-	LimitedSupportTemplate       = "https://raw.githubusercontent.com/TheUndeadKing/managed-notifications/PDLimitedSupport/osd/limited_support/egressFailureLimitedSupport.json"
+	LimitedSupportTemplate       = "https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/limited_support/egressFailureLimitedSupport.json"
 )
 
 type EgressVerification struct {

--- a/cmd/network/verification.go
+++ b/cmd/network/verification.go
@@ -805,11 +805,6 @@ func printVersion() {
 func generateLimitedSupportTemplate(out *output.Output) lsupport.Post {
 	failures := out.GetEgressURLFailures()
 	if len(failures) > 0 {
-		egressUrls := make([]string, len(failures))
-		for i, failure := range failures {
-			egressUrls[i] = failure.EgressURL()
-		}
-
 		return lsupport.Post{
 			Template: LimitedSupportTemplate,
 		}


### PR DESCRIPTION
**JIRA**: 
[OSD-24259](https://issues.redhat.com/browse/OSD-24259)

**SUMMARY**:
If cluster can't access DMS (OR) PD while validating network using _verify-egress_. It should ask prompt to move cluster into LS instead of SL prompt