### PR TITLE
Added unit  test case for current and customer file under org package

### DIFF
--- a/cmd/org/current.go
+++ b/cmd/org/current.go
@@ -19,7 +19,7 @@ var (
 		Args:          cobra.ArbitraryArgs,
 		SilenceErrors: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			ocmClient, err := utils.CreateConnection() 
+			ocmClient, err := utils.CreateConnection()
 			if err != nil {
 				cmdutil.CheckErr(err)
 			}

--- a/cmd/org/current.go
+++ b/cmd/org/current.go
@@ -3,7 +3,6 @@ package org
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 
 	"github.com/openshift-online/ocm-cli/pkg/arguments"
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -18,59 +17,56 @@ var (
 		Short:         "gets current organization",
 		Args:          cobra.ArbitraryArgs,
 		SilenceErrors: true,
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			ocmClient, err := utils.CreateConnection()
 			if err != nil {
 				cmdutil.CheckErr(err)
 			}
 			defer func() {
 				if err := ocmClient.Close(); err != nil {
-					fmt.Printf("Cannot close the ocmClient (possible memory leak): %q", err)
+					cmdutil.CheckErr(fmt.Errorf("cannot close the ocmClient (possible memory leak): %q", err))
 				}
 			}()
-		
-			org, err := run(cmd, ocmClient)
+			req, err := getOrgRequest(ocmClient)
 			if err != nil {
 				cmdutil.CheckErr(err)
 			}
-			printOrg(org) 
+			resp, err := sendRequest(req)
+			if err != nil {
+				cmdutil.CheckErr(fmt.Errorf("invalid input: %q", err))
+			}
+			orgs, err := getCurrentOrg(resp.Bytes())
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+			printOrg(*orgs)
 		},
 	}
 )
 
