### PR TITLE
Update osdctl servicelog list with better help output

### DIFF
--- a/cmd/servicelog/cmd.go
+++ b/cmd/servicelog/cmd.go
@@ -18,9 +18,8 @@ func NewCmdServiceLog() *cobra.Command {
 		},
 	}
 
-	// Add subcommands
-	servicelogCmd.AddCommand(listCmd)      // servicelog list
-	servicelogCmd.AddCommand(newPostCmd()) // servicelog post
+	servicelogCmd.AddCommand(newListCmd())
+	servicelogCmd.AddCommand(newPostCmd())
 
 	return servicelogCmd
 }


### PR DESCRIPTION
SRE has spent a lot of hours today and yesterday troubleshooting an issue for a customer, where it seems PDBs were ignored and nodes were force drained. We eventually saw an automated service log that indicated we _do_ force drain after a configurable timeout.

This updates the `osdctl servicelog list` command with more helpful output on `--help` so you can see the various options.

I was also tempted to set `--all-messages` as the default, but I can see how it would be noisy, so opting for better help for now.

I also refactored this to use an options struct for consistency

<img width="723" alt="Screenshot 2024-12-18 at 1 47 45 PM" src="https://github.com/user-attachments/assets/2da967ae-c652-4921-9695-ac5c9c1ee900" />
