### PR TITLE
OSD-27873-dynatrace-component-promotion

### DIFF
--- a/cmd/promote/cmd.go
+++ b/cmd/promote/cmd.go
@@ -3,6 +3,7 @@ package promote
 import (
 	"fmt"
 
+	"github.com/openshift/osdctl/cmd/promote/dynatrace"
 	"github.com/openshift/osdctl/cmd/promote/pko"
 	"github.com/openshift/osdctl/cmd/promote/saas"
 	"github.com/spf13/cobra"
@@ -19,6 +20,7 @@ func NewCmdPromote() *cobra.Command {
 
 	promoteCmd.AddCommand(saas.NewCmdSaas())
 	promoteCmd.AddCommand(pko.NewCmdPKO())
+	promoteCmd.AddCommand(dynatrace.NewCmdDynatrace())
 
 	return promoteCmd
 }

--- a/cmd/promote/dynatrace/dt_app_interface.go
+++ b/cmd/promote/dynatrace/dt_app_interface.go
@@ -1,0 +1,213 @@
+package dynatrace
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Service struct {
+	Name              string `yaml:"name"`
+	ResourceTemplates []struct {
+		Name    string `yaml:"name"`
+		URL     string `yaml:"url"`
+		PATH    string `yaml:"path"`
+		Targets []struct {
+			Name       string
+			Namespace  map[string]string      `yaml:"namespace"`
+			Ref        string                 `yaml:"ref"`
+			Parameters map[string]interface{} `yaml:"parameters"`
+		} `yaml:"targets"`
+	} `yaml:"resourceTemplates"`
+}
+
+type AppInterface struct {
+	GitDirectory string
+}
+
+func DefaultAppInterfaceDirectory() string {
+	return filepath.Join(os.Getenv("HOME"), "git", "app-interface")
+}
+
+func BootstrapOsdCtlForAppInterfaceAndServicePromotions(appInterfaceCheckoutDir string) AppInterface {
+	a := AppInterface{}
+	if appInterfaceCheckoutDir != "" {
+		a.GitDirectory = appInterfaceCheckoutDir
+		err := checkAppInterfaceCheckout(a.GitDirectory)
+		if err != nil {
+			log.Fatalf("Provided directory %s is not an AppInterface directory: %v", a.GitDirectory, err)
+		}
+		return a
+	}
+
+	dir, err := getBaseDir()
+	if err == nil {
+		a.GitDirectory = dir
+		err = checkAppInterfaceCheckout(a.GitDirectory)
+		if err == nil {
+			return a
+		}
+	}
+
+	log.Printf("Not running in AppInterface directory: %v - Trying %s next\n", err, DefaultAppInterfaceDirectory())
+	a.GitDirectory = DefaultAppInterfaceDirectory()
+	err = checkAppInterfaceCheckout(a.GitDirectory)
+	if err != nil {
+		log.Fatalf("%s is not an AppInterface directory: %v", DefaultAppInterfaceDirectory(), err)
+	}
+
+	log.Printf("Found AppInterface in %s.\n", a.GitDirectory)
+	return a
+}
+
+// checkAppInterfaceCheckout checks if the script is running in the checkout of app-interface
+func checkAppInterfaceCheckout(directory string) error {
+	cmd := exec.Command("git", "remote", "-v")
+	cmd.Dir = directory
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("error executing 'git remote -v': %v", err)
+	}
+
+	outputString := string(output)
+
+	// Check if the output contains the app-interface repository URL
+	if !strings.Contains(outputString, "gitlab.cee.redhat.com") && !strings.Contains(outputString, "app-interface") {
+		return fmt.Errorf("not running in checkout of app-interface")
+	}
+	//fmt.Println("Running in checkout of app-interface.")
+
+	return nil
+}
+
+func GetCurrentGitHashFromAppInterface(saarYamlFile []byte, serviceName string) (string, string, string, error) {
+	var currentGitHash string
+	var serviceRepo string
+	var service Service
+	var serviceFilepath string
+
+	err := yaml.Unmarshal(saarYamlFile, &service)
+	if err != nil {
+		log.Fatal(fmt.Errorf("cannot unmarshal yaml data of service %s: %v", serviceName, err))
+	}
+
+	for _, resourceTemplate := range service.ResourceTemplates {
+		for _, target := range resourceTemplate.Targets {
+			if strings.Contains(target.Name, "production-") {
+				currentGitHash = target.Ref
+				serviceFilepath = resourceTemplate.PATH
+				break
+			}
+		}
+	}
+
+	if currentGitHash == "" {
+		return "", "", "", fmt.Errorf("production namespace not found for service %s", serviceName)
+	}
+
+	if len(service.ResourceTemplates) > 0 {
+		serviceRepo = service.ResourceTemplates[0].URL
+	}
+
+	if serviceRepo == "" {
+		return "", "", "", fmt.Errorf("service repo not found for service %s", serviceName)
+	}
+
+	return currentGitHash, serviceRepo, serviceFilepath, nil
+}
+
+func (a AppInterface) UpdateAppInterface(component, saasFile, currentGitHash, promotionGitHash, branchName string) error {
+	cmd := exec.Command("git", "checkout", "master")
+	cmd.Dir = a.GitDirectory
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to checkout master branch: %v", err)
+	}
+
+	cmd = exec.Command("git", "branch", "-D", branchName)
+	cmd.Dir = a.GitDirectory
+	err = cmd.Run()
+	if err != nil {
+		fmt.Printf("failed to cleanup branch %s: %v, continuing to create it.\n", branchName, err)
+	}
+
+	cmd = exec.Command("git", "checkout", "-b", branchName, "master")
+	cmd.Dir = a.GitDirectory
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to create branch %s: %v, does it already exist? If so, please delete it with `git branch -D %s` first", branchName, err, branchName)
+	}
+
+	// Update the hash in the SAAS file
+
+	fileContent, err := os.ReadFile(saasFile)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %v", saasFile, err)
+	}
+	var newContent string
+
+	// Replace the hash in the file content
+	newContent = strings.ReplaceAll(string(fileContent), currentGitHash, promotionGitHash)
+
+	err = os.WriteFile(saasFile, []byte(newContent), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write to file %s: %v", saasFile, err)
+	}
+
+	return nil
+}
+
+func (a AppInterface) UpdatePackageTag(saasFile, oldTag, promotionTag, branchName string) error {
+	cmd := exec.Command("git", "checkout", "master")
+	cmd.Dir = a.GitDirectory
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to checkout master branch: %v", err)
+	}
+
+	cmd = exec.Command("git", "branch", "-D", branchName)
+	cmd.Dir = a.GitDirectory
+	err = cmd.Run()
+	if err != nil {
+		fmt.Printf("failed to cleanup branch %s: %v, continuing to create it.\n", branchName, err)
+	}
+
+	// Update the hash in the SAAS file
+	fileContent, err := os.ReadFile(saasFile)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %v", saasFile, err)
+	}
+
+	// Replace the hash in the file content
+	newContent := strings.ReplaceAll(string(fileContent), oldTag, promotionTag)
+
+	err = os.WriteFile(saasFile, []byte(newContent), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write to file %s: %v", saasFile, err)
+	}
+	return nil
+}
+
+func (a AppInterface) CommitSaasFile(saasFile, commitMessage string) error {
+	// Commit the change
+	cmd := exec.Command("git", "add", saasFile)
+	cmd.Dir = a.GitDirectory
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to add file %s: %v", saasFile, err)
+	}
+
+	cmd = exec.Command("git", "commit", "-m", commitMessage)
+	cmd.Dir = a.GitDirectory
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to commit changes: %v", err)
+	}
+
+	return nil
+}