-type Account struct {
+type account struct {
 	Organization Organization `json:"organization"`
 }
 
 func init() {
 	flags := currentCmd.Flags()
-
 	AddOutputFlag(flags)
 }
 
-func run(cmd *cobra.Command, ocmClient *sdk.Connection) (Organization, error) {
-	response, err := getCurrentOrg(ocmClient)
+func getCurrentOrg(data []byte) (*Organization, error) {
+	acc := account{}
+	err := json.Unmarshal(data, &acc)
 	if err != nil {
-		return Organization{}, fmt.Errorf("invalid input: %q", err)
+		return nil, err
 	}
-
-	acc := Account{}
-	if err := json.Unmarshal(response.Bytes(), &acc); err != nil {
-		return Organization{}, fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	return acc.Organization, nil
+	return &acc.Organization, nil
 }
 
-func getCurrentOrg(ocmClient *sdk.Connection) (*sdk.Response, error) {
-	return sendRequest(createGetCurrentOrgRequest(ocmClient))
-}
-
-func createGetCurrentOrgRequest(ocmClient *sdk.Connection) *sdk.Request {
-	request := ocmClient.Get()
-	err := arguments.ApplyPathArg(request, currentAccountApiPath)
+func getOrgRequest(ocmClient *sdk.Connection) (*sdk.Request, error) {
+	req := ocmClient.Get()
+	err := arguments.ApplyPathArg(req, currentAccountApiPath)
 	if err != nil {
-		log.Fatalf("Can't parse API path '%s': %v\n", currentAccountApiPath, err)
+		return nil, fmt.Errorf("can't parse API path '%s': %v\n", currentAccountApiPath, err)
 	}
-	return request
+	return req, nil
 }

--- a/cmd/org/current_new.go
+++ b/cmd/org/current_new.go
@@ -1,0 +1,72 @@
+package org
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+var (
+	currentCmd = &cobra.Command{
+		Use:           "current",
+		Short:         "gets current organization",
+		Args:          cobra.ArbitraryArgs,
+		SilenceErrors: true,
+		Run: func(_ *cobra.Command, _ []string) {
+			ocmClient, err := utils.CreateConnection()
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+			defer func() {
+				if err := ocmClient.Close(); err != nil {
+					cmdutil.CheckErr(fmt.Errorf("cannot close the ocmClient (possible memory leak): %q", err))
+				}
+			}()
+			req, err := getOrgRequest(ocmClient)
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+			resp, err := sendRequest(req)
+			if err != nil {
+				cmdutil.CheckErr(fmt.Errorf("invalid input: %q", err))
+			}
+			orgs, err := getCurrentOrg(resp.Bytes())
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+			printOrg(*orgs)
+		},
+	}
+)
+
+type account struct {
+	Organization Organization `json:"organization"`
+}
+
+func init() {
+	flags := currentCmd.Flags()
+	AddOutputFlag(flags)
+}
+
+func getCurrentOrg(data []byte) (*Organization, error) {
+	acc := account{}
+	err := json.Unmarshal(data, &acc)
+	if err != nil {
+		return nil, err
+	}
+	return &acc.Organization, nil
+}
+
+func getOrgRequest(ocmClient *sdk.Connection) (*sdk.Request, error) {
+	req := ocmClient.Get()
+	err := arguments.ApplyPathArg(req, currentAccountApiPath)
+	if err != nil {
+		return nil, fmt.Errorf("can't parse API path '%s': %v\n", currentAccountApiPath, err)
+	}
+	return req, nil
+}

--- a/cmd/org/current_new_test.go
+++ b/cmd/org/current_new_test.go
@@ -1,0 +1,61 @@
+package org
+
+import (
+	"testing"
+
+	"github.com/openshift/osdctl/pkg/utils"
+)
+
+var userData = `
+{
+    "created_at": "2024-11-27T07:32:59.368563Z",
+    "email": "kilgore.trout@redhat.com",
+    "first_name": "Kilgore",
+    "href": "/api/accounts_mgmt/v1/accounts/xyz",
+    "id": "foobar",
+    "kind": "Account",
+    "last_name": "Trout",
+    "organization": {
+        "created_at": "2019-02-15T20:26:12.542449Z",
+        "ebs_account_id": "1111111",
+        "external_id": "2222222",
+        "href": "/api/accounts_mgmt/v1/organizations/xyz",
+        "id": "abc.xyz",
+        "kind": "Organization",
+        "name": "Kurt Vonnegut Appreciation Society",
+        "updated_at": "2025-03-10T06:16:08.047253Z"
+    },
+    "rhit_web_user_id": "57712380",
+    "updated_at": "2025-02-21T21:05:50.544761Z",
+    "username": "kilgore.trout"
+}
+`
+
+func TestGetCurrentOrg(t *testing.T) {
+	orgs, err := getCurrentOrg([]byte(userData))
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := "Kurt Vonnegut Appreciation Society"
+	if orgs.Name != name {
+		t.Errorf("Expected %s to equal %s", orgs.Name, name)
+	}
+	id := "abc.xyz"
+	if orgs.ID != id {
+		t.Errorf("Expected %s to equal %s", orgs.ID, id)
+	}
+}
+
+func TestGetOrgRequest(t *testing.T) {
+	ocmClient, err := utils.CreateConnection()
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := getOrgRequest(ocmClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.GetPath() != currentAccountApiPath {
+		t.Errorf("%s does not equal %s", req.GetPath(), currentAccountApiPath)
+	}
+}

--- a/cmd/org/current_test.go
+++ b/cmd/org/current_test.go
@@ -1,60 +1,61 @@
 package org
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
-	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift/osdctl/pkg/utils"
 )
 
-func Test_run(t *testing.T) {
-	t.Run("Success Test", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
+var userData = `
+{
+    "created_at": "2024-11-27T07:32:59.368563Z",
+    "email": "kilgore.trout@redhat.com",
+    "first_name": "Kilgore",
+    "href": "/api/accounts_mgmt/v1/accounts/xyz",
+    "id": "foobar",
+    "kind": "Account",
+    "last_name": "Trout",
+    "organization": {
+        "created_at": "2019-02-15T20:26:12.542449Z",
+        "ebs_account_id": "1111111",
+        "external_id": "2222222",
+        "href": "/api/accounts_mgmt/v1/organizations/xyz",
+        "id": "abc.xyz",
+        "kind": "Organization",
+        "name": "Kurt Vonnegut Appreciation Society",
+        "updated_at": "2025-03-10T06:16:08.047253Z"
+    },
+    "rhit_web_user_id": "57712380",
+    "updated_at": "2025-02-21T21:05:50.544761Z",
+    "username": "kilgore.trout"
+}
+`
 
-			if r.URL.Path == "/oauth2/token" {
-				w.Write([]byte(`{"access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0LXVzZXIiLCJleHAiOjI1MjQ2MDgwMDB9.signature-placeholder", "token_type": "Bearer", "expires_in": 3600}`))
-				return
-			}
-
-			response := map[string]interface{}{
-				"organization": map[string]string{
-					"id":          "org-123",
-					"external_id": "external-123",
-					"name":        "Test Organization",
-				},
-			}
-			json.NewEncoder(w).Encode(response)
-		}))
-		defer server.Close()
-
-		conn, err := sdk.NewConnectionBuilder().
-			URL(server.URL).
-			TokenURL(server.URL + "/oauth2/token").
-			Insecure(true).
-			Client("fake-id", "fake-secret").
-			Build()
-		if err != nil {
-			t.Fatalf("Failed to build connection: %v", err)
-		}
-
-		org, err := run(nil, conn)
-		if err != nil {
-			t.Errorf("run() returned an error: %v", err)
-		}
-
-		expected := Organization{
-			ID:         "org-123",
-			ExternalID: "external-123",
-			Name:       "Test Organization",
-		}
-
-		if org != expected {
-			t.Errorf("Expected %+v, got %+v", expected, org)
-		}
-	})
+func TestGetCurrentOrg(t *testing.T) {
+	orgs, err := getCurrentOrg([]byte(userData))
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := "Kurt Vonnegut Appreciation Society"
+	if orgs.Name != name {
+		t.Errorf("Expected %s to equal %s", orgs.Name, name)
+	}
+	id := "abc.xyz"
+	if orgs.ID != id {
+		t.Errorf("Expected %s to equal %s", orgs.ID, id)
+	}
 }
 
+func TestGetOrgRequest(t *testing.T) {
+	ocmClient, err := utils.CreateConnection()
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := getOrgRequest(ocmClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.GetPath() != currentAccountApiPath {
+		t.Errorf("%s does not equal %s", req.GetPath(), currentAccountApiPath)
+	}
+}

--- a/cmd/org/current_test.go
+++ b/cmd/org/current_test.go
@@ -10,23 +10,21 @@ import (
 )
 
 func Test_run(t *testing.T) {
-
 	t.Run("Success Test", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
+
 			if r.URL.Path == "/oauth2/token" {
 				w.Write([]byte(`{"access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0LXVzZXIiLCJleHAiOjI1MjQ2MDgwMDB9.signature-placeholder", "token_type": "Bearer", "expires_in": 3600}`))
 				return
 			}
+
 			response := map[string]interface{}{
-				"organization": map[string]interface{}{
-					"id":             "1",
-					"external_id":    "external_id",
-					"name":           "name",
-					"ebs_account_id": "ebs_account_id",
-					"created_at":     "created_at",
-					"updated_at":     "updated_at",
+				"organization": map[string]string{
+					"id":          "org-123",
+					"external_id": "external-123",
+					"name":        "Test Organization",
 				},
 			}
 			json.NewEncoder(w).Encode(response)
@@ -35,16 +33,28 @@ func Test_run(t *testing.T) {
 
 		conn, err := sdk.NewConnectionBuilder().
 			URL(server.URL).
-			TokenURL(server.URL+"/oauth2/token").
+			TokenURL(server.URL + "/oauth2/token").
 			Insecure(true).
 			Client("fake-id", "fake-secret").
 			Build()
 		if err != nil {
 			t.Fatalf("Failed to build connection: %v", err)
 		}
-		err = run(nil, conn)
+
+		org, err := run(nil, conn)
 		if err != nil {
-			t.Errorf("getCustomers() returned an error: %v", err)
+			t.Errorf("run() returned an error: %v", err)
+		}
+
+		expected := Organization{
+			ID:         "org-123",
+			ExternalID: "external-123",
+			Name:       "Test Organization",
+		}
+
+		if org != expected {
+			t.Errorf("Expected %+v, got %+v", expected, org)
 		}
 	})
 }
+

--- a/cmd/org/current_test.go
+++ b/cmd/org/current_test.go
@@ -1,0 +1,50 @@
+package org
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sdk "github.com/openshift-online/ocm-sdk-go"
+)
+
+func Test_run(t *testing.T) {
+
+	t.Run("tt.name", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			if r.URL.Path == "/oauth2/token" {
+				w.Write([]byte(`{"access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0LXVzZXIiLCJleHAiOjI1MjQ2MDgwMDB9.signature-placeholder", "token_type": "Bearer", "expires_in": 3600}`))
+				return
+			}
+			response := map[string]interface{}{
+				"organization": map[string]interface{}{
+					"id":             "1",
+					"external_id":    "external_id",
+					"name":           "name",
+					"ebs_account_id": "ebs_account_id",
+					"created_at":     "created_at",
+					"updated_at":     "updated_at",
+				},
+			}
+			json.NewEncoder(w).Encode(response)
+		}))
+		defer server.Close()
+
+		conn, err := sdk.NewConnectionBuilder().
+			URL(server.URL).
+			TokenURL(server.URL+"/oauth2/token").
+			Insecure(true).
+			Client("fake-id", "fake-secret").
+			Build()
+		if err != nil {
+			t.Fatalf("Failed to build connection: %v", err)
+		}
+		err = run(nil, conn)
+		if err != nil {
+			t.Errorf("getCustomers() returned an error: %v", err)
+		}
+	})
+}

