### PR TITLE
Support Passing Namespace Ref For SaaS Promotions

### DIFF
--- a/cmd/promote/saas/saas.go
+++ b/cmd/promote/saas/saas.go
@@ -16,6 +16,7 @@ type saasOptions struct {
 	appInterfaceCheckoutDir string
 	serviceName             string
 	gitHash                 string
+	namespaceRef            string
 }
 
 // newCmdSaas implementes the saas command to interact with promoting SaaS services/operators
@@ -54,7 +55,7 @@ func NewCmdSaas() *cobra.Command {
 				os.Exit(1)
 			}
 
-			err := servicePromotion(appInterface, ops.serviceName, ops.gitHash, ops.osd, ops.hcp)
+			err := servicePromotion(appInterface, ops.serviceName, ops.gitHash, ops.namespaceRef, ops.osd, ops.hcp)
 			if err != nil {
 				fmt.Printf("Error while promoting service: %v\n", err)
 				os.Exit(1)
@@ -68,6 +69,7 @@ func NewCmdSaas() *cobra.Command {
 	saasCmd.Flags().BoolVarP(&ops.list, "list", "l", false, "List all SaaS services/operators")
 	saasCmd.Flags().StringVarP(&ops.serviceName, "serviceName", "", "", "SaaS service/operator getting promoted")
 	saasCmd.Flags().StringVarP(&ops.gitHash, "gitHash", "g", "", "Git hash of the SaaS service/operator commit getting promoted")
+	saasCmd.Flags().StringVarP(&ops.namespaceRef, "namespaceRef", "n", "", "SaaS target namespace reference name")
 	saasCmd.Flags().BoolVarP(&ops.osd, "osd", "", false, "OSD service/operator getting promoted")
 	saasCmd.Flags().BoolVarP(&ops.hcp, "hcp", "", false, "HCP service/operator getting promoted")
 	saasCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interfache checkout. Falls back to `pwd` and "+git.DefaultAppInterfaceDirectory())

--- a/cmd/promote/saas/utils.go
+++ b/cmd/promote/saas/utils.go
@@ -36,7 +36,7 @@ func listServiceNames(appInterface git.AppInterface) error {
 	return nil
 }
 
-func servicePromotion(appInterface git.AppInterface, serviceName, gitHash string, osd, hcp bool) error {
+func servicePromotion(appInterface git.AppInterface, serviceName, gitHash string, namespaceRef string, osd, hcp bool) error {
 	_, err := GetServiceNames(appInterface, OSDSaasDir, BPSaasDir, CADSaasDir)
 	if err != nil {
 		return err
@@ -58,7 +58,7 @@ func servicePromotion(appInterface git.AppInterface, serviceName, gitHash string
 		return fmt.Errorf("failed to read SAAS file: %v", err)
 	}
 
-	currentGitHash, serviceRepo, err := git.GetCurrentGitHashFromAppInterface(serviceData, serviceName)
+	currentGitHash, serviceRepo, err := git.GetCurrentGitHashFromAppInterface(serviceData, serviceName, namespaceRef)
 	if err != nil {
 		return fmt.Errorf("failed to get current git hash or service repo: %v", err)
 	}


### PR DESCRIPTION
Support passing the namespace reference to OSD operator SaaS promotions to support non-staandard app-interface saas files.

Example usage:
```
osdctl promote saas --serviceName saas-osd-rhobs-rules-and-dashboards --osd --gitHash 31affec25937012dd7b5d1fd661f1d62d878e9fa --namespaceRef app-sre-observability-production-int.appsrep09ue1
```
