### PR TITLE
update the pull secret prefix to work on both normal and domainprefix configured cluster

### DIFF
--- a/cmd/cluster/transferowner.go
+++ b/cmd/cluster/transferowner.go
@@ -295,7 +295,8 @@ func updateManifestWork(conn *sdk.Connection, kubeCli client.Client, clusterID, 
 		return fmt.Errorf("failed to get cluster: %w", err)
 	}
 
-	secretNamePrefix := hostedCluster.Name() + "-pull"
+	// Use domain prefix here instead of hostedcluster.Name, since the pull secret will follow the domain prefix
+	secretNamePrefix := hostedCluster.DomainPrefix() + "-pull"
 
 	// Generate a random new secret name based on the existing pull secret name
 	randomSuffix := func(chars string, length int) string {


### PR DESCRIPTION
Confirmed that for cluster without domain prefix specified, it will set the domain prefix the same as cluster name.
And on service cluster, the pull secret name will follow the pattern as ${DOMAIN_PREFIX}-pull for both kinds