### PR TITLE
Add unit tests for servicelog in post_test.go

### DIFF
--- a/cmd/servicelog/post_test.go
+++ b/cmd/servicelog/post_test.go
@@ -284,7 +284,7 @@ func TestParseUserParameters(t *testing.T) {
 		expectValues []string
 	}{
 		{
-			name:         "Valid Parameters",
+			name:         "valid_parameters",
 			input:        []string{"FOO=BAR", "BAZ=QUX"},
 			expectNames:  []string{"${FOO}", "${BAZ}"},
 			expectValues: []string{"BAR", "QUX"},
@@ -311,7 +311,7 @@ func TestPrintTemplate(t *testing.T) {
 		expected error
 	}{
 		{
-			name: "Valid input with no errors",
+			name: "valid_input_with_no_errors",
 			input: &PostCmdOptions{
 				Message: servicelog.Message{
 					Severity:      "info",
@@ -342,7 +342,7 @@ func TestPrintClusters(t *testing.T) {
 		expected error
 	}{
 		{
-			name: "Valid clusters input with no errors",
+			name: "valid_clusters_input_with_no_errors",
 			input: func() []*v1.Cluster {
 				clusters := []*v1.Cluster{}
 				cluster1, _ := v1.NewCluster().ExternalID("cluster-1").Build()
@@ -395,12 +395,12 @@ func TestParseClustersFile(t *testing.T) {
 		expected error
 	}{
 		{
-			name:     "Valid JSON input with no errors",
+			name:     "valid_JSON_input_with_no_errors",
 			input:    []byte(`{"clusters":["cluster-1","cluster-2"]}`),
 			expected: nil,
 		},
 		{
-			name:     "Invalid JSON input with errors",
+			name:     "invalid_JSON_input_with_errors",
 			input:    []byte(`{"clusters":["cluster-1","cluster-2"`),
 			expected: assert.AnError,
 		},
@@ -431,7 +431,7 @@ func TestReplaceFlags(t *testing.T) {
 		expectedFilter string
 	}{
 		{
-			name: "Valid Flag Replacement in Message",
+			name: "valid_flag_replacement_in_Message",
 			inputOptions: PostCmdOptions{
 				Message: servicelog.Message{Summary: "This is a FILTERREPLACE test"},
 			},
@@ -440,7 +440,7 @@ func TestReplaceFlags(t *testing.T) {
 			expectedMsg: "This is a successful test",
 		},
 		{
-			name: "Valid Flag Replacement in filtersFromFile",
+			name: "valid_flag_replacement_in_filtersFromFile",
 			inputOptions: PostCmdOptions{
 				filtersFromFile: "Some filter with FILTERREPLACE",
 			},
@@ -466,28 +466,28 @@ func TestCheckLeftovers(t *testing.T) {
 		excludes     []string
 	}{
 		{
-			name: "No Leftovers",
+			name: "no_leftovers",
 			inputOptions: PostCmdOptions{
 				Message: servicelog.Message{Summary: "This is a test"},
 			},
 			excludes: []string{},
 		},
 		{
-			name: "Leftovers Found in Message",
+			name: "leftovers_found_in_message",
 			inputOptions: PostCmdOptions{
 				Message: servicelog.Message{Summary: "This is a ${PLACEHOLDER} test"},
 			},
 			excludes: []string{"${PLACEHOLDER}"},
 		},
 		{
-			name: "Leftovers Found in filtersFromFile",
+			name: "leftovers_found_in_filtersFromFile",
 			inputOptions: PostCmdOptions{
 				filtersFromFile: "Some filter with ${FILTER}",
 			},
 			excludes: []string{"${FILTER}"},
 		},
 		{
-			name: "Excluded Leftovers",
+			name: "excluded_leftovers",
 			inputOptions: PostCmdOptions{
 				Message: servicelog.Message{Summary: "This is a ${PLACEHOLDER} test"},
 			},
@@ -510,7 +510,7 @@ func TestReadTemplate(t *testing.T) {
 		prepare     func()
 	}{
 		{
-			name: "Internal only template",
+			name: "internal_only_template",
 			options: PostCmdOptions{
 				InternalOnly: true,
 			},
@@ -523,7 +523,7 @@ func TestReadTemplate(t *testing.T) {
 			},
 		},
 		{
-			name: "Pre-canned template with overrides",
+			name: "pre-canned_template_with_overrides",
 			options: PostCmdOptions{
 				InternalOnly: false,
 				Overrides:    []string{"some_override"},
@@ -535,7 +535,7 @@ func TestReadTemplate(t *testing.T) {
 			},
 		},
 		{
-			name: "Template file provided",
+			name: "template_file_provided",
 			options: PostCmdOptions{
 				InternalOnly: false,
 				Template:     "template.json",
@@ -567,14 +567,8 @@ func TestReadTemplate(t *testing.T) {
 			if tt.prepare != nil {
 				tt.prepare()
 			}
-
-			// Run the function
 			tt.options.readTemplate()
-
-			// Check if the expected message is set correctly
 			assert.Equal(t, tt.expectedMsg, tt.options.Message)
-
-			// Remove the template file if it was used
 			if tt.options.Template == "template.json" {
 				os.Remove(tt.options.Template)
 			}
@@ -589,14 +583,14 @@ func TestReadFilterFile(t *testing.T) {
 		prepare        func(t *testing.T, options *PostCmdOptions)
 	}{
 		{
-			name: "No filter files specified",
+			name: "no_filter_files_specified",
 			options: PostCmdOptions{
 				filterFiles: []string{},
 			},
 			expectedFilter: "",
 		},
 		{
-			name: "One filter file",
+			name: "one_filter_file",
 			options: PostCmdOptions{
 				filterFiles: []string{},
 			},
@@ -616,7 +610,7 @@ func TestReadFilterFile(t *testing.T) {
 			},
 		},
 		{
-			name: "Multiple filter files",
+			name: "multiple_filter_files",
 			options: PostCmdOptions{
 				filterFiles: []string{},
 			},
@@ -666,7 +660,7 @@ func TestPrintPostOutput(t *testing.T) {
 		inputOptions PostCmdOptions
 	}{
 		{
-			name: "No clusters",
+			name: "no_clusters",
 			inputOptions: PostCmdOptions{
 				successfulClusters: map[string]string{},
 				failedClusters:     map[string]string{},

--- a/cmd/servicelog/post_test.go
+++ b/cmd/servicelog/post_test.go
@@ -1,11 +1,18 @@
 package servicelog
 
 import (
+	"encoding/json"
+
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/osdctl/internal/servicelog"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSetup(t *testing.T) {
@@ -107,4 +114,589 @@ var _ = Describe("Test posting service logs", func() {
 			Expect(err).Should(HaveOccurred())
 		})
 	})
+
+	Context("initializing PostCmdOptions", func() {
+		It("initializes the PostCmdOptions structure", func() {
+			options := &PostCmdOptions{}
+			err := options.Init()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(options.successfulClusters).NotTo(BeNil())
+			Expect(options.failedClusters).NotTo(BeNil())
+		})
+	})
+
+	Context("validating PostCmdOptions", func() {
+		It("fails when cluster-id is missing and no filter is provided", func() {
+			options := &PostCmdOptions{}
+			err := options.Validate()
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).To(Equal("no cluster identifier has been found"))
+		})
+
+		It("validates successfully with a cluster-id", func() {
+			options := &PostCmdOptions{
+				ClusterId: "test-cluster",
+			}
+			err := options.Validate()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("validates successfully with a filter", func() {
+			options := &PostCmdOptions{
+				filterParams: []string{"cloud_provider.id is 'gcp'"},
+			}
+			err := options.Validate()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("newPostCmd function", func() {
+		It("creates a new post command", func() {
+			cmd := newPostCmd()
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Use).To(Equal("post CLUSTER_ID"))
+			Expect(cmd.Short).To(Equal("Post a service log to a cluster or list of clusters"))
+		})
+	})
+
+	Context("getDocClusterType function", func() {
+		It("returns the correct cluster type from the documentation URL", func() {
+			message := "Check the documentation at https://docs.openshift.com/dedicated/welcome/index.html"
+			clusterType := getDocClusterType(message)
+			Expect(clusterType).To(Equal("osd"))
+		})
+
+		It("returns an empty string when the documentation URL is not present", func() {
+			message := "No documentation URL here."
+			clusterType := getDocClusterType(message)
+			Expect(clusterType).To(Equal(""))
+		})
+	})
+
+	Context("accessing files", func() {
+		It("reads a local file successfully", func() {
+			content := []byte("test content")
+			tmpfile, err := os.CreateTemp("", "example")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			defer os.Remove(tmpfile.Name())
+
+			_, err = tmpfile.Write(content)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			err = tmpfile.Close()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fileContent, err := options.accessFile(tmpfile.Name())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fileContent).To(Equal(content))
+		})
+
+		It("reads a URL successfully", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("test content"))
+			}))
+			defer server.Close()
+
+			fileContent, err := options.accessFile(server.URL)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fileContent).To(Equal([]byte("test content")))
+		})
+
+		It("returns an error for a non-existent file", func() {
+			_, err := options.accessFile("non-existent-file")
+			Expect(err).Should(HaveOccurred())
+		})
+
+		It("returns an error for a directory", func() {
+			dir, err := os.MkdirTemp("", "exampledir")
+			Expect(err).ShouldNot(HaveOccurred())
+
+			defer os.RemoveAll(dir)
+
+			_, err = options.accessFile(dir)
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	Context("parsing template", func() {
+		It("parses a valid JSON template successfully", func() {
+			template := servicelog.Message{
+				Summary:      "Test Summary",
+				Description:  "Test Description",
+				InternalOnly: true,
+			}
+			jsonData, err := json.Marshal(template)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			err = options.parseTemplate(jsonData)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(options.Message.Summary).To(Equal(template.Summary))
+			Expect(options.Message.Description).To(Equal(template.Description))
+			Expect(options.Message.InternalOnly).To(Equal(template.InternalOnly))
+		})
+
+		It("returns an error for an invalid JSON template", func() {
+			jsonData := []byte(`{"summary": "Test Summary", "description": "Test Description", "internal_only": "this should be bool"}`)
+
+			err := options.parseTemplate(jsonData)
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	Context("cleaning up", func() {
+		It("cleans up successfully", func() {
+			successful := map[string]string{
+				"cluster-1": "success",
+			}
+
+			failed := map[string]string{}
+
+			clusters := []*v1.Cluster{}
+			cluster1, _ := v1.NewCluster().ExternalID("cluster-1").Build()
+			cluster2, _ := v1.NewCluster().ExternalID("cluster-2").Build()
+
+			clusters = append(clusters, cluster1)
+			clusters = append(clusters, cluster2)
+
+			options := &PostCmdOptions{
+				successfulClusters: successful,
+				failedClusters:     failed,
+			}
+
+			options.cleanUp(clusters)
+
+			// cluster-1 should not be in failedClusters
+			Expect(options.failedClusters).ToNot(HaveKey("cluster-1"))
+
+			// cluster-2 should be in failedClusters
+			Expect(options.failedClusters).To(HaveKey("cluster-2"))
+			Expect(options.failedClusters["cluster-2"]).To(Equal("cannot send message due to program interruption"))
+		})
+	})
 })
+
+func TestParseUserParameters(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        []string
+		expectNames  []string
+		expectValues []string
+	}{
+		{
+			name:         "Valid Parameters",
+			input:        []string{"FOO=BAR", "BAZ=QUX"},
+			expectNames:  []string{"${FOO}", "${BAZ}"},
+			expectValues: []string{"BAR", "QUX"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := &PostCmdOptions{TemplateParams: tt.input}
+			userParameterNames = []string{}
+			userParameterValues = []string{}
+
+			options.parseUserParameters()
+
+			assert.Equal(t, tt.expectNames, userParameterNames)
+			assert.Equal(t, tt.expectValues, userParameterValues)
+		})
+	}
+}
+
+func TestPrintTemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *PostCmdOptions
+		expected error
+	}{
+		{
+			name: "Valid input with no errors",
+			input: &PostCmdOptions{
+				Message: servicelog.Message{
+					Severity:      "info",
+					ServiceName:   "TestService",
+					ClusterID:     "cluster-123",
+					Summary:       "Test Summary",
+					Description:   "This is a test message",
+					InternalOnly:  false,
+					EventStreamID: "event-456",
+					DocReferences: []string{"doc-1", "doc-2"},
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.input.printTemplate()
+			assert.Equal(t, tt.expected, err)
+		})
+	}
+}
+
+func TestPrintClusters(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []*v1.Cluster
+		expected error
+	}{
+		{
+			name: "Valid clusters input with no errors",
+			input: func() []*v1.Cluster {
+				clusters := []*v1.Cluster{}
+				cluster1, _ := v1.NewCluster().ExternalID("cluster-1").Build()
+				cluster2, _ := v1.NewCluster().ExternalID("cluster-2").Build()
+				clusters = append(clusters, cluster1)
+				clusters = append(clusters, cluster2)
+				return clusters
+			}(),
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &PostCmdOptions{}
+			err := o.printClusters(tt.input)
+			assert.Equal(t, tt.expected, err)
+		})
+	}
+}
+
+func TestListMessagedClusters(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]string
+		expected error
+	}{
+		{
+			name:     "Valid clusters input with no errors",
+			input:    nil,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusters := make(map[string]string, 4)
+			clusters["Id1"] = "Status1"
+			clusters["Id2"] = "Status2"
+			clusters["Id3"] = "Status3"
+			clusters["Id4"] = "Status4"
+			o := &PostCmdOptions{}
+			err := o.listMessagedClusters(clusters)
+			assert.Equal(t, tt.expected, err)
+		})
+	}
+}
+
+func TestParseClustersFile(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		input    []byte
+		expected error
+	}{
+		{
+			name:     "Valid JSON input with no errors",
+			input:    []byte(`{"clusters":["cluster-1","cluster-2"]}`),
+			expected: nil,
+		},
+		{
+			name:     "Invalid JSON input with errors",
+			input:    []byte(`{"clusters":["cluster-1","cluster-2"`),
+			expected: assert.AnError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := &PostCmdOptions{}
+			err := options.parseClustersFile(tt.input)
+			if tt.expected == nil {
+				assert.NoError(t, err)
+				assert.Equal(t, 2, len(options.ClustersFile.Clusters))
+				assert.Equal(t, "cluster-1", options.ClustersFile.Clusters[0])
+				assert.Equal(t, "cluster-2", options.ClustersFile.Clusters[1])
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestReplaceFlags(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputOptions   PostCmdOptions
+		flagName       string
+		flagValue      string
+		expectedMsg    string
+		expectedFilter string
+	}{
+		{
+			name: "Valid Flag Replacement in Message",
+			inputOptions: PostCmdOptions{
+				Message: servicelog.Message{Summary: "This is a FILTERREPLACE test"},
+			},
+			flagName:    "FILTERREPLACE",
+			flagValue:   "successful",
+			expectedMsg: "This is a successful test",
+		},
+		{
+			name: "Valid Flag Replacement in filtersFromFile",
+			inputOptions: PostCmdOptions{
+				filtersFromFile: "Some filter with FILTERREPLACE",
+			},
+			flagName:       "FILTERREPLACE",
+			flagValue:      "value",
+			expectedFilter: "Some filter with value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.inputOptions.replaceFlags(tt.flagName, tt.flagValue)
+			assert.Equal(t, tt.expectedMsg, tt.inputOptions.Message.Summary)
+			assert.Equal(t, tt.expectedFilter, tt.inputOptions.filtersFromFile)
+
+		})
+	}
+}
+
+func TestCheckLeftovers(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputOptions PostCmdOptions
+		excludes     []string
+	}{
+		{
+			name: "No Leftovers",
+			inputOptions: PostCmdOptions{
+				Message: servicelog.Message{Summary: "This is a test"},
+			},
+			excludes: []string{},
+		},
+		{
+			name: "Leftovers Found in Message",
+			inputOptions: PostCmdOptions{
+				Message: servicelog.Message{Summary: "This is a ${PLACEHOLDER} test"},
+			},
+			excludes: []string{"${PLACEHOLDER}"},
+		},
+		{
+			name: "Leftovers Found in filtersFromFile",
+			inputOptions: PostCmdOptions{
+				filtersFromFile: "Some filter with ${FILTER}",
+			},
+			excludes: []string{"${FILTER}"},
+		},
+		{
+			name: "Excluded Leftovers",
+			inputOptions: PostCmdOptions{
+				Message: servicelog.Message{Summary: "This is a ${PLACEHOLDER} test"},
+			},
+			excludes: []string{"${PLACEHOLDER}"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.inputOptions.checkLeftovers(tt.excludes)
+			// no assert is required as checkleftover doesn't return anything, We just have to ensure no Fatal logs are logged.
+		})
+	}
+}
+
+func TestReadTemplate(t *testing.T) {
+	tests := []struct {
+		name        string
+		options     PostCmdOptions
+		expectedMsg servicelog.Message
+		prepare     func()
+	}{
+		{
+			name: "Internal only template",
+			options: PostCmdOptions{
+				InternalOnly: true,
+			},
+			expectedMsg: servicelog.Message{
+				Severity:     "Info",
+				ServiceName:  "SREManualAction",
+				Summary:      "INTERNAL ONLY, DO NOT SHARE WITH CUSTOMER",
+				Description:  "${MESSAGE}",
+				InternalOnly: true,
+			},
+		},
+		{
+			name: "Pre-canned template with overrides",
+			options: PostCmdOptions{
+				InternalOnly: false,
+				Overrides:    []string{"some_override"},
+			},
+			expectedMsg: servicelog.Message{
+				Severity:     "Info",
+				ServiceName:  "SREManualAction",
+				InternalOnly: true,
+			},
+		},
+		{
+			name: "Template file provided",
+			options: PostCmdOptions{
+				InternalOnly: false,
+				Template:     "template.json",
+			},
+			expectedMsg: servicelog.Message{
+				Severity:     "Info",
+				ServiceName:  "TestService",
+				Summary:      "Test Summary",
+				Description:  "Test Description",
+				InternalOnly: true,
+			},
+			prepare: func() {
+				fileContent := `{
+					"severity": "Info",
+					"service_name": "TestService",
+					"summary": "Test Summary",
+					"description": "Test Description",
+					"internal_only": true
+				}`
+				if err := os.WriteFile("template.json", []byte(fileContent), 0644); err != nil {
+					t.Fatalf("Failed to create template file: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.prepare != nil {
+				tt.prepare()
+			}
+
+			// Run the function
+			tt.options.readTemplate()
+
+			// Check if the expected message is set correctly
+			assert.Equal(t, tt.expectedMsg, tt.options.Message)
+
+			// Remove the template file if it was used
+			if tt.options.Template == "template.json" {
+				os.Remove(tt.options.Template)
+			}
+		})
+	}
+}
+
+func TestReadFilterFile(t *testing.T) {
+	tests := []struct {
+		name           string
+		options        PostCmdOptions
+		expectedFilter string
+		prepare        func() // Prepare function to set up any necessary conditions for the test
+	}{
+		{
+			name: "No filter files specified",
+			options: PostCmdOptions{
+				filterFiles: []string{}, // No filter files
+			},
+			expectedFilter: "",
+		},
+		{
+			name: "One filter file",
+			options: PostCmdOptions{
+				filterFiles: []string{"filter1.txt"},
+			},
+			expectedFilter: "(Filter content from filter1.txt)",
+			prepare: func() {
+				// Create a temporary filter file
+				fileContent := "Filter content from filter1.txt"
+				if err := os.WriteFile("filter1.txt", []byte(fileContent), 0644); err != nil {
+					t.Fatalf("Failed to create filter file: %v", err)
+				}
+			},
+		},
+		{
+			name: "Multiple filter files",
+			options: PostCmdOptions{
+				filterFiles: []string{"filter1.txt", "filter2.txt"},
+			},
+			expectedFilter: "(Filter content from filter1.txt) and (Filter content from filter2.txt)",
+			prepare: func() {
+				// Create temporary filter files-
+				fileContent1 := "Filter content from filter1.txt"
+				fileContent2 := "Filter content from filter2.txt"
+				if err := os.WriteFile("filter1.txt", []byte(fileContent1), 0644); err != nil {
+					t.Fatalf("Failed to create filter1 file: %v", err)
+				}
+				if err := os.WriteFile("filter2.txt", []byte(fileContent2), 0644); err != nil {
+					t.Fatalf("Failed to create filter2 file: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.prepare != nil {
+				tt.prepare()
+			}
+			// Call the readFilterFile function (leaving the log.Fatal inside it)
+			tt.options.readFilterFile()
+			// Check if the expected filter was set correctly
+			assert.Equal(t, tt.expectedFilter, tt.options.filtersFromFile)
+			// Cleanup the files that were created
+			for _, filterFile := range tt.options.filterFiles {
+				os.Remove(filterFile)
+			}
+		})
+	}
+}
+
+// Can't Handle positive case as it is going to logs.Fatal().
+// Commenting out the positive tests so that if inFuture, fatal is changed to error or panic then we can use same test with addition of defer to validate positive cases
+func TestPrintPostOutput(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputOptions PostCmdOptions
+	}{
+		{
+			name: "No clusters",
+			inputOptions: PostCmdOptions{
+				successfulClusters: map[string]string{},
+				failedClusters:     map[string]string{},
+			},
+		},
+		/*		{
+					name: "Only successful clusters",
+					inputOptions: PostCmdOptions{
+						successfulClusters: map[string]string{"cluster1": "success"},
+						failedClusters:     map[string]string{},
+					},
+				},
+				{
+					name: "Only failed clusters",
+					inputOptions: PostCmdOptions{
+						successfulClusters: map[string]string{},
+						failedClusters:     map[string]string{"cluster2": "failed"},
+					},
+				},
+				{
+					name: "Both successful and failed clusters",
+					inputOptions: PostCmdOptions{
+						successfulClusters: map[string]string{"cluster1": "success"},
+						failedClusters:     map[string]string{"cluster2": "failed"},
+					},
+				},
+		*/
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.inputOptions.printPostOutput()
+		})
+	}
+}

--- a/cmd/servicelog/post_test.go
+++ b/cmd/servicelog/post_test.go
@@ -149,15 +149,6 @@ var _ = Describe("Test posting service logs", func() {
 		})
 	})
 
-	Context("newPostCmd function", func() {
-		It("creates a new post command", func() {
-			cmd := newPostCmd()
-			Expect(cmd).NotTo(BeNil())
-			Expect(cmd.Use).To(Equal("post CLUSTER_ID"))
-			Expect(cmd.Short).To(Equal("Post a service log to a cluster or list of clusters"))
-		})
-	})
-
 	Context("getDocClusterType function", func() {
 		It("returns the correct cluster type from the documentation URL", func() {
 			message := "Check the documentation at https://docs.openshift.com/dedicated/welcome/index.html"


### PR DESCRIPTION
This PR significantly enhances the test coverage for the post.go file in Servicelog, increasing the overall coverage by approximately 50%. To achieve this, additional unit tests were added for various functions in the post file, written in post_test.go. These new tests ensure the correct functionality of the methods defined in post.go. 

User Story -->   https://issues.redhat.com/browse/OSD-28412

~/git/osdctl/cmd/servicelog$   go test -coverprofile=coverage.out
go tool cover -html=coverage.out

As a result, the code coverage for the servicelog package has increased to 48%. All tests have passed successfully, confirming that the newly added tests function as expected and contribute to improved overall test coverage.