--- a/cmd/promote/dynatrace/dt_git_cmd.go
+++ b/cmd/promote/dynatrace/dt_git_cmd.go
@@ -1,0 +1,69 @@
+package dynatrace
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+var (
+	baseDirOnce sync.Once
+	BaseDir     string
+	baseDirErr  error
+)
+
+// getBaseDir returns the base directory of the git repository, this can only be called once per process
+func getBaseDir() (string, error) {
+	baseDirOnce.Do(func() {
+		baseDirCmd := exec.Command("git", "rev-parse", "--show-toplevel")
+		baseDirOutput, err := baseDirCmd.Output()
+		if err != nil {
+			baseDirErr = err
+			return
+		}
+
+		BaseDir = strings.TrimSpace(string(baseDirOutput))
+	})
+
+	return BaseDir, baseDirErr
+}
+
+func checkBehindMaster(dir string) error {
+	fmt.Printf("### Checking 'master' branch is up to date ###\n")
+
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("error executing git rev-parse command: %v", err)
+	}
+
+	branch := strings.TrimSpace(string(output))
+	if branch != "master" {
+		return fmt.Errorf("you are not on the 'master' branch")
+	}
+
+	// Fetch the latest changes from the upstream repository
+	cmd = exec.Command("git", "fetch", "upstream")
+	cmd.Dir = dir
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("error executing git fetch command: %v", err)
+	}
+
+	cmd = exec.Command("git", "rev-list", "--count", "HEAD..upstream/master")
+	cmd.Dir = dir
+	output, err = cmd.Output()
+	if err != nil {
+		return fmt.Errorf("error executing git rev-list command: %v", err)
+	}
+
+	behindCount := strings.TrimSpace(string(output))
+	if behindCount != "0" {
+		return fmt.Errorf("you are behind 'master' by this many commits: %s", behindCount)
+	}
+	fmt.Printf("### 'master' branch is up to date ###\n\n")
+
+	return nil
+}

