### PR TITLE
Bump osd-network-verifier to v1.1.2

### DIFF
--- a/cmd/network/verification.go
+++ b/cmd/network/verification.go
@@ -323,7 +323,7 @@ func (e *EgressVerification) generateAWSValidateEgressInput(ctx context.Context,
 	// Configure verifier's PlatformType based on cluster info or user request
 	input.PlatformType, err = e.getPlatform()
 	if err != nil {
-		return nil, fmt.Errorf("requested platform not supported by the verifier: %w", err)
+		return nil, fmt.Errorf("platform not supported: %w", err)
 	}
 	e.log.Info(ctx, "using platform: %s", input.PlatformType)
 
@@ -434,6 +434,10 @@ func (e *EgressVerification) getPlatform() (cloud.Platform, error) {
 		if e.cluster.CloudProvider().ID() == "aws" {
 			return cloud.AWSClassic, nil
 		}
+	}
+	// TODO drop this check once GCP support enabled
+	if platform == cloud.GCPClassic {
+		err = fmt.Errorf("osdctl's implementation of the network verifier doesn't yet support GCP")
 	}
 	return platform, err
 }

--- a/cmd/network/verification.go
+++ b/cmd/network/verification.go
@@ -137,7 +137,7 @@ func NewCmdValidateEgress() *cobra.Command {
 	validateEgressCmd.Flags().StringVar(&e.Region, "region", "", "(optional) AWS region")
 	validateEgressCmd.Flags().BoolVar(&e.Debug, "debug", false, "(optional) if provided, enable additional debug-level logging")
 	validateEgressCmd.Flags().BoolVarP(&e.AllSubnets, "all-subnets", "A", false, "(optional) an option for Privatelink clusters to run osd-network-verifier against all subnets listed by ocm.")
-	validateEgressCmd.Flags().StringVar(&e.platformName, "platform", "", "(optional) override for cloud platform/product. E.g., 'aws-classic' (OSD/ROSA Classic), 'aws-hcp' (ROSA HCP), or 'aws-hcpzeroegress'")
+	validateEgressCmd.Flags().StringVar(&e.platformName, "platform", "", "(optional) override for cloud platform/product. E.g., 'aws-classic' (OSD/ROSA Classic), 'aws-hcp' (ROSA HCP), or 'aws-hcp-zeroegress'")
 	validateEgressCmd.Flags().DurationVar(&e.EgressTimeout, "egress-timeout", 5*time.Second, "(optional) timeout for individual egress verification requests")
 	validateEgressCmd.Flags().BoolVar(&e.Version, "version", false, "When present, prints out the version of osd-network-verifier being used")
 	validateEgressCmd.Flags().StringVar(&e.Probe, "probe", "curl", "(optional) select the probe to be used for egress testing. Either 'curl' (default) or 'legacy'")

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/openshift/cloud-credential-operator v0.0.0-20240522005141-2f29d9103ce2
 	github.com/openshift/gcp-project-operator v0.0.0-20220920194256-df38e31387a7
 	github.com/openshift/hive/apis v0.0.0-20240216200617-8c54fc9cac45
-	github.com/openshift/osd-network-verifier v1.0.1
+	github.com/openshift/osd-network-verifier v1.1.2
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/shopspring/decimal v1.3.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -465,8 +465,8 @@ github.com/openshift/gcp-project-operator v0.0.0-20220920194256-df38e31387a7 h1:
 github.com/openshift/gcp-project-operator v0.0.0-20220920194256-df38e31387a7/go.mod h1:BKXSfGFecnNJ/NBv61AjSP9ngf9jiP4KbPShTkO9XtA=
 github.com/openshift/hive/apis v0.0.0-20240216200617-8c54fc9cac45 h1:t9PeXKK13eqBPG59+uLIzOLU75Rl5GPYNU6WPPvy1J4=
 github.com/openshift/hive/apis v0.0.0-20240216200617-8c54fc9cac45/go.mod h1:jqpZWDUo9JcnO4Q5RuNWjESE1EJ3Qi9xowBBi0nyxQA=
-github.com/openshift/osd-network-verifier v1.0.1 h1:xMfJqYwavMvTIjjcOdvXfJAFNGQs24qpmmjC1wMS4Hs=
-github.com/openshift/osd-network-verifier v1.0.1/go.mod h1:X3dVNkC91NYTf2kTXUS/PeRTNvfS97WbvIqPIDP083M=
+github.com/openshift/osd-network-verifier v1.1.2 h1:iF8Wk6W5Q/fNFQi4h8mOF/rsLpgmI1y7WNKimv+jqJk=
+github.com/openshift/osd-network-verifier v1.1.2/go.mod h1:X3dVNkC91NYTf2kTXUS/PeRTNvfS97WbvIqPIDP083M=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/perimeterx/marshmallow v1.1.4 h1:pZLDH9RjlLGGorbXhcaQLhfuV0pFMNfPO55FuFkxqLw=


### PR DESCRIPTION
This PR addresses [OSD-25867](https://issues.redhat.com/browse/OSD-25867), which calls for the latest version (v1.1.2) of osd-network-verifier to be integrated into `osdctl network verify-egress`. This new version came with breaking changes to the API: specifically, we now use a `Platform` struct type instead of a string to specify the cloud platform under test. This latest version of the verifier also includes experimental support for HCP zero egress clusters; enable this with `--platform=aws-hcp-zeroegress`.