### PR TITLE
[wip] SDCICD-1418 add cmd option to promote operator saas through canary hives

### DIFF
--- a/cmd/promote/saas/saas.go
+++ b/cmd/promote/saas/saas.go
@@ -9,9 +9,10 @@ import (
 )
 
 type saasOptions struct {
-	list bool
-	osd  bool
-	hcp  bool
+	list   bool
+	osd    bool
+	hcp    bool
+	canary string
 
 	appInterfaceCheckoutDir string
 	serviceName             string
@@ -19,7 +20,7 @@ type saasOptions struct {
 	namespaceRef            string
 }
 
-// newCmdSaas implementes the saas command to interact with promoting SaaS services/operators
+// NewCmdSaas implementes the saas command to interact with promoting SaaS services/operators
 func NewCmdSaas() *cobra.Command {
 	ops := &saasOptions{}
 	saasCmd := &cobra.Command{
@@ -31,8 +32,8 @@ func NewCmdSaas() *cobra.Command {
 		# List all SaaS services/operators
 		osdctl promote saas --list
 
-		# Promote a SaaS service/operator
-		osdctl promote saas --serviceName <service-name> --gitHash <git-hash> --osd
+		# Promote a SaaS service/operator to production 
+		osdctl promote saas --serviceName <service-name> --gitHash <git-hash> --osd 
 		or
 		osdctl promote saas --serviceName <service-name> --gitHash <git-hash> --hcp`,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -55,7 +56,7 @@ func NewCmdSaas() *cobra.Command {
 				os.Exit(1)
 			}
 
-			err := servicePromotion(appInterface, ops.serviceName, ops.gitHash, ops.namespaceRef, ops.osd, ops.hcp)
+			err := servicePromotion(appInterface, ops.serviceName, ops.gitHash, ops.namespaceRef, ops.osd, ops.hcp, ops.canary)
 			if err != nil {
 				fmt.Printf("Error while promoting service: %v\n", err)
 				os.Exit(1)
@@ -72,6 +73,7 @@ func NewCmdSaas() *cobra.Command {
 	saasCmd.Flags().StringVarP(&ops.namespaceRef, "namespaceRef", "n", "", "SaaS target namespace reference name")
 	saasCmd.Flags().BoolVarP(&ops.osd, "osd", "", false, "OSD service/operator getting promoted")
 	saasCmd.Flags().BoolVarP(&ops.hcp, "hcp", "", false, "HCP service/operator getting promoted")
+	saasCmd.Flags().StringVarP(&ops.canary, "canary", "", "auto", "Select to promote service to canary production hives (yes/no/auto). By default, auto will deploy to canary only if target names containing -prod-canary- are set up in saas file. Otherwise will deploy to all production targets.")
 	saasCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interfache checkout. Falls back to `pwd` and "+git.DefaultAppInterfaceDirectory())
 
 	return saasCmd

--- a/cmd/promote/saas/utils.go
+++ b/cmd/promote/saas/utils.go
@@ -36,7 +36,7 @@ func listServiceNames(appInterface git.AppInterface) error {
 	return nil
 }
 
-func servicePromotion(appInterface git.AppInterface, serviceName, gitHash string, namespaceRef string, osd, hcp bool) error {
+func servicePromotion(appInterface git.AppInterface, serviceName, gitHash string, namespaceRef string, osd, hcp bool, canary string) error {
 	_, err := GetServiceNames(appInterface, OSDSaasDir, BPSaasDir, CADSaasDir)
 	if err != nil {
 		return err
@@ -58,7 +58,7 @@ func servicePromotion(appInterface git.AppInterface, serviceName, gitHash string
 		return fmt.Errorf("failed to read SAAS file: %v", err)
 	}
 
-	currentGitHash, serviceRepo, err := git.GetCurrentGitHashFromAppInterface(serviceData, serviceName, namespaceRef)
+	currentGitHash, serviceRepo, err := git.GetCurrentGitHashFromAppInterface(serviceData, serviceName, namespaceRef, canary)
 	if err != nil {
 		return fmt.Errorf("failed to get current git hash or service repo: %v", err)
 	}
@@ -77,7 +77,7 @@ func servicePromotion(appInterface git.AppInterface, serviceName, gitHash string
 		return fmt.Errorf("error in executing git log: %v", err)
 	}
 	branchName := fmt.Sprintf("promote-%s-%s", serviceName, promotionGitHash)
-	err = appInterface.UpdateAppInterface(serviceName, saasDir, currentGitHash, promotionGitHash, branchName)
+	err = appInterface.UpdateAppInterface(serviceName, saasDir, currentGitHash, promotionGitHash, branchName, canary)
 	if err != nil {
 		fmt.Printf("FAILURE: %v\n", err)
 	}
@@ -107,11 +107,11 @@ func GetServiceNames(appInterface git.AppInterface, saaDirs ...string) ([]string
 		if err != nil {
 			return nil, err
 		}
-		for _, filepath := range filepaths {
-			filename := strings.TrimPrefix(filepath, baseDir+"/"+dir+"/")
+		for _, fp := range filepaths {
+			filename := strings.TrimPrefix(fp, baseDir+"/"+dir+"/")
 			filename = strings.TrimSuffix(filename, ".yaml")
 			ServicesSlice = append(ServicesSlice, filename)
-			ServicesFilesMap[filename] = filepath
+			ServicesFilesMap[filename] = fp
 		}
 	}
 


### PR DESCRIPTION
Adds canary promotion option to osd saas promotions. i.e;

```	
osdctl promote saas --serviceName <service-name> --gitHash <git-hash> --osd  --canary=yes
```

- Default value for canary is "auto". This promotes service to canary targets if they are set up in saas file. Otherwise proceeds with normal promotion.  
- Followup planned for saas file updates to be compatible with this option. 