--- a/cmd/promote/dynatrace/dt_service_repo.go
+++ b/cmd/promote/dynatrace/dt_service_repo.go
@@ -1,0 +1,55 @@
+package dynatrace
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func CheckoutAndCompareGitHash(gitURL, gitHash, currentGitHash, serviceFullPath string) (string, string, error) {
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	err = os.Chdir(tempDir)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to change directory to temporary directory: %v", err)
+	}
+
+	cmd := exec.Command("git", "clone", gitURL, "source-dir")
+	err = cmd.Run()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to clone git repository: %v", err)
+	}
+
+	err = os.Chdir("source-dir")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to change directory to source-dir: %v", err)
+	}
+
+	if gitHash == "" {
+		fmt.Printf("No git hash provided. Using HEAD.\n")
+		cmd := exec.Command("git", "rev-list", "-n", "1", "HEAD", "--", serviceFullPath)
+		output, err := cmd.Output()
+		if err != nil {
+			return "", "", fmt.Errorf("failed to get git hash: %v", err)
+		}
+		gitHash = strings.TrimSpace(string(output))
+		fmt.Printf("The head githash is %s\n", gitHash)
+	}
+
+	if currentGitHash == gitHash {
+		return "", "", fmt.Errorf("git hash %s is already at HEAD", gitHash)
+	} else {
+		cmd := exec.Command("git", "log", "--no-merges", fmt.Sprintf("%s..%s", currentGitHash, gitHash))
+		commitLog, err := cmd.Output()
+		if err != nil {
+			return "", "", err
+		}
+		return gitHash, string(commitLog), nil
+	}
+}

