### PR TITLE
OSD-23467: Facilitate usage of osdctl dynatrace logs

### DIFF
--- a/cmd/cluster/dynatrace/logsCmd.go
+++ b/cmd/cluster/dynatrace/logsCmd.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	k8s "github.com/openshift/osdctl/pkg/k8s"
 	"github.com/spf13/cobra"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
@@ -14,6 +15,7 @@ var (
 	since         int
 	contains      string
 	sortOrder     string
+	clusterID     string
 	namespaceList []string
 	nodeList      []string
 	podList       []string
@@ -21,37 +23,67 @@ var (
 	statusList    []string
 )
 
+const (
+	logsCmdDescription = `
+  Fetch logs of current cluster context (by default) from Dynatrace and display the logs like oc logs.
+
+  This command also prints the Dynatrace URL and the corresponding DQL in the output.
+
+`
+
+	logsCmdExample = `
+  # Get the logs of HCP cluster in current cluster context.
+  $ osdctl cluster dynatrace logs
+
+  # Get the logs of a specific HCP cluster
+  $ osdctl cluster dynatrace logs -c <cluster-id>
+
+  # Get the logs of the pod alertmanager-main-0 in namespace openshift-monitoring
+  $ osdctl cluster dynatrace logs --po alertmanager-main-0 --namespace openshift-monitoring
+
+  # Only return logs newer than 2 hours old (an integer in hours)
+  $ osdctl cluster dynatrace logs --since 2
+
+  # Restrict return of logs to those that contain a specific phrase
+  $ osdctl cluster dynatrace logs --contains <phrase>
+`
+)
+
 func NewCmdLogs() *cobra.Command {
 	logsCmd := &cobra.Command{
-		Use:   "logs <cluster-id>",
-		Short: "Fetch logs from Dynatrace",
-		Long: `Fetch logs from Dynatrace and display the logs like oc logs.
-
-  This command also prints the Dynatrace URL and the corresponding DQL in the output.`,
-		Example: `
-  # Get the logs of HCP cluster hcp-cluster-id-123.
-  # Specify to get the logs of the pod alertmanager-main-0 in namespace openshift-monitoring
-  osdctl cluster dynatrace logs hcp-cluster-id-123 --namespace openshift-monitoring --pod alertmanager-main-0`,
-		Args:              cobra.ExactArgs(1),
+		Use:               "logs",
+		Short:             "Fetch logs from Dynatrace",
+		Long:              logsCmdDescription,
+		Example:           logsCmdExample,
+		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := main(args[0])
+			var err error
+			if clusterID == "" {
+				clusterID, err = k8s.GetCurrentCluster()
+				if err != nil {
+					cmdutil.CheckErr(err)
+				}
+			}
+			err = main(clusterID)
 			if err != nil {
 				cmdutil.CheckErr(err)
 			}
 		},
 	}
 
+	logsCmd.Flags().StringVar(&clusterID, "cluster", "", "Name or ID of the cluster (defaults to current cluster context)")
 	logsCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Only builds the query without fetching any logs from the tenant")
 	logsCmd.Flags().IntVar(&tail, "tail", 100, "Last 'n' logs to fetch (defaults to 100)")
 	logsCmd.Flags().IntVar(&since, "since", 1, "Number of hours (integer) since which to search (defaults to 1 hour)")
 	logsCmd.Flags().StringVar(&contains, "contains", "", "Include logs which contain a phrase")
 	logsCmd.Flags().StringVar(&sortOrder, "sort", "desc", "Sort the results by timestamp in either ascending or descending order. Accepted values are 'asc' and 'desc'")
-	logsCmd.Flags().StringSliceVar(&namespaceList, "namespace", []string{}, "Namespace(s) (comma-separated)")
 	logsCmd.Flags().StringSliceVar(&nodeList, "node", []string{}, "Node name(s) (comma-separated)")
 	logsCmd.Flags().StringSliceVar(&podList, "pod", []string{}, "Pod name(s) (comma-separated)")
-	logsCmd.Flags().StringSliceVar(&containerList, "container", []string{}, "Container name(s) (comma-separated)")
+	logsCmd.Flags().StringSliceVar(&podList, "po", []string{}, "Pod name(s) (comma-separated)")
 	logsCmd.Flags().StringSliceVar(&statusList, "status", []string{}, "Status(Info/Warn/Error) (comma-separated)")
+	logsCmd.Flags().StringSliceVarP(&containerList, "container", "c", []string{}, "Container name(s) (comma-separated)")
+	logsCmd.Flags().StringSliceVarP(&namespaceList, "namespace", "n", []string{}, "Namespace(s) (comma-separated)")
 
 	return logsCmd
 }

--- a/cmd/cluster/dynatrace/logsCmd.go
+++ b/cmd/cluster/dynatrace/logsCmd.go
@@ -36,7 +36,7 @@ const (
   $ osdctl cluster dynatrace logs
 
   # Get the logs of a specific HCP cluster
-  $ osdctl cluster dynatrace logs -c <cluster-id>
+  $ osdctl cluster dynatrace logs --cluster <cluster-id>
 
   # Get the logs of the pod alertmanager-main-0 in namespace openshift-monitoring
   $ osdctl cluster dynatrace logs --po alertmanager-main-0 --namespace openshift-monitoring
@@ -82,7 +82,7 @@ func NewCmdLogs() *cobra.Command {
 	logsCmd.Flags().StringSliceVar(&podList, "pod", []string{}, "Pod name(s) (comma-separated)")
 	logsCmd.Flags().StringSliceVar(&podList, "po", []string{}, "Pod name(s) (comma-separated)")
 	logsCmd.Flags().StringSliceVar(&statusList, "status", []string{}, "Status(Info/Warn/Error) (comma-separated)")
-	logsCmd.Flags().StringSliceVarP(&containerList, "container", "c", []string{}, "Container name(s) (comma-separated)")
+	logsCmd.Flags().StringSliceVar(&containerList, "container", []string{}, "Container name(s) (comma-separated)")
 	logsCmd.Flags().StringSliceVarP(&namespaceList, "namespace", "n", []string{}, "Namespace(s) (comma-separated)")
 
 	return logsCmd


### PR DESCRIPTION
[OSD-23467](https://issues.redhat.com//browse/OSD-23467): Facilitate usage of osdctl dynatrace logs

* Add clusterID fetching from current cluster context as default for dynatrace logs command, can still use `--cluster-id` flag to provide clusterID manually.

* Amend `--po`, `--container`, `--namespace`, flags to better align with `oc logs` command flags.

* Add examples to command to help with use.