### PR TITLE
OSD-27029: Guard against improper usage of the --subnet-id flag

### DIFF
--- a/cmd/network/aws.go
+++ b/cmd/network/aws.go
@@ -217,7 +217,6 @@ func (e *EgressVerification) isSubnetPublic(ctx context.Context, subnetID string
 	var routeTable string
 
 	// Try and find a Route Table associated with the given subnet
-
 	routeTable, err := utils.FindRouteTableForSubnetForVerification(e.awsClient, subnetID)
 
 	// Check that the RouteTable for the subnet has a default route to 0.0.0.0/0

--- a/pkg/utils/network.go
+++ b/pkg/utils/network.go
@@ -88,7 +88,6 @@ func findDefaultRouteTableForVPC(awsClient aws.Client, vpcID string) (string, er
 // Try and find a Route Table associated with the given subnet for Egress Verification
 
 func FindRouteTableForSubnetForVerification(verificationAwsClient verificationAWSClient, subnetID string) (string, error) {
-
 	var routeTable string
 	describeRouteTablesOutput, err := verificationAwsClient.DescribeRouteTables(context.TODO(), &ec2.DescribeRouteTablesInput{
 		Filters: []types.Filter{


### PR DESCRIPTION
The `--subnet-id` flag is a `StringArrayVar` which allows you to pass the flag multiple times to construct a slice of values. However, if you pass one value like `--subnet-id foo,bar,baz`, it manifests as strange failures later in the verification process.

This just adds a guard to that footgun and updates the examples to reflect.

```
> ./osdctl network verify-egress -S --subnet-id foo,bar,baz
2024/12/06 09:01:26 network verification failed to validate input: multiple subnets passed to a single --subnet-id flag, you must pass the flag per subnet, eg --subnet-id foo --subnet-id bar
```