--- a/cmd/promote/dynatrace/dt_utils.go
+++ b/cmd/promote/dynatrace/dt_utils.go
@@ -1,0 +1,141 @@
+package dynatrace
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	saasDynatraceDir = "data/services/osd-operators/cicd/saas/saas-dynatrace"
+)
+
+var (
+	ServicesSlice    []string
+	ServicesFilesMap = map[string]string{}
+)
+
+func listServiceNames(appInterface AppInterface) error {
+	_, err := GetServiceNames(appInterface, saasDynatraceDir)
+	if err != nil {
+		return err
+	}
+
+	sort.Strings(ServicesSlice)
+	fmt.Println("### Available service names ###")
+	for _, service := range ServicesSlice {
+		fmt.Println(service)
+	}
+
+	return nil
+}
+
+func servicePromotion(appInterface AppInterface, component, gitHash string) error {
+
+	_, err := GetServiceNames(appInterface, saasDynatraceDir)
+	if err != nil {
+		return err
+	}
+
+	component, err = ValidateServiceName(ServicesSlice, component)
+	if err != nil {
+		return err
+	}
+
+	saasDir, err := GetSaasDir(component)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("SAAS Directory: %v\n", saasDir)
+
+	serviceData, err := os.ReadFile(saasDir)
+	if err != nil {
+		return fmt.Errorf("failed to read SAAS file: %v", err)
+	}
+
+	currentGitHash, serviceRepo, serviceFullPath, err := GetCurrentGitHashFromAppInterface(serviceData, component)
+	if err != nil {
+		return fmt.Errorf("failed to get current git hash or service repo: %v", err)
+	}
+
+	fmt.Printf("Current Git Hash: %v\nGit Repo: %v\nComponent path: %v\n", currentGitHash, serviceRepo, serviceFullPath)
+
+	promotionGitHash, commitLog, err := CheckoutAndCompareGitHash(serviceRepo, gitHash, currentGitHash, strings.TrimPrefix(serviceFullPath, "/"))
+	if err != nil {
+		return fmt.Errorf("failed to checkout and compare git hash: %v", err)
+	} else if promotionGitHash == "" {
+		fmt.Printf("Unable to find a git hash to promote. Exiting.\n")
+		os.Exit(6)
+	}
+	fmt.Printf("Service: %s will be promoted to %s\n", component, promotionGitHash)
+	fmt.Printf("commitLog: %v\n", commitLog)
+	branchName := fmt.Sprintf("promote-%s-%s", component, promotionGitHash)
+
+	err = appInterface.UpdateAppInterface(component, saasDir, currentGitHash, promotionGitHash, branchName)
+	if err != nil {
+		fmt.Printf("FAILURE: %v\n", err)
+	}
+
+	commitMessage := fmt.Sprintf("Promote %s to %s\n\nSee %s/compare/%s...%s for contents of the promotion.\n clog:%s", component, promotionGitHash, serviceRepo, currentGitHash, promotionGitHash, commitLog)
+	err = appInterface.CommitSaasFile(saasDir, commitMessage)
+	if err != nil {
+		return fmt.Errorf("failed to commit changes to app-interface: %w", err)
+	}
+	fmt.Printf("commitMessage: %s\n", commitMessage)
+
+	fmt.Printf("The branch %s is ready to be pushed\n", branchName)
+	fmt.Println("")
+	fmt.Println("DT service:", component)
+	fmt.Println("from:", currentGitHash)
+	fmt.Println("to:", promotionGitHash)
+	fmt.Println("READY TO PUSH,", component, "promotion commit is ready locally")
+	return nil
+}
+
+func GetServiceNames(appInterface AppInterface, saaDirs ...string) ([]string, error) {
+	baseDir := appInterface.GitDirectory
+
+	for _, dir := range saaDirs {
+		dirGlob := filepath.Join(baseDir, dir)
+		filepaths, err := filepath.Glob(dirGlob + "/*.yaml")
+		if err != nil {
+			return nil, err
+		}
+
+		for _, filepath := range filepaths {
+			filename := strings.TrimPrefix(filepath, baseDir+"/"+dir+"/")
+			filename = strings.TrimSuffix(filename, ".yaml")
+			ServicesSlice = append(ServicesSlice, filename)
+			ServicesFilesMap[filename] = filepath
+		}
+	}
+
+	return ServicesSlice, nil
+}
+
+func ValidateServiceName(serviceSlice []string, serviceName string) (string, error) {
+	fmt.Printf("### Checking if service %s exists ###\n", serviceName)
+	for _, service := range serviceSlice {
+		if service == serviceName {
+			fmt.Printf("Service %s found\n", serviceName)
+			return serviceName, nil
+		}
+		if service == "dynatrace-"+serviceName {
+			fmt.Printf("Service %s found\n", serviceName)
+			return "dynatrace-" + serviceName, nil
+		}
+	}
+
+	return serviceName, fmt.Errorf("service %s not found", serviceName)
+}
+
+func GetSaasDir(component string) (string, error) {
+	if saasDir, ok := ServicesFilesMap[component]; ok {
+		if strings.Contains(saasDir, ".yaml") {
+			return saasDir, nil
+		}
+	}
+	return "", fmt.Errorf("saas directory for service %s not found", component)
+}