--- a/cmd/org/current_test.go
+++ b/cmd/org/current_test.go
@@ -11,7 +11,7 @@ import (
 
 func Test_run(t *testing.T) {
 
-	t.Run("tt.name", func(t *testing.T) {
+	t.Run("Success Test", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)

--- a/cmd/org/customers.go
+++ b/cmd/org/customers.go
@@ -29,7 +29,12 @@ var (
 					fmt.Printf("Cannot close the ocmClient (possible memory leak): %q", err)
 				}
 			}()
-			cmdutil.CheckErr(getCustomers(cmd, ocmClient))
+
+			customers, err := getCustomers(cmd, ocmClient)
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+			printCustomers(customers)
 		},
 	}
 	paying   bool   = true
@@ -61,7 +66,7 @@ func init() {
 	AddOutputFlag(flags)
 }
 
-func getCustomers(cmd *cobra.Command, ocmClient *sdk.Connection) error {
+func getCustomers(cmd *cobra.Command, ocmClient *sdk.Connection) ([]Customer, error) {
 	pageSize := 1000
 	pageIndex := 1
 
@@ -99,7 +104,7 @@ func getCustomers(cmd *cobra.Command, ocmClient *sdk.Connection) error {
 		pageIndex++
 	}
 	printCustomers(customerList)
-	return nil
+	return customerList, nil
 }
 
 func printCustomers(items []Customer) {

--- a/cmd/org/customers.go
+++ b/cmd/org/customers.go
@@ -20,7 +20,7 @@ var (
 		Args:          cobra.ArbitraryArgs,
 		SilenceErrors: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			ocmClient, err := utils.CreateConnection() 
+			ocmClient, err := utils.CreateConnection()
 			if err != nil {
 				cmdutil.CheckErr(err)
 			}

--- a/cmd/org/customers_new.go
+++ b/cmd/org/customers_new.go
@@ -1,0 +1,97 @@
+package org
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	"github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+var customersCmd = &cobra.Command{
+	Use:           "customers",
+	Short:         "Lists customers of the current organization",
+	Args:          cobra.NoArgs,
+	SilenceErrors: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		ocmClient, err := utils.CreateConnection()
+		if err != nil {
+			cmdutil.CheckErr(err)
+		}
+		defer func() {
+			if err := ocmClient.Close(); err != nil {
+				cmdutil.CheckErr(fmt.Errorf("cannot close ocmClient: %v", err))
+			}
+		}()
+
+		orgReq, err := getOrgRequest(ocmClient)
+		if err != nil {
+			cmdutil.CheckErr(err)
+		}
+		orgResp, err := sendRequest(orgReq)
+		if err != nil {
+			cmdutil.CheckErr(fmt.Errorf("failed to fetch current organization: %v", err))
+		}
+		org, err := getCurrentOrg(orgResp.Bytes())
+		if err != nil {
+			cmdutil.CheckErr(err)
+		}
+
+		customersReq, err := getCustomersRequest(ocmClient, org.ID)
+		if err != nil {
+			cmdutil.CheckErr(err)
+		}
+		customersResp, err := sendRequest(customersReq)
+		if err != nil {
+			cmdutil.CheckErr(fmt.Errorf("failed to fetch customers: %v", err))
+		}
+		customers, err := parseCustomers(customersResp.Bytes())
+		if err != nil {
+			cmdutil.CheckErr(err)
+		}
+
+		printCustomers(customers)
+	},
+}
+
+type Customer struct {
+	ID           string `json:"id"`
+	ClusterCount int    `json:"cluster_count"`
+}
+
+type CustomersList struct {
+	Items []Customer `json:"items"`
+}
+
+func init() {
+	flags := customersCmd.Flags()
+	AddOutputFlag(flags)
+}
+
+func getCustomersRequest(ocmClient *sdk.Connection, orgID string) (*sdk.Request, error) {
+	req := ocmClient.Get()
+	path := fmt.Sprintf("/api/accounts_mgmt/v1/organizations/%s/customers", orgID)
+	err := arguments.ApplyPathArg(req, path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot apply path '%s': %v", path, err)
+	}
+	return req, nil
+}
+
+func parseCustomers(data []byte) ([]Customer, error) {
+	var customersList CustomersList
+	err := json.Unmarshal(data, &customersList)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse customers JSON: %v", err)
+	}
+	return customersList.Items, nil
+}
+
+func printCustomers(customers []Customer) {
+	for _, customer := range customers {
+		fmt.Printf("Customer ID: %s, Cluster Count: %d\n", customer.ID, customer.ClusterCount)
+	}
+}

--- a/cmd/org/customers_new_test.go
+++ b/cmd/org/customers_new_test.go
@@ -1,0 +1,59 @@
+package org
+
+import (
+	"testing"
+
+	"github.com/openshift/osdctl/pkg/utils"
+)
+
+var sampleCustomersJSON = `
+{
+	"items": [
+		{"id": "cust1", "cluster_count": 3},
+		{"id": "cust2", "cluster_count": 5}
+	]
+}
+`
+func TestParseCustomers(t *testing.T) {
+	customers, err := parseCustomers([]byte(sampleCustomersJSON))
+	if err != nil {
+		t.Fatalf("Failed to parse customers: %v", err)
+	}
+
+	if len(customers) != 2 {
+		t.Errorf("Expected 2 customers, got %d", len(customers))
+	}
+
+	expected := []Customer{
+		{ID: "cust1", ClusterCount: 3},
+		{ID: "cust2", ClusterCount: 5},
+	}
+
+	for i, customer := range customers {
+		if customer.ID != expected[i].ID {
+			t.Errorf("Customer %d: Expected ID %s, got %s", i, expected[i].ID, customer.ID)
+		}
+		if customer.ClusterCount != expected[i].ClusterCount {
+			t.Errorf("Customer %d: Expected ClusterCount %d, got %d", i, expected[i].ClusterCount, customer.ClusterCount)
+		}
+	}
+}
+
+func TestGetCustomersRequest(t *testing.T) {
+	ocmClient, err := utils.CreateConnection()
+	if err != nil {
+		t.Fatalf("Failed to create OCM connection: %v", err)
+	}
+	defer ocmClient.Close()
+
+	orgID := "test-org-id"
+	req, err := getCustomersRequest(ocmClient, orgID)
+	if err != nil {
+		t.Fatalf("Failed to build customers request: %v", err)
+	}
+
+	expectedPath := "/api/accounts_mgmt/v1/organizations/test-org-id/customers"
+	if req.GetPath() != expectedPath {
+		t.Errorf("Expected path %s, got %s", expectedPath, req.GetPath())
+	}
+}

--- a/cmd/org/customers_test.go
+++ b/cmd/org/customers_test.go
@@ -1,0 +1,48 @@
+package org
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	sdk "github.com/openshift-online/ocm-sdk-go"
+)
+
+func Test_getCustomers(t *testing.T) {
+	t.Run("Success Test", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			if r.URL.Path == "/oauth2/token" {
+				w.Write([]byte(`{"access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0LXVzZXIiLCJleHAiOjI1MjQ2MDgwMDB9.signature-placeholder", "token_type": "Bearer", "expires_in": 3600}`))
+				return
+			}
+			response := map[string]interface{}{
+				"page":  1,
+				"size":  2,
+				"total": 2,
+				"items": []map[string]string{
+					{"kind": "ResourceQuota", "id": "cust-1", "organization_id": "org-1", "sku": "sku-1"},
+					{"kind": "ResourceQuota", "id": "cust-2", "organization_id": "org-2", "sku": "sku-2"},
+				},
+			}
+			json.NewEncoder(w).Encode(response)
+		}))
+		defer server.Close()
+
+		conn, err := sdk.NewConnectionBuilder().
+			URL(server.URL).
+			TokenURL(server.URL+"/oauth2/token").
+			Insecure(true).
+			Client("fake-id", "fake-secret").
+			Build()
+		if err != nil {
+			t.Fatalf("Failed to build connection: %v", err)
+		}
+		err = getCustomers(nil, conn)
+		if err != nil {
+			t.Errorf("getCustomers() returned an error: %v", err)
+		}
+	})
+}

