### PR TITLE
osd-27986 - Log in to the provided cluster when running `osdctl cluster validate-pull-secret`

### DIFF
--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -35,7 +35,7 @@ func NewCmdCluster(streams genericclioptions.IOStreams, client *k8s.LazyClient, 
 	clusterCmd.AddCommand(access.NewCmdAccess(streams, client))
 	clusterCmd.AddCommand(newCmdCpd())
 	clusterCmd.AddCommand(newCmdCheckBannedUser())
-	clusterCmd.AddCommand(newCmdValidatePullSecret(client))
+	clusterCmd.AddCommand(newCmdValidatePullSecret())
 	clusterCmd.AddCommand(newCmdEtcdHealthCheck())
 	clusterCmd.AddCommand(newCmdEtcdMemberReplacement())
 	clusterCmd.AddCommand(newCmdFromInfraId(globalOpts))


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-27986

---

The logic in `osdctl cluster validate-pull-secret $CLUSTER_ID` predates osdctl's ability to log into clusters via backplane, and, therefore, does not automatically retrieve a kubeconfig for the cluster provided by the `$CLUSTER_ID` positional. Rather, it uses the local kubeconfig, which could result in false positives if the user is not already logged into the cluster they want to check. Ultimately, this will result in misleading servicelogs being sent to clusters with issues unrelated to their pull-secret

This PR updates the `validate-pull-secret` logic to login to the cluster we're checking, rather than use the local kubeconfig, so that we can ensure the check is always performed accurately