--- a/cmd/promote/dynatrace/dynatrace.go
+++ b/cmd/promote/dynatrace/dynatrace.go
@@ -46,8 +46,8 @@ func NewCmdDynatrace() *cobra.Command {
 			}
 
 			if ops.component == "" {
-				fmt.Println("Error: Please provide dynatrace component to promote.\n\n")
-				fmt.Println("Please run 'osdctl promote dynatrace --list' to check available dynatrace components for promotion.\n\n")
+				fmt.Printf("Error: Please provide dynatrace component to promote.\n\n")
+				fmt.Printf("Please run 'osdctl promote dynatrace --list' to check available dynatrace components for promotion.\n\n")
 				cmd.Help()
 				os.Exit(1)
 			}

--- a/cmd/promote/dynatrace/dynatrace.go
+++ b/cmd/promote/dynatrace/dynatrace.go
@@ -1,0 +1,79 @@
+package dynatrace
+
+import (
+	"fmt"
+	"os"
+
+	git "github.com/openshift/osdctl/cmd/promote/git"
+	"github.com/spf13/cobra"
+)
+
+type promoteDynatraceOptions struct {
+	list bool
+
+	appInterfaceCheckoutDir string
+	gitHash                 string
+	component               string
+}
+
+// NewCmdPromote implements the promote command to promote services/operators
+func NewCmdDynatrace() *cobra.Command {
+	ops := &promoteDynatraceOptions{}
+	promoteDynatraceCmd := &cobra.Command{
+		Use:               "dynatrace",
+		Short:             "Utilities to promote dynatrace",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		Example: `
+		# List all Dynatrace components available for promotion
+		osdctl promote dynatrace --list
+
+		# Promote a dynatrace component
+		osdctl promote dynatrace --component <component> --gitHash <git-hash>`,
+
+		Run: func(cmd *cobra.Command, args []string) {
+			ops.validateSaasFlow()
+			appInterface := BootstrapOsdCtlForAppInterfaceAndServicePromotions(ops.appInterfaceCheckoutDir)
+
+			if ops.list {
+				if ops.component != "" || ops.gitHash != "" {
+					fmt.Printf("Error: --list cannot be used with any other flags\n\n")
+					cmd.Help()
+					os.Exit(1)
+				}
+				listServiceNames(appInterface)
+				os.Exit(0)
+			}
+
+			if ops.component == "" {
+				fmt.Println("Error: Please provide dynatrace component to promote.\n\n")
+				fmt.Println("Please run 'osdctl promote dynatrace --list' to check available dynatrace components for promotion.\n\n")
+				cmd.Help()
+				os.Exit(1)
+			}
+			err := servicePromotion(appInterface, ops.component, ops.gitHash)
+			if err != nil {
+				fmt.Printf("Error while promoting service: %v\n", err)
+				os.Exit(1)
+			}
+
+			os.Exit(0)
+		},
+	}
+
+	promoteDynatraceCmd.Flags().BoolVarP(&ops.list, "list", "l", false, "List all SaaS services/operators")
+	promoteDynatraceCmd.Flags().StringVarP(&ops.component, "component", "c", "", "Dynatrace component getting promoted")
+	promoteDynatraceCmd.Flags().StringVarP(&ops.gitHash, "gitHash", "g", "", "Git hash of the SaaS service/operator commit getting promoted")
+	promoteDynatraceCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interfache checkout. Falls back to `pwd` and "+git.DefaultAppInterfaceDirectory())
+
+	return promoteDynatraceCmd
+}
+
+func (o *promoteDynatraceOptions) validateSaasFlow() {
+	if o.component == "" && o.gitHash == "" {
+		fmt.Printf("Usage: For dynatrace component, please provide --component and (optional) --gitHash\n")
+		fmt.Printf("--component is the name of the component, i.e. dynatrace-dynakube\n")
+		fmt.Printf("--gitHash is the target git commit for the dt component, if not specified defaults to HEAD of master\n\n")
+		return
+	}
+}


### PR DESCRIPTION
[OSD-27873](https://issues.redhat.com//browse/OSD-27873) : Promote Dynatrace components using osdctl promote command.

##List all Dynatrace components available for promotion
		
`osdctl promote dynatrace --list`
		
##Promote a dynatrace component
		
`osdctl promote dynatrace --component <component> --gitHash <git-hash>`

--component is the name of the component, i.e. dynatrace-dynakube
--gitHash is the target git commit for the dynatrace component, if not specified defaults to HEAD of master
