### PR TITLE
OSD-25401: Bump osd-network-verifier to 1.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/openshift/gcp-project-operator v0.0.0-20220920194256-df38e31387a7
 	github.com/openshift/hive/apis v0.0.0-20240216200617-8c54fc9cac45
 	github.com/openshift/hypershift/api v0.0.0-20241102085541-7ba3433476ee
-	github.com/openshift/osd-network-verifier v1.2.0
+	github.com/openshift/osd-network-verifier v1.2.1
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/shopspring/decimal v1.3.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,8 @@ github.com/openshift/hive/apis v0.0.0-20240216200617-8c54fc9cac45 h1:t9PeXKK13eq
 github.com/openshift/hive/apis v0.0.0-20240216200617-8c54fc9cac45/go.mod h1:jqpZWDUo9JcnO4Q5RuNWjESE1EJ3Qi9xowBBi0nyxQA=
 github.com/openshift/hypershift/api v0.0.0-20241102085541-7ba3433476ee h1:KcTMINwDpRMeVwfJjzboXzEDzBgRvK4k4GQHyISZ9gI=
 github.com/openshift/hypershift/api v0.0.0-20241102085541-7ba3433476ee/go.mod h1:NIT2Bs83re4seKsT3Xp+ENOOCN2Gl++mguuGGhNnN/8=
-github.com/openshift/osd-network-verifier v1.2.0 h1:cdc7+tCmNjdyNPi04shAZrqau+79lvb8OjDjtpGe43w=
-github.com/openshift/osd-network-verifier v1.2.0/go.mod h1:X3dVNkC91NYTf2kTXUS/PeRTNvfS97WbvIqPIDP083M=
+github.com/openshift/osd-network-verifier v1.2.1 h1:mrxLHY0wNIULn59opVFKroeBTwVNWc6nUB4dXI4bRfM=
+github.com/openshift/osd-network-verifier v1.2.1/go.mod h1:X3dVNkC91NYTf2kTXUS/PeRTNvfS97WbvIqPIDP083M=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=
 github.com/perimeterx/marshmallow v1.1.4 h1:pZLDH9RjlLGGorbXhcaQLhfuV0pFMNfPO55FuFkxqLw=


### PR DESCRIPTION
Bugfix bump of the network verifier to fix an issue with potential leaked security groups under certain KMS failure modes.