### PR TITLE
OSD-24997: Show if a user is banned when using osdctl cluster context

### DIFF
--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -248,9 +248,7 @@ func (o *contextOptions) printLongOutput(data *contextData) {
 	printDynatraceResources(data)
 
 	// Print User Banned Details
-	if data.UserBanned {
-		printUserBannedStatus(data)
-	}
+	printUserBannedStatus(data)
 }
 
 func (o *contextOptions) printShortOutput(data *contextData) {
@@ -763,12 +761,16 @@ func printDynatraceResources(data *contextData) {
 
 func printUserBannedStatus(data *contextData) {
 	var name string = "User Ban Details"
-	fmt.Println(delimiter + name)
-	fmt.Println("User is banned")
-	fmt.Printf("Ban code = %v\n", data.BanCode)
-	fmt.Printf("Ban description = %v\n", data.BanDescription)
-	if data.BanCode == BanCodeExportControlCompliance {
-		fmt.Println("User banned due to export control compliance.\nPlease follow the steps detailed here: https://github.com/openshift/ops-sop/blob/master/v4/alerts/UpgradeConfigSyncFailureOver4HrSRE.md#user-banneddisabled-due-to-export-control-compliance .")
+	fmt.Println("\n" + delimiter + name)
+	if data.UserBanned {
+		fmt.Println("User is banned")
+		fmt.Printf("Ban code = %v\n", data.BanCode)
+		fmt.Printf("Ban description = %v\n", data.BanDescription)
+		if data.BanCode == BanCodeExportControlCompliance {
+			fmt.Println("User banned due to export control compliance.\nPlease follow the steps detailed here: https://github.com/openshift/ops-sop/blob/master/v4/alerts/UpgradeConfigSyncFailureOver4HrSRE.md#user-banneddisabled-due-to-export-control-compliance .")
+		}
+	} else {
+		fmt.Println("User is not banned")
 	}
 }
 


### PR DESCRIPTION
This PR adds output to osdctl cluster context to show if a user is banned. The goal is to cut down on SRE toil time by showing this information at the beginning of the troubleshooting process. Output looks like this

>> User Ban Details
User is banned
Ban code = pending
Ban description = pending