### PR TITLE
Drop blocking prompt when version is outdated

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -153,9 +153,5 @@ func versionCheck() {
 
 	if utils.Version != strings.TrimPrefix(latestVersion, "v") {
 		_, _ = fmt.Fprintf(os.Stderr, "WARN: The current version (%s) is different than the latest released version (%s). It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.\n", utils.Version, latestVersion)
-
-		if !utils.ConfirmPrompt() {
-			os.Exit(0)
-		}
 	}
 }


### PR DESCRIPTION
When running commands on an older version of `osdctl`, it currently blocks execution waiting for the user to provide input. When this happens in aliases (subshell etc), the execution blocks and it is not clear why.

As we are logging a warning to `stderr`, I feel that is enough for someone to then go update if they choose, or ignore it.

This isn't urgent, but it is a small quality of life improvement for automating tasks around `osdctl`.