### PR TITLE
OSD-28828 : Fixed osdctl promote dynatrace command 

### DIFF
--- a/cmd/promote/dynatrace/dt_app_interface.go
+++ b/cmd/promote/dynatrace/dt_app_interface.go
@@ -98,7 +98,7 @@ func GetCurrentGitHashFromAppInterface(saarYamlFile []byte, serviceName string) 
 
 	for _, resourceTemplate := range service.ResourceTemplates {
 		for _, target := range resourceTemplate.Targets {
-			if strings.Contains(target.Name, "production-") {
+			if strings.Contains(target.Name, "production-") || strings.Contains(target.Namespace["$ref"], "hivep") {
 				currentGitHash = target.Ref
 				serviceFilepath = resourceTemplate.PATH
 				break


### PR DESCRIPTION
Added fix for osdctl promote dynatrace command that was failing for following components due to different template for their saas file. 
dynatrace-opentelemetry-operator
dynatrace-operator
dynatrace-rules

Closes [OSD-28828](https://issues.redhat.com//browse/OSD-28828)
