### PR TITLE
OSD-25053: Add basic GCP support for network egress verification

### DIFF
--- a/cmd/network/aws_test.go
+++ b/cmd/network/aws_test.go
@@ -1,0 +1,428 @@
+package network
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/osd-network-verifier/pkg/data/cloud"
+	"github.com/openshift/osd-network-verifier/pkg/proxy"
+	onv "github.com/openshift/osd-network-verifier/pkg/verifier"
+	"testing"
+	"time"
+)
+
+type mockEgressVerificationAWSClient struct {
+	describeSecurityGroupsResp *ec2.DescribeSecurityGroupsOutput
+	describeSubnetsResp        *ec2.DescribeSubnetsOutput
+	describeRouteTablesResp    *ec2.DescribeRouteTablesOutput
+}
+
+func (m mockEgressVerificationAWSClient) DescribeSubnets(context.Context, *ec2.DescribeSubnetsInput, ...func(options *ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
+	return m.describeSubnetsResp, nil
+}
+
+func (m mockEgressVerificationAWSClient) DescribeSecurityGroups(context.Context, *ec2.DescribeSecurityGroupsInput, ...func(options *ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {
+	return m.describeSecurityGroupsResp, nil
+}
+func (m mockEgressVerificationAWSClient) DescribeRouteTables(context.Context, *ec2.DescribeRouteTablesInput, ...func(options *ec2.Options)) (*ec2.DescribeRouteTablesOutput, error) {
+	return m.describeRouteTablesResp, nil
+}
+
+func Test_egressVerification_setupForAws(t *testing.T) {
+	tests := []struct {
+		name      string
+		e         *EgressVerification
+		expectErr bool
+	}{
+		{
+			name:      "no ClusterId requires subnet/sg",
+			e:         &EgressVerification{},
+			expectErr: true,
+		},
+		{
+			name:      "no ClusterId with subnet",
+			e:         &EgressVerification{SubnetIds: []string{"subnet-a"}},
+			expectErr: true,
+		},
+		{
+			name:      "no ClusterId with security group",
+			e:         &EgressVerification{SecurityGroupId: "sg-a"},
+			expectErr: true,
+		},
+		{
+			name:      "no ClusterId with platform type",
+			e:         &EgressVerification{platformName: "aws"},
+			expectErr: true,
+		},
+		{
+			name: "no ClusterId with subnet and security group",
+			e: &EgressVerification{
+				SubnetIds:       []string{"subnet-a", "subnet-b", "subnet-c"},
+				SecurityGroupId: "sg-b",
+			},
+			expectErr: true,
+		},
+		{
+			name: "no ClusterId with subnet and platform type",
+			e: &EgressVerification{
+				SubnetIds:    []string{"subnet-a", "subnet-b", "subnet-c"},
+				platformName: "aws",
+			},
+			expectErr: true,
+		},
+		{
+			name: "no ClusterId with security group and platform type",
+			e: &EgressVerification{
+				SecurityGroupId: "sg-b",
+				platformName:    "aws",
+			},
+			expectErr: true,
+		},
+		{
+			name: "ClusterId optional",
+			e: &EgressVerification{
+				SubnetIds:       []string{"subnet-a", "subnet-b", "subnet-c"},
+				SecurityGroupId: "sg-b",
+				platformName:    "aws",
+				log:             newTestLogger(t),
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			err := test.e.fetchCluster(ctx)
+			if err != nil {
+				t.Errorf("expected no err, got %s", err)
+			}
+
+			_, err = test.e.setupForAws(ctx)
+			if err != nil {
+				if !test.expectErr {
+					t.Errorf("expected no err, got %s", err)
+				}
+			} else {
+				if test.expectErr {
+					t.Errorf("expected err, got none")
+				}
+			}
+		})
+	}
+}
+
+func Test_egressVerification_GenerateAWSValidateEgressInput(t *testing.T) {
+	tests := []struct {
+		name      string
+		e         *EgressVerification
+		region    string
+		expected  *onv.ValidateEgressInput
+		expectErr bool
+	}{
+		{
+			name: "Cluster-wide proxy requires cacert when there is an additional trust bundle",
+			e: &EgressVerification{
+				cluster: newTestCluster(t, cmv1.NewCluster().
+					CloudProvider(cmv1.NewCloudProvider().ID("aws")).
+					Product(cmv1.NewProduct().ID("rosa")).
+					AdditionalTrustBundle("REDACTED").
+					Proxy(cmv1.NewProxy().HTTPProxy("http://my.proxy:80").HTTPSProxy("https://my.proxy:443")),
+				),
+				log: newTestLogger(t),
+			},
+			region:    "us-east-2",
+			expectErr: true,
+		},
+		{
+			name: "Transparent cluster-wide proxy",
+			e: &EgressVerification{
+				awsClient: mockEgressVerificationAWSClient{
+					describeSecurityGroupsResp: &ec2.DescribeSecurityGroupsOutput{
+						SecurityGroups: []types.SecurityGroup{
+							{
+								GroupId: aws.String("sg-abcd"),
+							},
+						},
+					},
+					describeSubnetsResp: &ec2.DescribeSubnetsOutput{
+						Subnets: []types.Subnet{
+							{
+								SubnetId: aws.String("subnet-abcd"),
+							},
+						},
+					},
+					describeRouteTablesResp: &ec2.DescribeRouteTablesOutput{
+						RouteTables: []types.RouteTable{
+							{
+								RouteTableId: aws.String("rt-id"),
+								Routes: []types.Route{
+									{
+										GatewayId: aws.String("gateway"),
+									},
+								},
+							},
+						},
+					},
+				},
+				cluster: newTestCluster(t, cmv1.NewCluster().
+					CloudProvider(cmv1.NewCloudProvider().ID("aws")).
+					Product(cmv1.NewProduct().ID("rosa")).
+					Proxy(cmv1.NewProxy().HTTPProxy("http://my.proxy:80").HTTPSProxy("https://my.proxy:443")),
+				),
+				log: newTestLogger(t),
+			},
+			region: "us-east-2",
+			expected: &onv.ValidateEgressInput{
+				SubnetID: "subnet-abcd",
+				Proxy: proxy.ProxyConfig{
+					HttpProxy:  "http://my.proxy:80",
+					HttpsProxy: "https://my.proxy:443",
+				},
+				AWS: onv.AwsEgressConfig{
+					SecurityGroupIDs: []string{"sg-abcd"},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "Cluster specific KMS key forward",
+			e: &EgressVerification{
+				awsClient: mockEgressVerificationAWSClient{
+					describeSecurityGroupsResp: &ec2.DescribeSecurityGroupsOutput{
+						SecurityGroups: []types.SecurityGroup{
+							{
+								GroupId: aws.String("sg-abcd"),
+							},
+						},
+					},
+					describeSubnetsResp: &ec2.DescribeSubnetsOutput{
+						Subnets: []types.Subnet{
+							{
+								SubnetId: aws.String("subnet-abcd"),
+							},
+						},
+					},
+					describeRouteTablesResp: &ec2.DescribeRouteTablesOutput{
+						RouteTables: []types.RouteTable{
+							{
+								RouteTableId: aws.String("rt-id"),
+								Routes: []types.Route{
+									{
+										GatewayId: aws.String("gateway"),
+									},
+								},
+							},
+						},
+					},
+				},
+
+				cluster: newTestCluster(t, cmv1.NewCluster().
+					CloudProvider(cmv1.NewCloudProvider().ID("aws")).
+					Product(cmv1.NewProduct().ID("rosa")).
+					AWS(cmv1.NewAWS().KMSKeyArn("some-KMS-key-ARN")),
+				),
+				log:           newTestLogger(t),
+				EgressTimeout: 42 * time.Second,
+			},
+			region: "us-east-2",
+			expected: &onv.ValidateEgressInput{
+				SubnetID: "subnet-abcd",
+				AWS: onv.AwsEgressConfig{
+					SecurityGroupIDs: []string{"sg-abcd"},
+					KmsKeyID:         "some-KMS-key-ARN",
+				},
+				Timeout: 42 * time.Second,
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := test.e.generateAWSValidateEgressInput(context.Background(), cloud.AWSClassic)
+			if err != nil {
+				if !test.expectErr {
+					t.Errorf("expected no err, got %s", err)
+				}
+			} else {
+				if test.expectErr {
+					t.Errorf("expected err, got none")
+				}
+				for i := range actual {
+					if !compareValidateEgressInput(test.expected, actual[i]) {
+						t.Errorf("expected %v, got %v", test.expected, actual[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func Test_egressVerification_GetAwsSecurityGroupId(t *testing.T) {
+	tests := []struct {
+		name      string
+		e         *EgressVerification
+		expected  string
+		expectErr bool
+	}{
+		{
+			name: "manual override",
+			e: &EgressVerification{
+				awsClient: mockEgressVerificationAWSClient{
+					describeSecurityGroupsResp: &ec2.DescribeSecurityGroupsOutput{
+						SecurityGroups: []types.SecurityGroup{
+							{
+								GroupId: aws.String("sg-abcd"),
+							},
+						},
+					},
+				},
+				log:             newTestLogger(t),
+				cluster:         newTestCluster(t, cmv1.NewCluster().CloudProvider(cmv1.NewCloudProvider().ID("aws"))),
+				SecurityGroupId: "override",
+			},
+			expected:  "override",
+			expectErr: false,
+		},
+		{
+			name: "zero from AWS",
+			e: &EgressVerification{
+				awsClient: mockEgressVerificationAWSClient{
+					describeSecurityGroupsResp: &ec2.DescribeSecurityGroupsOutput{
+						SecurityGroups: []types.SecurityGroup{},
+					},
+				},
+				log:     newTestLogger(t),
+				cluster: newTestCluster(t, cmv1.NewCluster().CloudProvider(cmv1.NewCloudProvider().ID("aws"))),
+			},
+			expectErr: true,
+		},
+		{
+			name: "one from AWS",
+			e: &EgressVerification{
+				awsClient: mockEgressVerificationAWSClient{
+					describeSecurityGroupsResp: &ec2.DescribeSecurityGroupsOutput{
+						SecurityGroups: []types.SecurityGroup{
+							{
+								GroupId: aws.String("sg-abcd"),
+							},
+						},
+					},
+				},
+				log:     newTestLogger(t),
+				cluster: newTestCluster(t, cmv1.NewCluster().CloudProvider(cmv1.NewCloudProvider().ID("aws"))),
+			},
+			expected:  "sg-abcd",
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := test.e.getSecurityGroupId(context.TODO())
+			if err != nil {
+				if !test.expectErr {
+					t.Errorf("expected no err, got %s", err)
+				}
+			} else {
+				if test.expectErr {
+					t.Errorf("expected err, got none")
+				}
+				if actual != test.expected {
+					t.Errorf("expected sg-id %s, got %s", test.expected, actual)
+				}
+			}
+		})
+	}
+}
+
+func Test_egressVerification_GetAwsSubnetId(t *testing.T) {
+	tests := []struct {
+		name      string
+		e         *EgressVerification
+		expected  string
+		expectErr bool
+	}{
+		{
+			name: "manual override",
+			e: &EgressVerification{
+				log:       newTestLogger(t),
+				SubnetIds: []string{"override"},
+			},
+			expected:  "override",
+			expectErr: false,
+		},
+		{
+			name: "non-PrivateLink + BYOVPC unsupported",
+			e: &EgressVerification{
+				cluster: newTestCluster(t, cmv1.NewCluster().AWS(cmv1.NewAWS().PrivateLink(false).SubnetIDs("subnet-abcd"))),
+				log:     newTestLogger(t),
+			},
+			expectErr: true,
+		},
+		{
+			name: "PrivateLink + BYOVPC picks the first subnet",
+			e: &EgressVerification{
+				cluster: newTestCluster(t, cmv1.NewCluster().AWS(cmv1.NewAWS().PrivateLink(true).SubnetIDs("subnet-abcd"))),
+				log:     newTestLogger(t),
+			},
+			expected:  "subnet-abcd",
+			expectErr: false,
+		},
+		{
+			name: "non-BYOVPC clusters get subnets from AWS",
+			e: &EgressVerification{
+				awsClient: mockEgressVerificationAWSClient{
+					describeSubnetsResp: &ec2.DescribeSubnetsOutput{
+						Subnets: []types.Subnet{
+							{
+								SubnetId: aws.String("subnet-abcd"),
+							},
+						},
+					},
+				},
+				cluster: newTestCluster(t, cmv1.NewCluster()),
+				log:     newTestLogger(t),
+			},
+			expected:  "subnet-abcd",
+			expectErr: false,
+		},
+		{
+			name: "non-BYOVPC clusters error if no subnets found in AWS",
+			e: &EgressVerification{
+				awsClient: mockEgressVerificationAWSClient{
+					describeSubnetsResp: &ec2.DescribeSubnetsOutput{
+						Subnets: []types.Subnet{},
+					},
+				},
+				cluster: newTestCluster(t, cmv1.NewCluster()),
+				log:     newTestLogger(t),
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := test.e.getAwsSubnetIds(context.TODO())
+			if err != nil {
+				if !test.expectErr {
+					t.Errorf("expected no err, got %s", err)
+				}
+			} else {
+				for i := range actual {
+
+					if test.expectErr {
+						t.Errorf("expected err, got none")
+					}
+					if actual[i] != test.expected {
+						t.Errorf("expected subnet-id %s, got %s", test.expected, actual[i])
+					}
+				}
+			}
+		})
+	}
+}

--- a/cmd/network/gcp.go
+++ b/cmd/network/gcp.go
@@ -1,0 +1,102 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"github.com/openshift/osd-network-verifier/pkg/data/cloud"
+	"github.com/openshift/osd-network-verifier/pkg/verifier"
+	"golang.org/x/oauth2/google"
+)
+
+func (e *EgressVerification) setupForGcp(ctx context.Context) (*google.Credentials, error) {
+	// If the user does not provide a ClusterID, but provides the Platform as GCP, require explicit subnet-id
+	if e.ClusterId == "" {
+		if e.SubnetIds == nil || e.platformName == "" {
+			return nil, fmt.Errorf("--subnet-id and --platform are required when --cluster-id is not specified")
+		}
+	}
+
+	return google.FindDefaultCredentials(ctx)
+}
+
+func (e *EgressVerification) generateGcpValidateEgressInput(ctx context.Context, platform cloud.Platform) ([]*verifier.ValidateEgressInput, error) {
+	input, err := e.defaultValidateEgressInput(ctx, platform)
+	if err != nil {
+		return nil, fmt.Errorf("failed to assemble validate egress input: %s", err)
+	}
+
+	// We don't store any tags for GCP in OCM like we do for AWS, so we just use the default
+	// GCP doesn't support uppercase labels
+	input.Tags["name"] = "osd-network-verifier"
+
+	subnetIds, err := e.getGcpSubnetIds(ctx)
+	if err != nil {
+		return nil, err
+	}
+	input.SubnetID = subnetIds[0]
+
+	// Allow overriding the region
+	if e.Region != "" {
+		input.GCP.Region = e.Region
+	} else {
+		input.GCP.Region = e.cluster.Region().ID()
+	}
+	if input.GCP.Region == "" {
+		return nil, fmt.Errorf("could not get region from OCM, specify manually with --region")
+	}
+
+	if e.VpcName != "" {
+		input.GCP.VpcName = e.VpcName
+	} else {
+		input.GCP.VpcName = e.cluster.GCPNetwork().VPCName()
+	}
+	if input.GCP.VpcName == "" {
+		return nil, fmt.Errorf("could not get vpc name from OCM, specify manually with --vpc")
+	}
+
+	// Allow overriding the project ID
+	if e.GcpProjectID != "" {
+		input.GCP.ProjectID = e.GcpProjectID
+	} else {
+		input.GCP.ProjectID = e.cluster.GCP().ProjectID()
+	}
+	if input.GCP.ProjectID == "" {
+		return nil, fmt.Errorf("could not get GCP project ID from OCM, specify manually with --gcp-project-id")
+	}
+
+	// We default to zone B for the region, as does osd-network-verifier, since it has the most instance types.
+	input.GCP.Zone = fmt.Sprintf("%s-b", input.GCP.Region)
+
+	// Creating a slice of input values for the network-verifier to loop over.
+	// All inputs are essentially equivalent except their subnet ids
+	inputs := make([]*verifier.ValidateEgressInput, len(subnetIds))
+	for i := range subnetIds {
+		// Copying a pointer to avoid overwriting it
+		var myinput = &verifier.ValidateEgressInput{}
+		*myinput = *input
+		inputs[i] = myinput
+		inputs[i].SubnetID = subnetIds[i]
+	}
+
+	return inputs, nil
+}
+
+func (e *EgressVerification) getGcpSubnetIds(ctx context.Context) ([]string, error) {
+	if e.SubnetIds != nil {
+		e.log.Info(ctx, "using manually specified subnet-id(s): %s", e.SubnetIds)
+		return e.SubnetIds, nil
+	}
+
+	// TODO: Add support for non-BYOVPC in GCP
+	// Protect against non-BYOVPC, where we don't have OCM data on subnets.
+	if e.cluster.GCPNetwork().ComputeSubnet() == "" && e.cluster.GCPNetwork().ControlPlaneSubnet() == "" {
+		return nil, fmt.Errorf("this cluster is non-BYOVPC and discovering subnets not yet supported, pass via --subnet-id")
+	}
+
+	subnetIds := []string{
+		e.cluster.GCPNetwork().ComputeSubnet(),
+		e.cluster.GCPNetwork().ControlPlaneSubnet(),
+	}
+
+	return subnetIds, nil
+}

--- a/cmd/network/gcp_test.go
+++ b/cmd/network/gcp_test.go
@@ -1,0 +1,79 @@
+package network
+
+import (
+	"context"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/osd-network-verifier/pkg/data/cloud"
+	"testing"
+)
+
+func Test_setupForGcp_InvalidOptions(t *testing.T) {
+	e := &EgressVerification{}
+	_, err := e.setupForGcp(context.Background())
+	if err != nil && err.Error() != "--subnet-id and --platform are required when --cluster-id is not specified" {
+		t.Errorf("expected error but got %s", err)
+	}
+}
+
+// This tests GCP with data being pulled from OCM. We hydrate a cluster with the data versus mocking OCM
+func Test_generateGcpValidateEgressInput_DefaultBehavior(t *testing.T) {
+	e := &EgressVerification{
+		cluster: newTestCluster(t, cmv1.NewCluster().
+			CloudProvider(cmv1.NewCloudProvider().ID("gcp")).
+			Region(cmv1.NewCloudRegion().ID("us-east1")).
+			Product(cmv1.NewProduct().ID("rosa")).
+			GCP(cmv1.NewGCP().ProjectID("my-project")).
+			GCPNetwork(cmv1.NewGCPNetwork().VPCName("test-vpc").ComputeSubnet("subnet-compute").ControlPlaneSubnet("subnet-cpane")),
+		),
+		log: newTestLogger(t),
+	}
+	inputs, err := e.generateGcpValidateEgressInput(context.Background(), cloud.GCPClassic)
+	if err != nil {
+		t.Errorf("expected no error but got %s", err)
+	}
+
+	if len(inputs) != 2 {
+		t.Errorf("expected 2 inputs but got %d", len(inputs))
+	}
+
+	sampleInput := inputs[0]
+	if sampleInput.SubnetID != "subnet-compute" {
+		t.Errorf("expected subnet-compute but got %s", inputs[0].SubnetID)
+	}
+
+	if sampleInput.GCP.Zone != "us-east1-b" {
+		t.Errorf("expected GCP.Zone to be us-east1-b but got %s", sampleInput.GCP.Zone)
+	}
+
+	if sampleInput.Tags["name"] != "osd-network-verifier" {
+		t.Errorf("expected tag name=osd-network-verifier but got value %s", sampleInput.Tags["name"])
+	}
+}
+
+// This tests GCP without data from OCM
+func Test_generateGcpValidateEgressInput_UserProvidedValues(t *testing.T) {
+	e := &EgressVerification{
+		Region:       "us-east1",
+		GcpProjectID: "my-project",
+		SubnetIds:    []string{"subnet-compute", "subnet-cpane"},
+		VpcName:      "test-vpc",
+		log:          newTestLogger(t),
+	}
+	inputs, err := e.generateGcpValidateEgressInput(context.Background(), cloud.GCPClassic)
+	if err != nil {
+		t.Errorf("expected no error but got %s", err)
+	}
+
+	sampleInput := inputs[0]
+	if sampleInput.SubnetID != "subnet-compute" {
+		t.Errorf("expected subnet-compute but got %s", inputs[0].SubnetID)
+	}
+
+	if sampleInput.GCP.Zone != "us-east1-b" {
+		t.Errorf("expected GCP.Zone to be us-east1-b but got %s", sampleInput.GCP.Zone)
+	}
+
+	if sampleInput.Tags["name"] != "osd-network-verifier" {
+		t.Errorf("expected tag name=osd-network-verifier but got value %s", sampleInput.Tags["name"])
+	}
+}

--- a/cmd/network/verification_test.go
+++ b/cmd/network/verification_test.go
@@ -3,10 +3,6 @@ package network
 import (
 	"context"
 	"fmt"
-	"reflect"
-	"testing"
-	"time"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -15,10 +11,11 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/osd-network-verifier/pkg/data/cloud"
 	"github.com/openshift/osd-network-verifier/pkg/output"
-	"github.com/openshift/osd-network-verifier/pkg/proxy"
 	onv "github.com/openshift/osd-network-verifier/pkg/verifier"
 	"github.com/openshift/osdctl/cmd/servicelog"
 	"k8s.io/apimachinery/pkg/runtime"
+	"reflect"
+	"testing"
 )
 
 func newTestLogger(t *testing.T) logging.Logger {
@@ -40,262 +37,6 @@ func newTestCluster(t *testing.T, cb *cmv1.ClusterBuilder) *cmv1.Cluster {
 	}
 
 	return cluster
-}
-
-type mockEgressVerificationAWSClient struct {
-	describeSecurityGroupsResp *ec2.DescribeSecurityGroupsOutput
-	describeSubnetsResp        *ec2.DescribeSubnetsOutput
-	describeRouteTablesResp    *ec2.DescribeRouteTablesOutput
-}
-
-func (m mockEgressVerificationAWSClient) DescribeSubnets(context.Context, *ec2.DescribeSubnetsInput, ...func(options *ec2.Options)) (*ec2.DescribeSubnetsOutput, error) {
-	return m.describeSubnetsResp, nil
-}
-
-func (m mockEgressVerificationAWSClient) DescribeSecurityGroups(context.Context, *ec2.DescribeSecurityGroupsInput, ...func(options *ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {
-	return m.describeSecurityGroupsResp, nil
-}
-func (m mockEgressVerificationAWSClient) DescribeRouteTables(context.Context, *ec2.DescribeRouteTablesInput, ...func(options *ec2.Options)) (*ec2.DescribeRouteTablesOutput, error) {
-	return m.describeRouteTablesResp, nil
-}
-func Test_egressVerificationSetup(t *testing.T) {
-	tests := []struct {
-		name      string
-		e         *EgressVerification
-		expectErr bool
-	}{
-		{
-			name:      "no ClusterId requires subnet/sg",
-			e:         &EgressVerification{},
-			expectErr: true,
-		},
-		{
-			name:      "no ClusterId with subnet",
-			e:         &EgressVerification{SubnetIds: []string{"subnet-a"}},
-			expectErr: true,
-		},
-		{
-			name:      "no ClusterId with security group",
-			e:         &EgressVerification{SecurityGroupId: "sg-a"},
-			expectErr: true,
-		},
-		{
-			name:      "no ClusterId with platform type",
-			e:         &EgressVerification{platformName: "aws"},
-			expectErr: true,
-		},
-		{
-			name: "no ClusterId with subnet and security group",
-			e: &EgressVerification{
-				SubnetIds:       []string{"subnet-a", "subnet-b", "subnet-c"},
-				SecurityGroupId: "sg-b",
-			},
-			expectErr: true,
-		},
-		{
-			name: "no ClusterId with subnet and platform type",
-			e: &EgressVerification{
-				SubnetIds:    []string{"subnet-a", "subnet-b", "subnet-c"},
-				platformName: "aws",
-			},
-			expectErr: true,
-		},
-		{
-			name: "no ClusterId with security group and platform type",
-			e: &EgressVerification{
-				SecurityGroupId: "sg-b",
-				platformName:    "aws",
-			},
-			expectErr: true,
-		},
-		{
-			name: "ClusterId optional",
-			e: &EgressVerification{
-				SubnetIds:       []string{"subnet-a", "subnet-b", "subnet-c"},
-				SecurityGroupId: "sg-b",
-				platformName:    "aws",
-				log:             newTestLogger(t),
-			},
-			expectErr: false,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
-			err := test.e.fetchCluster(ctx)
-			if err != nil {
-				t.Errorf("expected no err, got %s", err)
-			}
-
-			_, err = test.e.setupForAws(ctx)
-			if err != nil {
-				if !test.expectErr {
-					t.Errorf("expected no err, got %s", err)
-				}
-			} else {
-				if test.expectErr {
-					t.Errorf("expected err, got none")
-				}
-			}
-		})
-	}
-}
-
-func Test_egressVerificationGenerateAWSValidateEgressInput(t *testing.T) {
-	tests := []struct {
-		name      string
-		e         *EgressVerification
-		region    string
-		expected  *onv.ValidateEgressInput
-		expectErr bool
-	}{
-
-		{
-			name: "GCP Unsupported",
-			e: &EgressVerification{
-				cluster: newTestCluster(t, cmv1.NewCluster().CloudProvider(cmv1.NewCloudProvider().ID("gcp"))),
-				log:     newTestLogger(t),
-			},
-			expectErr: true,
-		},
-		{
-			name: "Cluster-wide proxy requires cacert when there is an additional trust bundle",
-			e: &EgressVerification{
-				cluster: newTestCluster(t, cmv1.NewCluster().
-					CloudProvider(cmv1.NewCloudProvider().ID("aws")).
-					Product(cmv1.NewProduct().ID("rosa")).
-					AdditionalTrustBundle("REDACTED").
-					Proxy(cmv1.NewProxy().HTTPProxy("http://my.proxy:80").HTTPSProxy("https://my.proxy:443")),
-				),
-				log: newTestLogger(t),
-			},
-			region:    "us-east-2",
-			expectErr: true,
-		},
-		{
-			name: "Transparent cluster-wide proxy",
-			e: &EgressVerification{
-				awsClient: mockEgressVerificationAWSClient{
-					describeSecurityGroupsResp: &ec2.DescribeSecurityGroupsOutput{
-						SecurityGroups: []types.SecurityGroup{
-							{
-								GroupId: aws.String("sg-abcd"),
-							},
-						},
-					},
-					describeSubnetsResp: &ec2.DescribeSubnetsOutput{
-						Subnets: []types.Subnet{
-							{
-								SubnetId: aws.String("subnet-abcd"),
-							},
-						},
-					},
-					describeRouteTablesResp: &ec2.DescribeRouteTablesOutput{
-						RouteTables: []types.RouteTable{
-							{
-								RouteTableId: aws.String("rt-id"),
-								Routes: []types.Route{
-									{
-										GatewayId: aws.String("gateway"),
-									},
-								},
-							},
-						},
-					},
-				},
-				cluster: newTestCluster(t, cmv1.NewCluster().
-					CloudProvider(cmv1.NewCloudProvider().ID("aws")).
-					Product(cmv1.NewProduct().ID("rosa")).
-					Proxy(cmv1.NewProxy().HTTPProxy("http://my.proxy:80").HTTPSProxy("https://my.proxy:443")),
-				),
-				log: newTestLogger(t),
-			},
-			region: "us-east-2",
-			expected: &onv.ValidateEgressInput{
-				SubnetID: "subnet-abcd",
-				Proxy: proxy.ProxyConfig{
-					HttpProxy:  "http://my.proxy:80",
-					HttpsProxy: "https://my.proxy:443",
-				},
-				AWS: onv.AwsEgressConfig{
-					SecurityGroupIDs: []string{"sg-abcd"},
-				},
-			},
-			expectErr: false,
-		},
-		{
-			name: "Cluster specific KMS key forward",
-			e: &EgressVerification{
-				awsClient: mockEgressVerificationAWSClient{
-					describeSecurityGroupsResp: &ec2.DescribeSecurityGroupsOutput{
-						SecurityGroups: []types.SecurityGroup{
-							{
-								GroupId: aws.String("sg-abcd"),
-							},
-						},
-					},
-					describeSubnetsResp: &ec2.DescribeSubnetsOutput{
-						Subnets: []types.Subnet{
-							{
-								SubnetId: aws.String("subnet-abcd"),
-							},
-						},
-					},
-					describeRouteTablesResp: &ec2.DescribeRouteTablesOutput{
-						RouteTables: []types.RouteTable{
-							{
-								RouteTableId: aws.String("rt-id"),
-								Routes: []types.Route{
-									{
-										GatewayId: aws.String("gateway"),
-									},
-								},
-							},
-						},
-					},
-				},
-
-				cluster: newTestCluster(t, cmv1.NewCluster().
-					CloudProvider(cmv1.NewCloudProvider().ID("aws")).
-					Product(cmv1.NewProduct().ID("rosa")).
-					AWS(cmv1.NewAWS().KMSKeyArn("some-KMS-key-ARN")),
-				),
-				log:           newTestLogger(t),
-				EgressTimeout: 42 * time.Second,
-			},
-			region: "us-east-2",
-			expected: &onv.ValidateEgressInput{
-				SubnetID: "subnet-abcd",
-				AWS: onv.AwsEgressConfig{
-					SecurityGroupIDs: []string{"sg-abcd"},
-					KmsKeyID:         "some-KMS-key-ARN",
-				},
-				Timeout: 42 * time.Second,
-			},
-			expectErr: false,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actual, err := test.e.generateAWSValidateEgressInput(context.TODO(), test.region)
-			if err != nil {
-				if !test.expectErr {
-					t.Errorf("expected no err, got %s", err)
-				}
-			} else {
-				if test.expectErr {
-					t.Errorf("expected err, got none")
-				}
-				for i := range actual {
-					if !compareValidateEgressInput(test.expected, actual[i]) {
-						t.Errorf("expected %v, got %v", test.expected, actual[i])
-					}
-				}
-			}
-		})
-	}
 }
 
 func Test_egressVerificationGetPlatform(t *testing.T) {
@@ -371,206 +112,29 @@ func Test_egressVerificationGetPlatform(t *testing.T) {
 	}
 }
 
-func Test_egressVerificationGetSecurityGroupId(t *testing.T) {
-	tests := []struct {
-		name      string
-		e         *EgressVerification
-		expected  string
-		expectErr bool
-	}{
-		{
-			name: "manual override",
-			e: &EgressVerification{
-				awsClient: mockEgressVerificationAWSClient{
-					describeSecurityGroupsResp: &ec2.DescribeSecurityGroupsOutput{
-						SecurityGroups: []types.SecurityGroup{
-							{
-								GroupId: aws.String("sg-abcd"),
-							},
-						},
-					},
-				},
-				log:             newTestLogger(t),
-				cluster:         newTestCluster(t, cmv1.NewCluster().CloudProvider(cmv1.NewCloudProvider().ID("aws"))),
-				SecurityGroupId: "override",
-			},
-			expected:  "override",
-			expectErr: false,
-		},
-		{
-			name: "zero from AWS",
-			e: &EgressVerification{
-				awsClient: mockEgressVerificationAWSClient{
-					describeSecurityGroupsResp: &ec2.DescribeSecurityGroupsOutput{
-						SecurityGroups: []types.SecurityGroup{},
-					},
-				},
-				log:     newTestLogger(t),
-				cluster: newTestCluster(t, cmv1.NewCluster().CloudProvider(cmv1.NewCloudProvider().ID("aws"))),
-			},
-			expectErr: true,
-		},
-		{
-			name: "one from AWS",
-			e: &EgressVerification{
-				awsClient: mockEgressVerificationAWSClient{
-					describeSecurityGroupsResp: &ec2.DescribeSecurityGroupsOutput{
-						SecurityGroups: []types.SecurityGroup{
-							{
-								GroupId: aws.String("sg-abcd"),
-							},
-						},
-					},
-				},
-				log:     newTestLogger(t),
-				cluster: newTestCluster(t, cmv1.NewCluster().CloudProvider(cmv1.NewCloudProvider().ID("aws"))),
-			},
-			expected:  "sg-abcd",
-			expectErr: false,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actual, err := test.e.getSecurityGroupId(context.TODO())
-			if err != nil {
-				if !test.expectErr {
-					t.Errorf("expected no err, got %s", err)
-				}
-			} else {
-				if test.expectErr {
-					t.Errorf("expected err, got none")
-				}
-				if actual != test.expected {
-					t.Errorf("expected sg-id %s, got %s", test.expected, actual)
-				}
-			}
-		})
-	}
-}
-
-func Test_egressVerificationGetSubnetId(t *testing.T) {
-	tests := []struct {
-		name      string
-		e         *EgressVerification
-		expected  string
-		expectErr bool
-	}{
-		{
-			name: "manual override",
-			e: &EgressVerification{
-				log:       newTestLogger(t),
-				SubnetIds: []string{"override"},
-			},
-			expected:  "override",
-			expectErr: false,
-		},
-		{
-			name: "non-PrivateLink + BYOVPC unsupported",
-			e: &EgressVerification{
-				cluster: newTestCluster(t, cmv1.NewCluster().AWS(cmv1.NewAWS().PrivateLink(false).SubnetIDs("subnet-abcd"))),
-				log:     newTestLogger(t),
-			},
-			expectErr: true,
-		},
-		{
-			name: "PrivateLink + BYOVPC picks the first subnet",
-			e: &EgressVerification{
-				cluster: newTestCluster(t, cmv1.NewCluster().AWS(cmv1.NewAWS().PrivateLink(true).SubnetIDs("subnet-abcd"))),
-				log:     newTestLogger(t),
-			},
-			expected:  "subnet-abcd",
-			expectErr: false,
-		},
-		{
-			name: "non-BYOVPC clusters get subnets from AWS",
-			e: &EgressVerification{
-				awsClient: mockEgressVerificationAWSClient{
-					describeSubnetsResp: &ec2.DescribeSubnetsOutput{
-						Subnets: []types.Subnet{
-							{
-								SubnetId: aws.String("subnet-abcd"),
-							},
-						},
-					},
-				},
-				cluster: newTestCluster(t, cmv1.NewCluster()),
-				log:     newTestLogger(t),
-			},
-			expected:  "subnet-abcd",
-			expectErr: false,
-		},
-		{
-			name: "non-BYOVPC clusters error if no subnets found in AWS",
-			e: &EgressVerification{
-				awsClient: mockEgressVerificationAWSClient{
-					describeSubnetsResp: &ec2.DescribeSubnetsOutput{
-						Subnets: []types.Subnet{},
-					},
-				},
-				cluster: newTestCluster(t, cmv1.NewCluster()),
-				log:     newTestLogger(t),
-			},
-			expectErr: true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			actual, err := test.e.getSubnetIds(context.TODO())
-			if err != nil {
-				if !test.expectErr {
-					t.Errorf("expected no err, got %s", err)
-				}
-			} else {
-				for i := range actual {
-
-					if test.expectErr {
-						t.Errorf("expected err, got none")
-					}
-					if actual[i] != test.expected {
-						t.Errorf("expected subnet-id %s, got %s", test.expected, actual[i])
-					}
-				}
-			}
-		})
-	}
-}
-
 func TestDefaultValidateEgressInput(t *testing.T) {
-	customTags := map[string]string{
-		"a": "b",
-	}
-
 	tests := []struct {
-		region         string
-		withCustomTags bool
-		expectErr      bool
+		region    string
+		expectErr bool
 	}{
 		{
-			region:         "us-east-2",
-			withCustomTags: false,
-			expectErr:      false,
+			region:    "us-east-2",
+			expectErr: false,
 		},
 		{
-			region:         "eu-central-1",
-			withCustomTags: true,
-			expectErr:      false,
-		},
-		{
-			region:         "us-central-1",
-			withCustomTags: false,
-			expectErr:      true,
+			region:    "eu-central-1",
+			expectErr: false,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.region, func(t *testing.T) {
 			cluster := newTestCluster(t, cmv1.NewCluster().AWS(cmv1.NewAWS()))
-			if test.withCustomTags {
-				cluster = newTestCluster(t, cmv1.NewCluster().AWS(cmv1.NewAWS().Tags(customTags)))
+			e := &EgressVerification{
+				cluster: cluster,
+				log:     newTestLogger(t),
 			}
-			actual, err := defaultValidateEgressInput(context.TODO(), cluster, test.region)
+			_, err := e.defaultValidateEgressInput(context.Background(), cloud.AWSClassic)
 			if err != nil {
 				if !test.expectErr {
 					t.Errorf("expected no err, got %s", err)
@@ -578,16 +142,6 @@ func TestDefaultValidateEgressInput(t *testing.T) {
 			} else {
 				if test.expectErr {
 					t.Errorf("expected err, got none")
-				}
-				if test.withCustomTags {
-					for k := range customTags {
-						if v, ok := actual.Tags[k]; !ok {
-							t.Errorf("expected %v to contain %v", actual.Tags, k)
-							if v != customTags[k] {
-								t.Errorf("expected %v to contain %v: %v", actual.Tags, k, customTags[k])
-							}
-						}
-					}
 				}
 			}
 		})
@@ -711,7 +265,7 @@ func Test_egressVerificationGetSubnetIdAllSubnetsFlag(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual, err := test.e.getSubnetIds(context.TODO())
+			actual, err := test.e.getAwsSubnetIds(context.TODO())
 			if err != nil {
 				if !test.expectErr {
 					t.Errorf("expected no err, got %s", err)

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/mock v0.4.0
+	golang.org/x/oauth2 v0.23.0
 	golang.org/x/sync v0.8.0
 	golang.org/x/term v0.25.0
 	google.golang.org/api v0.171.0
@@ -210,7 +211,6 @@ require (
 	golang.org/x/crypto v0.28.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/net v0.30.0 // indirect
-	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.19.0 // indirect
 	golang.org/x/time v0.5.0 // indirect


### PR DESCRIPTION
This adds support for `osdctl network verify-egress` for GCP clusters. With this first pass this only works with BYOVPC clusters as in that scenario OCM has the network information needed. With non-BYOVPC, we need to implement further logic to lookup subnets, vpc and zones. For now, in this scenario, you can provide that data via CLI arguments.

 This works as follows:

- We reach out to OCM to get cluster information
- When GCP, we then attempt to pull all the data from the cluster model
- If we run into issues, inform the user to pass the data manually
- Perform the network verification just like AWS

**Note** Right now, OCM does not return the GCP project ID, although it should, and a bug [exists](https://issues.redhat.com/browse/OCM-12562) so this can go out in the meantime, but once they merge that we can omit `--gcp-project-id` 

I tested this on each type of GCP cluster (BYOVPC and non), and an existing AWS cluster. Also added some basic tests for GCP. Additionally, it is worth noting the existing `verification_test.go` tests are centered around the existing use case which was AWS only, so I left those as is (with a few adjustments for some refactoring.)

I will note that there is more refactoring to be done here to decouple the verification struct building from the CLI's struct, but this is a good first pass imo.

## Sample Run
```
 ./osdctl network verify-egress --cluster-id 2f1dafmj9clha0cilltvq862rgknhi3v -S --gcp-project-id jbranham
2024/11/14 13:23:16 Preparing to check 2 subnet(s) with network verifier.
2024/11/14 13:23:16 running network verifier for subnet  jb-test-gcp-zk789-worker-subnet, security group []
Created instance with ID: verifier-6460
Applying labels
Successfully applied labels 
ComputeService Instance: verifier-6460 RUNNING
Gathering and parsing console log output...
Summary:
printing out failures:
 - egressURL error: https://events.amazonaws.com:443 (Could not resolve host: events.amazonaws.com)

printing out exceptions preventing the verifier from running the specific test:
printing out errors faced during the execution:
INFO[0076] The following clusters match the given parameters: 
Name                ID                                 State               Version             Cloud Provider      Region
jb-test-reuse-vpc   2f1dafmj9clha0cilltvq862rgknhi3v   ready               4.17.3              gcp                 us-east1

INFO[0077] The following template will be sent:         
{
  "severity":"Major",
  "service_name":"SREManualAction",
  "summary":"Action required: Network misconfiguration",
  "description":"Your cluster requires you to take action. SRE has observed that there have been changes made to the network configuration which impacts normal working of the cluster, including lack of network egress to these internet-based resources which are required for the cluster operation and support: https://events.amazonaws.com:443 (Could not resolve host: events.amazonaws.com). Please revert changes, and refer to documentation regarding firewall requirements for PrivateLink clusters: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs#.",
  "internal_only":false,
  "event_stream_id":"",
  "doc_references": [
    "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs."
  ]
}
Continue? (y/N): N
...
```