### PR TITLE
Allow overriding json values before sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,10 +361,28 @@ osdctl servicelog list ${CLUSTERID} --all-messages
 
 #### Post servicelogs
 
+**Notes:**
+
+* `-t` is used for loading a template from disk, or from a URI
+
+* `-i` is useful for posting an internal-only service log using a built-in template
+
+* `-r` is used to override the individual fields in the final JSON message. If it us used without `-t` or `-i` then it will provide its own defaults of `severity=Info` and `internal_only=True`, unless these are also overridden.
+
+* The `--dry-run` flag simulates the command and prints the SL without sending it.
+
+* Only valid fields (e.g summary, description, severity, internal_only) can be overridden using the `-r` flag. Invalid fields will result in errors.
+
 ```bash
 CLUSTER_ID= # the unique cluster name, or internal, external id for a cluster
 TEMPLATE= # file or url in which the template exists in
 osdctl servicelog post ${CLUSTER_ID} --template=${TEMPLATE} --dry-run
+
+# Post an internal-only service log message
+osdctl servicelog post ${CLUSTER_ID} -i -p "MESSAGE=This is an internal message" --dry-run
+
+# Post a short external message
+osdctl servicelog post ${CLUSTER_ID} -r "summary=External Message" -r "description=This is an external message" -r internal_only=False --dry-run
 
 QUERIES_HERE= # queries that can be run on ocm's `clusters` resource
 TEMPLATE= # file or url in which the template exists in

--- a/cmd/servicelog/common.go
+++ b/cmd/servicelog/common.go
@@ -3,12 +3,13 @@ package servicelog
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	v1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 	"github.com/openshift/osdctl/internal/servicelog"
 	"github.com/openshift/osdctl/pkg/utils"
-	"time"
 )
 
 var (

--- a/cmd/servicelog/post_test.go
+++ b/cmd/servicelog/post_test.go
@@ -1,0 +1,110 @@
+package servicelog
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/osdctl/internal/servicelog"
+)
+
+func TestSetup(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Setup Suite")
+}
+
+var _ = Describe("Test posting service logs", func() {
+	var options *PostCmdOptions
+
+	BeforeEach(func() {
+		options = &PostCmdOptions{
+			Overrides: []string{
+				"description=new description",
+				"summary=new summary",
+			},
+			Message: servicelog.Message{
+				Summary:      "The original summary",
+				InternalOnly: false,
+			},
+		}
+	})
+
+	Context("overriding a field", func() {
+		It("overrides string fields successfully", func() {
+			overrideString := "Overridden Summary"
+			err := options.overrideField("summary", overrideString)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(options.Message.Summary).To(Equal(overrideString))
+		})
+
+		It("overrides bool fields correctly", func() {
+			Expect(options.Message.InternalOnly).ToNot(Equal(true))
+
+			err := options.overrideField("internal_only", "true")
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(options.Message.InternalOnly).To(Equal(true))
+		})
+
+		It("errors when overriding a field that does not exist", func() {
+			err := options.overrideField("does_not_exist", "")
+
+			Expect(err).Should(HaveOccurred())
+		})
+
+		It("errors when overriding a bool with an unparsable string", func() {
+			err := options.overrideField("internal_only", "ThisIsNotABool")
+
+			Expect(err).Should(HaveOccurred())
+		})
+
+		It("errors when overriding an unsupported data type", func() {
+			err := options.overrideField("doc_references", "DoesntMatter")
+
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	Context("parsing overrides", func() {
+		It("parses correctly", func() {
+			overrideMap, err := options.parseOverrides()
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(overrideMap).To(HaveKey("description"))
+			Expect(overrideMap["description"]).To(Equal("new description"))
+			Expect(overrideMap).To(HaveKey("summary"))
+			Expect(overrideMap["summary"]).To(Equal("new summary"))
+		})
+
+		It("fails when an option contains no equals sign", func() {
+			options.Overrides = []string{
+				"THISDOESNOTHAVEANEQUALS",
+			}
+
+			_, err := options.parseOverrides()
+
+			Expect(err).Should(HaveOccurred())
+		})
+
+		It("fails when an option has no key", func() {
+			options.Overrides = []string{
+				"=VALUE",
+			}
+
+			_, err := options.parseOverrides()
+
+			Expect(err).Should(HaveOccurred())
+		})
+
+		It("fails when an option has no value", func() {
+			options.Overrides = []string{
+				"KEY=",
+			}
+
+			_, err := options.parseOverrides()
+
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
Combined with the `-i` option this makes it possible to send a servicelog without using a template at all.

Solves: https://issues.redhat.com/browse/OSD-26164