### PR TITLE
Set k8s controller runtime logger if not already set to avoid warning stacktraces

### DIFF
--- a/cmd/common/helpers.go
+++ b/cmd/common/helpers.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"io"
 
 	bplogin "github.com/openshift/backplane-cli/cmd/ocm-backplane/login"
 	bpconfig "github.com/openshift/backplane-cli/pkg/cli/config"
@@ -11,6 +12,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 // UpdateSecret updates a specified k8s secret with the provided data
@@ -47,6 +50,10 @@ func GetKubeConfigAndClient(clusterID string, elevationReasons ...string) (clien
 	}
 	if err != nil {
 		return nil, nil, nil, err
+	}
+	// To avoid warnings/backtrace, if k8s controller-runtime logger is not yet set, do it now...
+	if !log.Log.Enabled() {
+		log.SetLogger(zap.New(zap.WriteTo(io.Discard)))
 	}
 	// create the clientset
 	clientset, err := kubernetes.NewForConfig(kubeconfig)


### PR DESCRIPTION
These changes attempt to address the following warning + stack trace is dumped when k8s controller runtime logger is not set. 

"[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed."

When a new k8s client is created, if a logger has not been set,   a placeholder logger is added with the behavior to discard k8s controller runtime logs. I believe these logs would have been discarded w/o a logger set so the behavior should be the same.  A user can still set the logger before and/or after creating the k8s client if they wish. 
 
Although the stack trace may be a little alarming, the error appears to be benign and just a warning. 
A quick search in slack shows this has come up a decent amount in different utils. 

Example warning and stack trace when k8s logger is not set...
```
INFO[0063] Backplane URL retrieved via OCM environment: https://api.stage.backplane.openshift.com
INFO[0063] No PagerDuty API Key configuration available. This will result in failure of `ocm-backplane login --pd <incident-id>` command.
INFO[0067] Backplane URL retrieved via OCM environment: https://api.stage.backplane.openshift.com
INFO[0067] No PagerDuty API Key configuration available. This will result in failure of `ocm-backplane login --pd <incident-id>` command.
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
	>  goroutine 1 [running]:
	>  runtime/debug.Stack()
	>  	/opt/homebrew/Cellar/go/1.23.2/libexec/src/runtime/debug/stack.go:26 +0x64
	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	>  	/Users/maclark/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/log/log.go:60 +0xf4
	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).Enabled(0x14000663800, 0x0)
	>  	/Users/maclark/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.1/pkg/log/deleg.go:111 +0x30
	>  github.com/go-logr/logr.Logger.Enabled({{0x1076461e8?, 0x14000663800?}, 0x140009181f0?})
	>  	/Users/maclark/go/pkg/mod/github.com/go-logr/logr@v1.4.2/logr.go:263 +0x3c
	>  github.com/openshift/osdctl/cmd/common.GetKubeConfigAndClient({0x14000f76300, 0x20}, {0x1400078a580, 0x2, 0x2})
	>  	/Users/maclark/osdctl/cmd/common/helpers.go:60 +0x184
	>  github.com/openshift/osdctl/cmd/cluster.(*transferOwnerOptions).run(0x140001e7830)
	>  	/Users/maclark/osdctl/cmd/cluster/transferowner.go:788 +0x16f0
	>  github.com/openshift/osdctl/cmd/cluster.newCmdTransferOwner.func1(0x14000776308?, {0x1400076d440?, 0x4?, 0x105862a31?})
	>  	/Users/maclark/osdctl/cmd/cluster/transferowner.go:78 +0x20
	>  github.com/spf13/cobra.(*Command).execute(0x14000776308, {0x1400076d3e0, 0x6, 0x6})
	>  	/Users/maclark/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1019 +0x814
	>  github.com/spf13/cobra.(*Command).ExecuteC(0x14000024608)
	>  	/Users/maclark/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x350
	>  github.com/spf13/cobra.(*Command).Execute(0x1075c4268?)
	>  	/Users/maclark/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071 +0x1c
	>  main.main()
	>  	/Users/maclark/osdctl/main.go:23 +0xd0
```