### PR TITLE
Replace defunct package brought in by importing 'oc'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -282,3 +282,7 @@ require (
 	sigs.k8s.io/kustomize/api v0.19.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.5.0 // indirect
 )
+
+// We import 'oc' which relies on this, and is pointed at the GitHub repo which no longer exists.
+// Since we don't use it, and it causes 'go list' to fail (mainly used in IDEs), replace it with nothing.
+replace github.com/apcera/gssapi => ./empty


### PR DESCRIPTION
https://github.com/openshift/osdctl/commit/7c2ab3fa8dca51acdf537a2b14cee1b1cf659ac5 brought in the `oc` module so we could use the `MustGather` command natively in our code.

As a result, that brought in `github.com/apcera/gssapi` which is a repo that no longer exists. It is vendored upstream, but appears to not be used.

This replaces it with nothing, which prevents failures with `go list` etc. I don't love the solution, but the alternative is to shell out to `oc adm must-gather` which is also less than ideal.

Fixes the following:
```
> go list -modfile=/Users/jbranham/git/openshift/osdctl/go.mod -m -json -mod=mod all
go: github.com/apcera/gssapi@v0.0.0-00010101000000-000000000000: invalid version: git ls-remote -q origin in /Users/jbranham/.asdf/installs/golang/1.23.6/packages/pkg/mod/cache/vcs/7e22c68b7feb70d66e45280edd7cced5c3af06d0970ddc07b564ffa2acfe5ce4: exit status 128:
        remote: Repository not found.
        fatal: repository 'https://github.com/apcera/gssapi/' not found
```