### PR TITLE
OSD-26326: Replace GetHCPNamespace input field to support External ID

### DIFF
--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -418,7 +417,10 @@ func (o *contextOptions) generateContextData() (*contextData, []error) {
 			}
 			queryTxt := query.Build()
 			data.DyntraceEnvURL = hcpCluster.DynatraceURL
-			data.DyntraceLogsURL = dynatrace.GetLinkToWebConsole(hcpCluster.DynatraceURL, 10, base64.StdEncoding.EncodeToString([]byte(queryTxt)))
+			data.DyntraceLogsURL, err = dynatrace.GetLinkToWebConsole(hcpCluster.DynatraceURL, 10, queryTxt)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("failed to get url: %v", err))
+			}
 		}
 	}
 

--- a/cmd/cluster/dynatrace/cluster.go
+++ b/cmd/cluster/dynatrace/cluster.go
@@ -72,7 +72,7 @@ func FetchClusterDetails(clusterKey string) (hcpCluster HCPCluster, error error)
 	if err != nil {
 		return HCPCluster{}, fmt.Errorf("error retreiving Service Cluster for given HCP %s", err)
 	}
-	hcpCluster.hcpNamespace, err = ocmutils.GetHCPNamespace(clusterKey)
+	hcpCluster.hcpNamespace, err = ocmutils.GetHCPNamespace(cluster.ID())
 	if err != nil {
 		return HCPCluster{}, fmt.Errorf("error retreiving HCP Namespace for given cluster")
 	}

--- a/cmd/cluster/dynatrace/logsCmd.go
+++ b/cmd/cluster/dynatrace/logsCmd.go
@@ -91,7 +91,7 @@ func GetLinkToWebConsole(dtURL string, since int, finalQuery string) (string, er
 	}
 	mStr, err := json.Marshal(SearchQuery)
 	if err != nil {
-		return fmt.Sprintf("failed to create JSON for sharable URL"), err
+		return "", fmt.Errorf("failed to create JSON for sharable URL: %v", err)
 	}
 	return fmt.Sprintf("%sui/apps/dynatrace.logs/?gtf=-%dh&gf=all&sortDirection=desc&advancedQueryMode=true&isDefaultQuery=false&visualizationType=table#%s\n\n", dtURL, since, url.PathEscape(string(mStr))), nil
 }

--- a/cmd/cluster/dynatrace/logsCmd.go
+++ b/cmd/cluster/dynatrace/logsCmd.go
@@ -1,8 +1,9 @@
 package dynatrace
 
 import (
-	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -56,8 +57,43 @@ func NewCmdLogs() *cobra.Command {
 	return logsCmd
 }
 
-func GetLinkToWebConsole(dtURL string, since int, base64Url string) string {
-	return fmt.Sprintf("%sui/apps/dynatrace.logs/?gtf=-%dh&gf=all&sortDirection=desc&advancedQueryMode=true&isDefaultQuery=false&visualizationType=table#%s\n\n", dtURL, since, base64Url)
+func GetLinkToWebConsole(dtURL string, since int, finalQuery string) (string, error) {
+	SearchQuery := map[string]interface{}{
+		"version": "0",
+		"data": map[string]interface{}{
+			"tableConfig": map[string]interface{}{
+				"visibleColumns": []string{"timestamp", "status", "content"},
+				"columnAttributes": map[string]interface{}{
+					"columnWidths": map[string]interface{}{},
+					"lineWraps": map[string]interface{}{
+						"timestamp": true,
+						"status":    true,
+						"content":   true,
+					},
+					"tableLineWrap": true,
+				},
+				"columnOrder": []string{"timestamp", "status", "content"},
+			},
+			"queryConfig": map[string]interface{}{
+				"query":     finalQuery,
+				"timeframe": map[string]interface{}{"from": fmt.Sprintf("now()-%vh", since), "to": "now()"},
+				"filter": map[string]interface{}{
+					"datatype": "logs",
+					"filters":  map[string]interface{}{},
+					"sort": map[string]interface{}{
+						"field":     "timestamp",
+						"direction": "desc",
+					},
+				},
+				"showDqlEditor": true,
+			},
+		},
+	}
+	mStr, err := json.Marshal(SearchQuery)
+	if err != nil {
+		return fmt.Sprintf("failed to create JSON for sharable URL"), err
+	}
+	return fmt.Sprintf("%sui/apps/dynatrace.logs/?gtf=-%dh&gf=all&sortDirection=desc&advancedQueryMode=true&isDefaultQuery=false&visualizationType=table#%s\n\n", dtURL, since, url.PathEscape(string(mStr))), nil
 }
 
 func main(clusterID string) error {
@@ -76,7 +112,14 @@ func main(clusterID string) error {
 	}
 
 	fmt.Println(query.Build())
-	fmt.Println("\nLink to Web Console - \n", GetLinkToWebConsole(hcpCluster.DynatraceURL, since, base64.StdEncoding.EncodeToString([]byte(query.finalQuery))))
+
+	url, err := GetLinkToWebConsole(hcpCluster.DynatraceURL, since, query.finalQuery)
+
+	if err != nil {
+		return fmt.Errorf("failed to get url: %v:", err)
+	}
+
+	fmt.Println("\nLink to Web Console - \n", url)
 
 	if dryRun {
 		return nil


### PR DESCRIPTION
### Summary:
**Issue 1:**
When we pass hcp external Id to fetch logs from dt it throws following error. 

`error: failed to acquire cluster details error retreiving HCP Namespace for given cluster
`

Upon investigation, i found _FetchClusterDetails_  func gets the _clusterKey_ input from the cmdline. The following value passed directly to _ocmutils.GetHCPNamespace_ func. I'd replace to pass the `cluster.ID()` to resolve this panic issue & accept the external id as well.

**Issue 2:**
The dt url generated is in classic format. Which result issue in adding the fliters in the web ui, when we open the url generated from osdctl cmd. 

i'd made changes to generate link in app logs format

### Card [OSD-26326](https://issues.redhat.com/browse/OSD-26326)