### PR TITLE
fix(OSD-26926): add missing acm namespaces to dyntrace gather-logs command

### DIFF
--- a/cmd/cluster/dynatrace/hcpGatherLogsCmd.go
+++ b/cmd/cluster/dynatrace/hcpGatherLogsCmd.go
@@ -65,7 +65,7 @@ func gatherLogs(clusterID string) (error error) {
 
 	fmt.Printf("Using HCP Namespace %v\n", hcpCluster.hcpNamespace)
 
-	gatherNamespaces := []string{hcpCluster.hcpNamespace, hcpCluster.klusterletNS, hcpCluster.hostedNS, "hypershift", "cert-manager", "redhat-cert-manager-operator"}
+	gatherNamespaces := []string{hcpCluster.hcpNamespace, hcpCluster.klusterletNS, hcpCluster.hostedNS, "hypershift", "cert-manager", "redhat-cert-manager-operator", "open-cluster-management-agent", "open-cluster-management-agent-addon"}
 	gatherDir, err := setupGatherDir(hcpCluster.hcpNamespace)
 	if err != nil {
 		return err


### PR DESCRIPTION
We're missing data of following namespaces when executing the gather command:
- open-cluster-management-agent                                  
- open-cluster-management-agent-addon 

This PR adds them to the gather command. 