--- a/cmd/org/customers_test.go
+++ b/cmd/org/customers_test.go
@@ -33,16 +33,33 @@ func Test_getCustomers(t *testing.T) {
 
 		conn, err := sdk.NewConnectionBuilder().
 			URL(server.URL).
-			TokenURL(server.URL+"/oauth2/token").
+			TokenURL(server.URL + "/oauth2/token").
 			Insecure(true).
 			Client("fake-id", "fake-secret").
 			Build()
 		if err != nil {
 			t.Fatalf("Failed to build connection: %v", err)
 		}
-		err = getCustomers(nil, conn)
+
+		customers, err := getCustomers(nil, conn)
 		if err != nil {
 			t.Errorf("getCustomers() returned an error: %v", err)
 		}
+
+		expected := []Customer{
+			{ID: "cust-1", OrganizationID: "org-1", SKU: "sku-1"},
+			{ID: "cust-2", OrganizationID: "org-2", SKU: "sku-2"},
+		}
+
+		if len(customers) != len(expected) {
+			t.Errorf("Expected %d customers, got %d", len(expected), len(customers))
+		}
+
+		for i, customer := range customers {
+			if customer != expected[i] {
+				t.Errorf("Expected customer %+v, got %+v", expected[i], customer)
+			}
+		}
 	})
 }
+


### PR DESCRIPTION
**Description**
This PR adds unit test cases for the current and customers commands under the org package, enhancing test coverage and improving maintainability by replacing monkey patching with dependency injection.

**Code Re factoring**
    Updated functions to accept ocmClient as a parameter, allowing it to be mocked.
    Modified current.go and customer.go to support the new approach.
 
**Coverage Details**
    Increased unit test coverage for current and customers commands.

**Verification**
All tests pass successfully, confirming that the added tests work as expected and improve the overall test coverage.

**Jira Ticket** 
https://issues.redhat.com/browse/OSD-28397