### PR TITLE
OSD-26415: Allow pull-secret to be updated w/o transferring ownership.

### DIFF
--- a/cmd/cluster/transferowner.go
+++ b/cmd/cluster/transferowner.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fatih/color"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	hiveapiv1 "github.com/openshift/hive/apis/hive/v1"
 	hiveinternalv1alpha1 "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
@@ -38,23 +39,37 @@ import (
 const (
 	CheckSyncMaxAttempts = 24
 
-	SL_TRANSFER_INITIATED = "https://github.com/openshift/managed-notifications/raw/refs/heads/master/osd/clustertransfer_starting.json"
-	SL_TRANSFER_COMPLETE  = "https://github.com/openshift/managed-notifications/raw/refs/heads/master/osd/clustertransfer_completed.json"
+	SL_TRANSFER_INITIATED  = "https://github.com/openshift/managed-notifications/raw/refs/heads/master/osd/clustertransfer_starting.json"
+	SL_TRANSFER_COMPLETE   = "https://github.com/openshift/managed-notifications/raw/refs/heads/master/osd/clustertransfer_completed.json"
+	SL_PULL_SECRET_ROTATED = "https://raw.githubusercontent.com/openshift/managed-notifications/refs/heads/master/osd/pull_secret_rotated.json"
 )
 
 // transferOwnerOptions defines the struct for running transferOwner command
 type transferOwnerOptions struct {
-	output       string
-	clusterID    string
-	newOwnerName string
-	reason       string
-	dryrun       bool
-	hypershift   bool
-	cluster      *cmv1.Cluster
+	output           string
+	clusterID        string
+	newOwnerName     string
+	reason           string
+	dryrun           bool
+	hypershift       bool
+	doPullSecretOnly bool
+	cluster          *cmv1.Cluster
 
 	genericclioptions.IOStreams
 	GlobalOptions *globalflags.GlobalOptions
 }
+
+var red *color.Color
+var blue *color.Color
+var green *color.Color
+
+const transferOwnerCmdExample = `
+  # Transfer ownership
+  osdctl cluster transfer-owner --new-owner "new_OCM_userName" --cluster-id 1kfmyclusteristhebesteverp8m --reason "transfer ownership per jira-id"
+
+  # Update pull secret without transfering ownership
+  osdctl cluster transfer-owner --pull-secret-only --cluster-id 1kfmyclusteristhebesteverp8m --reason "update pull secret per jira-id" 
+`
 
 func newCmdTransferOwner(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	ops := newTransferOwnerOptions(streams, globalOpts)
@@ -62,7 +77,9 @@ func newCmdTransferOwner(streams genericclioptions.IOStreams, globalOpts *global
 		Use:               "transfer-owner",
 		Short:             "Transfer cluster ownership to a new user (to be done by Region Lead)",
 		Args:              cobra.NoArgs,
+		Example:           transferOwnerCmdExample,
 		DisableAutoGenTag: true,
+		PreRun:            func(cmd *cobra.Command, args []string) { cmdutil.CheckErr(ops.preRun()) },
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(ops.run())
 		},
@@ -71,11 +88,14 @@ func newCmdTransferOwner(streams genericclioptions.IOStreams, globalOpts *global
 	transferOwnerCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "The Internal Cluster ID/External Cluster ID/ Cluster Name")
 	transferOwnerCmd.Flags().StringVar(&ops.newOwnerName, "new-owner", ops.newOwnerName, "The new owners username to transfer the cluster to")
 	transferOwnerCmd.Flags().BoolVarP(&ops.dryrun, "dry-run", "d", false, "Dry-run - show all changes but do not apply them")
+	transferOwnerCmd.Flags().BoolVar(&ops.doPullSecretOnly, "pull-secret-only", false, "Update cluster pull secret from current OCM AccessToken data without ownership transfer")
 	transferOwnerCmd.Flags().StringVar(&ops.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)")
 
 	_ = transferOwnerCmd.MarkFlagRequired("cluster-id")
-	_ = transferOwnerCmd.MarkFlagRequired("new-owner")
 	_ = transferOwnerCmd.MarkFlagRequired("reason")
+	transferOwnerCmd.MarkFlagsOneRequired("new-owner", "pull-secret-only")
+	// Avoid user errors, typos, etc.. Dont allow 'new-owner' to be provided when rotating 'pull-secret-only'
+	transferOwnerCmd.MarkFlagsMutuallyExclusive("new-owner", "pull-secret-only")
 
 	return transferOwnerCmd
 }
@@ -94,6 +114,22 @@ type serviceLogParameters struct {
 	NewOwnerName          string
 	NewOwnerID            string
 	IsExternalOrgTransfer bool
+}
+
+// SL params for pull-secret updates w/o owner transfer
+type psOnlyServiceLogParameters struct {
+	ClusterID         string
+	OwnerName         string
+	OwnerID           string
+	PullSecretUpdated bool
+}
+
+func (o *transferOwnerOptions) preRun() error {
+	// Initialize the color formats...
+	red = color.New(color.FgHiRed, color.BgBlack)
+	green = color.New(color.FgHiGreen, color.BgBlack)
+	blue = color.New(color.FgHiBlue, color.BgBlack)
+	return nil
 }
 
 func generateInternalServiceLog(params serviceLogParameters) servicelog.PostCmdOptions {
@@ -266,8 +302,53 @@ func rolloutTelemeterClientPods(clientset *kubernetes.Clientset, namespace, sele
 	fmt.Printf("Pods in namespace %s with label selector '%s' have been deleted.\n", namespace, selector)
 	return nil
 }
+func getPullSecretTokenAuth(registryID string, secret *corev1.Secret) (*amv1.AccessTokenAuth, error) {
+	if len(registryID) <= 0 {
+		return nil, fmt.Errorf("error: registryID empty in getPullSecretToken()")
+	}
+	dockerConfigJsonBytes, found := secret.Data[".dockerconfigjson"]
+	if !found {
+		return nil, fmt.Errorf("secret missing '.dockerconfigjson'?")
+	}
+	dockerConfigJson, err := amv1.UnmarshalAccessToken(dockerConfigJsonBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse secret, err: %w", err)
+	}
+	registryAuth, found := dockerConfigJson.Auths()[registryID]
+	if !found {
+		return nil, fmt.Errorf("error: registry '%s not found in pull_secret.auths", registryID)
+	}
+	return registryAuth, nil
+}
 
-func verifyClusterPullSecret(clientset *kubernetes.Clientset, expectedPullSecret string) error {
+func comparePullSecretAuths(pullSecret *corev1.Secret, expectedAuths map[string]*amv1.AccessTokenAuth) error {
+	var errString strings.Builder
+	blue.Println("\nComparing pull-secret to expected auth sections...")
+	for akey, auth := range expectedAuths {
+		// Find the matching auth entry for this registry name in the cluster pull_secret data...
+		psTokenAuth, err := getPullSecretTokenAuth(akey, pullSecret)
+		if err != nil {
+			errString.WriteString(fmt.Sprintf("Failed to fetch expected auth['%s'] from cluster pull-secret, err:'%s'.\n", akey, err))
+		}
+		if auth.Auth() != psTokenAuth.Auth() {
+			errString.WriteString(fmt.Sprintf("Expected auth['%s'] does not match authToken found in cluster pull-secret.\n", akey))
+		} else {
+			green.Printf("Auth '%s' - tokens match\n", akey)
+		}
+		if auth.Email() != psTokenAuth.Email() {
+			errString.WriteString(fmt.Sprintf("Expected auth['%s'] does not match email found in cluster pull-secret.\n", akey))
+		} else {
+			green.Printf("Auth '%s' - emails match\n", akey)
+		}
+	}
+	if errString.Len() <= 0 {
+		return nil
+	} else {
+		return fmt.Errorf("%s", errString.String())
+	}
+}
+
+func verifyClusterPullSecret(clientset *kubernetes.Clientset, expectedPullSecret string, expectedAuths map[string]*amv1.AccessTokenAuth) error {
 	// Retrieve the pull secret from the "openshift-config" namespace
 	pullSecret, err := clientset.CoreV1().Secrets("openshift-config").Get(context.TODO(), "pull-secret", metav1.GetOptions{})
 	if err != nil {
@@ -279,14 +360,30 @@ func verifyClusterPullSecret(clientset *kubernetes.Clientset, expectedPullSecret
 	if !ok {
 		return fmt.Errorf("pull secret data not found in the secret")
 	}
+	err = comparePullSecretAuths(pullSecret, expectedAuths)
+	if err != nil {
+		red.Printf("\nFound mis-matching auth values during compare. Please review:\n%s", err)
+		fmt.Printf("Would you like to continue?")
+		if !utils.ConfirmPrompt() {
+			return fmt.Errorf("operation aborted by the user")
+		}
+	} else {
+		//fmt.Printf("\nComparison shows subset of Auths from OCM AuthToken have matching tokens + emails in cluster pull-secret. PASS\n")
+		green.Println("\nComparison shows subset of Auths from OCM AuthToken have matching tokens + emails in cluster pull-secret. PASS")
+	}
 
-	fmt.Println("Actual Cluster Pull Secret:")
+	blue.Println("Actual Cluster Pull Secret:")
 	fmt.Println(string(pullSecretData))
 
 	// Print the expected pull secret
-	fmt.Println("\nExpected Cluster Pull Secret:")
+	blue.Println("\nExpected Auths from OCM AccessToken expected to be present in Pull Secret (note this can be a subset):")
 	fmt.Println(expectedPullSecret)
 
+	// TODO: Consider confirming that the email and token values of the 'subset' of Auths
+	// contained in the OCM AccessToken actually matches email/token values in the cluster's
+	// openshift-config/pull-secret. Provide any descrepencies to the user here before
+	// prompting to visually evaluate.
+	//
 	// Ask the user to confirm if the actual pull secret matches their expectation
 	reader := bufio.NewReader(os.Stdin)
 	fmt.Print("\nDoes the actual pull secret match your expectation? (yes/no): ")
@@ -300,13 +397,13 @@ func verifyClusterPullSecret(clientset *kubernetes.Clientset, expectedPullSecret
 		return fmt.Errorf("operation aborted by the user")
 	}
 
-	fmt.Println("Pull secret verification successful.")
+	green.Println("Pull secret verification (by user) successful.")
 
 	return nil
 }
 
 func updateManifestWork(conn *sdk.Connection, kubeCli client.Client, clusterID, mgmtClusterName string, pullsecret []byte) error {
-
+	fmt.Printf("updateManifestwork begin...\n")
 	if err := workv1.AddToScheme(kubeCli.Scheme()); err != nil {
 		return fmt.Errorf("failed to add scheme: %w", err)
 	}
@@ -322,6 +419,7 @@ func updateManifestWork(conn *sdk.Connection, kubeCli client.Client, clusterID, 
 	secretNamePrefix := hostedCluster.DomainPrefix() + "-pull"
 
 	// Generate a random new secret name based on the existing pull secret name
+	// A new secret 'name' is used here to trigger the update(?)
 	randomSuffix := func(chars string, length int) string {
 		rand.Seed(time.Now().UnixNano())
 		result := make([]byte, length)
@@ -332,6 +430,7 @@ func updateManifestWork(conn *sdk.Connection, kubeCli client.Client, clusterID, 
 	}
 	newSecretName := secretNamePrefix + "-" + randomSuffix("0123456789abcdef", 6)
 
+	fmt.Printf("get() Manifestwork...\n")
 	manifestWork := &workv1.ManifestWork{}
 	err = kubeCli.Get(context.TODO(), types.NamespacedName{Name: manifestWorkName, Namespace: manifestWorkNamespace}, manifestWork)
 	if err != nil {
@@ -391,13 +490,15 @@ func updateManifestWork(conn *sdk.Connection, kubeCli client.Client, clusterID, 
 		}
 	}
 
+	fmt.Printf("update() Manifestwork...\n")
 	err = kubeCli.Update(context.TODO(), manifestWork, &client.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("cannot update the pull-secret within manifestwork: %w", err)
 	}
 
 	// The secret will be synced to the management cluster and guest cluster in a few seconds, wait here
-	fmt.Println("sleep 60 seconds here to make sure secret gets synced on guest cluster")
+	fmt.Println("Manifest work updated. ")
+	fmt.Println("Sleeping 60 seconds here to allow secret to be synced on guest cluster")
 	time.Sleep(time.Second * 60)
 
 	return nil
@@ -442,6 +543,7 @@ func (o *transferOwnerOptions) run() error {
 
 	// Create an OCM client to talk to the cluster API
 	// the user has to be logged in (e.g. 'ocm login')
+	var err error
 	ocm, err := utils.CreateConnection()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM client: %w", err)
@@ -456,11 +558,36 @@ func (o *transferOwnerOptions) run() error {
 	cluster, err := utils.GetClusterAnyStatus(ocm, o.clusterID)
 	o.cluster = cluster
 	o.clusterID = cluster.ID()
-
-	userDetails, err := ocm.AccountsMgmt().V1().Accounts().Account(o.newOwnerName).Get().Send()
-	userName, ok := userDetails.Body().GetUsername()
-	if !ok {
-		return fmt.Errorf("Failed to get username from new user id")
+	var userName string
+	var subscription *amv1.Subscription = nil
+	var oldOwnerAccount *amv1.Account = nil
+	var userDetails *amv1.AccountGetResponse
+	var ok bool
+	if o.doPullSecretOnly {
+		// This is updating the pull secret and not a ownwership transfer.
+		// Use existing subscription, account, and userName value...
+		subscription, err = utils.GetSubscription(ocm, o.clusterID)
+		if err != nil {
+			return fmt.Errorf("Failed to get subscription info for cluster:'%s', err: '%v'", o.clusterID, err)
+		}
+		oldOwnerAccount, err = utils.GetAccount(ocm, subscription.Creator().ID())
+		if err != nil {
+			return fmt.Errorf("Failed to get account info from subscription, err:'%v'", err)
+		}
+		userName = oldOwnerAccount.Username()
+		fmt.Printf("Old username:'%s'\n", userName)
+	} else {
+		// This is an ownership transfer.
+		// Lookup New Owner Name...
+		userDetails, err = ocm.AccountsMgmt().V1().Accounts().Account(o.newOwnerName).Get().Send()
+		if err != nil {
+			return fmt.Errorf("failed to fetch Account info, err:'%v'", err)
+		}
+		ok := false
+		userName, ok = userDetails.Body().GetUsername()
+		if !ok {
+			return fmt.Errorf("Failed to get username from new user id")
+		}
 	}
 
 	var mgmtCluster, svcCluster, hiveCluster, masterCluster *cmv1.Cluster
@@ -490,9 +617,12 @@ func (o *transferOwnerOptions) run() error {
 
 	elevationReasons := []string{
 		o.reason,
-		fmt.Sprintf("Updating pull secret using osdctl to tranfert owner to %s", o.newOwnerName),
 	}
-
+	if o.doPullSecretOnly {
+		elevationReasons = append(elevationReasons, fmt.Sprintf("Updating pull secret using osdctl"))
+	} else {
+		elevationReasons = append(elevationReasons, fmt.Sprintf("Updating pull secret using osdctl to tranfert owner to %s", o.newOwnerName))
+	}
 	// Gather all required information
 	fmt.Println("Gathering all required information for the cluster transfer...")
 	cluster, err = utils.GetCluster(ocm, o.clusterID)
@@ -505,19 +635,22 @@ func (o *transferOwnerOptions) run() error {
 		return fmt.Errorf("cluster has no external id")
 	}
 
-	subscription, err := utils.GetSubscription(ocm, o.clusterID)
-	if err != nil {
-		return fmt.Errorf("could not get subscription: %w", err)
+	if subscription == nil {
+		subscription, err = utils.GetSubscription(ocm, o.clusterID)
+		if err != nil {
+			return fmt.Errorf("could not get subscription: %w", err)
+		}
 	}
 
 	subscriptionID, ok := subscription.GetID()
 	if !ok {
 		return fmt.Errorf("Could not get subscription id")
 	}
-
-	oldOwnerAccount, ok := subscription.GetCreator()
-	if !ok {
-		return fmt.Errorf("cluster has no owner account")
+	if oldOwnerAccount == nil {
+		oldOwnerAccount, ok = subscription.GetCreator()
+		if !ok {
+			return fmt.Errorf("cluster has no owner account")
+		}
 	}
 
 	oldOrganizationId, ok := subscription.GetOrganizationID()
@@ -532,20 +665,38 @@ func (o *transferOwnerOptions) run() error {
 		fmt.Printf("Error: %s", err)
 		return fmt.Errorf("could not get current owner organization")
 	}
-
-	newAccount, err := utils.GetAccount(ocm, o.newOwnerName)
-	if err != nil {
-		return fmt.Errorf("could not get new owners account: %w", err)
-	}
-
-	newOrganization, ok := newAccount.GetOrganization()
-	if !ok {
-		return fmt.Errorf("new account has no organization")
+	var newAccount *amv1.Account = nil
+	var newOrganization *amv1.Organization = nil
+	var oldUsername string
+	if o.doPullSecretOnly {
+		// This is not an ownership transfer, just pull-secret update,
+		// new info == old info.
+		// TODO: Can likely skip most of the next set of checks, but why not?
+		oldUsername, ok = oldOwnerAccount.GetUsername()
+		if !ok {
+			fmt.Printf("old username not found?\n")
+		}
+		fmt.Printf("Using old account values. OwnerAccount:'%s'\n", oldUsername)
+		newAccount = oldOwnerAccount
+		newOrganization = oldOrganization
+	} else {
+		newAccount, err = utils.GetAccount(ocm, o.newOwnerName)
+		if err != nil {
+			return fmt.Errorf("could not get new owners account: %w", err)
+		}
+		newOrganization, ok = newAccount.GetOrganization()
+		if !ok {
+			return fmt.Errorf("new account has no organization")
+		}
 	}
 
 	newOrganizationId, ok := newOrganization.GetID()
 	if !ok {
 		return fmt.Errorf("new organization has no ID")
+	}
+	fmt.Printf("old orgID:'%s', new orgID:'%s'\n", newOrganizationId, oldOrganizationId)
+	if o.doPullSecretOnly && newOrganizationId != oldOrganizationId {
+		return fmt.Errorf("new org != old org. Ownership transfer not expected with pull-secret-only flag")
 	}
 
 	accountID, ok := newAccount.GetID()
@@ -610,22 +761,44 @@ func (o *transferOwnerOptions) run() error {
 		IsExternalOrgTransfer: orgChanged,
 	}
 
-	// Send a SL saying we're about to start
-	fmt.Println("Notify the customer before ownership transfer commences. Sending service log.")
-	postCmd := generateServiceLog(slParams, SL_TRANSFER_INITIATED)
-	if err := postCmd.Run(); err != nil {
-		fmt.Println("Failed to POST customer service log. Please manually send a service log to notify the customer before ownership transfer commences:")
-		fmt.Printf("osdctl servicelog post %v -t %v -p %v\n",
-			o.clusterID, SL_TRANSFER_INITIATED, strings.Join(postCmd.TemplateParams, " -p "))
+	var postCmd servicelog.PostCmdOptions
+	//TODO: If only updating the pull-secret, and not transfering ownership
+	//      should we send a SL both before and after the rotate operation?
+	//      Currently only sending an after the pull-secret update is completed
+	//      when not also transfering ownership.
+	if !o.doPullSecretOnly {
+		// Send a SL saying we're about to start ownership transfer
+		fmt.Println("Notify the customer before ownership transfer commences. Sending service log.")
+		postCmd = generateServiceLog(slParams, SL_TRANSFER_INITIATED)
+		if err := postCmd.Run(); err != nil {
+			fmt.Println("Failed to POST customer service log. Please manually send a service log to notify the customer before ownership transfer commences:")
+			fmt.Printf("osdctl servicelog post %v -t %v -p %v\n",
+				o.clusterID, SL_TRANSFER_INITIATED, strings.Join(postCmd.TemplateParams, " -p "))
+		}
 	}
 
 	// Send internal SL to cluster with additional details in case we
 	// need them later. This prevents leaking PII to customers.
-	postCmd = generateInternalServiceLog(slParams)
-	fmt.Println("Internal SL Being Sent")
-	if err := postCmd.Run(); err != nil {
-		fmt.Println("Failed to POST internal service log. Please manually send a service log to persist details of the customer transfer before proceeding:")
-		fmt.Println(fmt.Sprintf("osdctl servicelog post -i -p MESSAGE=\"From user '%s' in Red Hat account %s => user '%s' in Red Hat account %s.\" %s", slParams.OldOwnerName, slParams.OldOwnerID, slParams.NewOwnerName, slParams.NewOwnerID, slParams.ClusterID))
+	if o.doPullSecretOnly {
+		postCmd = servicelog.PostCmdOptions{
+			ClusterId: slParams.ClusterID,
+			TemplateParams: []string{
+				"MESSAGE=" + fmt.Sprintf("Pull-secret update initiated. UserName:'%s', OwnerID:'%s'", slParams.OldOwnerID, slParams.OldOwnerName),
+			},
+			InternalOnly: true,
+		}
+		fmt.Println("Internal SL Being Sent")
+		if err := postCmd.Run(); err != nil {
+			fmt.Println("Failed to POST internal service log. Please manually send a service log to persist details of the customer transfer before proceeding:")
+			fmt.Printf("osdctl servicelog post -i -p MESSAGE=\"Pull-secret update. UserName:'%s', OwnerID:'%s'.\" %s \n", slParams.OldOwnerID, slParams.OldOwnerName, slParams.ClusterID)
+		}
+	} else {
+		postCmd = generateInternalServiceLog(slParams)
+		fmt.Println("Internal SL Being Sent")
+		if err := postCmd.Run(); err != nil {
+			fmt.Println("Failed to POST internal service log. Please manually send a service log to persist details of the customer transfer before proceeding:")
+			fmt.Println(fmt.Sprintf("osdctl servicelog post -i -p MESSAGE=\"From user '%s' in Red Hat account %s => user '%s' in Red Hat account %s.\" %s", slParams.OldOwnerName, slParams.OldOwnerID, slParams.NewOwnerName, slParams.NewOwnerID, slParams.ClusterID))
+		}
 	}
 
 	masterKubeCli, _, masterKubeClientSet, err := common.GetKubeConfigAndClient(masterCluster.ID(), elevationReasons...)
@@ -633,10 +806,32 @@ func (o *transferOwnerOptions) run() error {
 		return fmt.Errorf("failed to retrieve Kubernetes configuration and client for Hive cluster ID %s: %w", masterCluster.ID(), err)
 	}
 
-	// Fetch the pull secret with the given new username
-	response, err := ocm.AccountsMgmt().V1().AccessToken().Post().Impersonate(userName).Parameter("body", nil).Send()
+	// Get account running this command to compare against cluster's account for
+	// impersonation purposes.
+	currentAccountResp, err := ocm.AccountsMgmt().V1().CurrentAccount().Get().Send()
+	var currentOCMAccount *amv1.Account = nil
 	if err != nil {
-		return fmt.Errorf("Can't send request: %w", err)
+		//Ignore this error and continue with an attempt to use 'impersonate' instead...
+		fmt.Fprintf(os.Stderr, "Failed to fetch currentAccount info, err:'%v'\n", err)
+		currentAccountResp = nil
+	} else {
+		currentOCMAccount = currentAccountResp.Body()
+	}
+
+	// Fetch the current Access Token for pull secret with the given new username from OCM
+	var response *amv1.AccessTokenPostResponse = nil
+	err = nil
+	if currentOCMAccount == nil || currentOCMAccount.Username() != userName {
+		// This account is not owned by the OCM account running this command, so impersonate...
+		// Impersonate requires region-lead permissions at this time.
+		response, err = ocm.AccountsMgmt().V1().AccessToken().Post().Impersonate(userName).Parameter("body", nil).Send()
+	} else {
+		// This account is owned by the OCM account running this command, no need to impersonate
+		// This allows non-region leads to test this utility against their own test clusters.
+		response, err = ocm.AccountsMgmt().V1().AccessToken().Post().Send()
+	}
+	if err != nil {
+		return fmt.Errorf("failed to fetch OCM AccessToken: %w", err)
 	}
 
 	auths, ok := response.Body().GetAuths()
@@ -658,13 +853,24 @@ func (o *transferOwnerOptions) run() error {
 		return fmt.Errorf("failed to marshal pull secret data: %w", err)
 	}
 
-	// Print the pull secret
-	fmt.Println("Pull Secret:")
+	//Attempt to pretty print the json for easier user initial review...
+	prettySecret, err := json.MarshalIndent(map[string]map[string]map[string]string{
+		"auths": authsMap,
+	}, "", " ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error Marshalling data for pretty print. Err:'%v'", err)
+	} else {
+		blue.Println("Pull Secret data(Indented)...")
+		blue.Printf("\n%s\n", prettySecret)
+	}
+
+	// Print the pull secret in it's actual form for user to confirm (ie no go, json, formatting errors, etc)
+	green.Print("\nPlease review Pull Secret data to be used for update(after formatting):\n")
 	fmt.Println(string(pullSecret))
 
 	// Ask the user if they would like to continue
 	var continueConfirmation string
-	fmt.Print("Do you want to continue? (yes/no): ")
+	fmt.Print("\nDo you want to continue? (yes/no): ")
 	_, err = fmt.Scanln(&continueConfirmation)
 	if err != nil {
 		return fmt.Errorf("failed to read user input: %w", err)
@@ -687,10 +893,12 @@ func (o *transferOwnerOptions) run() error {
 		}
 	}
 
+	fmt.Println("Create cluster kubecli...")
 	_, _, targetClientSet, err := common.GetKubeConfigAndClient(o.clusterID, elevationReasons...)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve Kubernetes configuration and client for cluster with ID %s: %w", o.clusterID, err)
 	}
+	fmt.Println("Cluster kubecli created")
 
 	// Rollout the telemeterClient pod for non HCP clusters
 	if !o.hypershift {
@@ -700,10 +908,33 @@ func (o *transferOwnerOptions) run() error {
 		}
 	}
 
-	err = verifyClusterPullSecret(targetClientSet, string(pullSecret))
+	err = verifyClusterPullSecret(targetClientSet, string(pullSecret), auths)
 	if err != nil {
 		return fmt.Errorf("error verifying cluster pull secret: %w", err)
 	}
+
+	if o.doPullSecretOnly {
+		// User has chosen to update pull secret w/o ownership transfer.
+		// Send SL to notify customer this is completed, then return the command.
+		fmt.Println("Notify the customer the pull-secret update is completed. Sending service log.")
+		//postCmd = generateServiceLog(slParams, SL_PULL_SECRET_ROTATED)
+		postCmd = servicelog.PostCmdOptions{
+			Template:       SL_PULL_SECRET_ROTATED,
+			ClusterId:      o.clusterID,
+			TemplateParams: []string{fmt.Sprintf("ACCOUNT=%s", oldOwnerAccountID)},
+		}
+
+		if err := postCmd.Run(); err != nil {
+			fmt.Println("Failed to POST service log. Please manually send a service log to notify the customer the pull-secrete update completed:")
+			fmt.Printf("osdctl servicelog post %v -t %v -p %v\n",
+				o.clusterID, SL_PULL_SECRET_ROTATED, strings.Join(postCmd.TemplateParams, " -p "))
+		}
+
+		fmt.Printf("Pull secret update complete, exiting successfully\n")
+		return nil
+	}
+
+	// Transfer ownership specific operations...
 
 	fmt.Printf("Transfer cluster: \t\t'%v' (%v)\n", externalClusterID, cluster.Name())
 	fmt.Printf("from user \t\t\t'%v' to '%v'\n", oldOwnerAccount.ID(), accountID)
@@ -760,7 +991,7 @@ func (o *transferOwnerOptions) run() error {
 		response, err := subscriptionClient.Update().Body(subscriptionOrgPatch).Send()
 
 		if err != nil || response.Status() != 200 {
-			return fmt.Errorf("request failed with status: %d, '%w'", response.Status(), err)
+			return fmt.Errorf("Update Subscription request to patch org failed with status: %d,  err:'%w'", response.Status(), err)
 		}
 		fmt.Printf("Patched organization on subscription\n")
 	}
@@ -769,7 +1000,16 @@ func (o *transferOwnerOptions) run() error {
 	patchRes, err := subscriptionCreatorPatchRequest.Send()
 
 	if err != nil || patchRes.Status() != 200 {
-		return fmt.Errorf("request failed with status: %d, '%w'", patchRes.Status(), err)
+		// err var is not always set to something meaningful here.
+		// Instead the response body usually contains the err info...
+		red.Fprintf(os.Stderr, "Error, Patch Request Response: '%s'\n", patchRes.String())
+		var errString string
+		if err != nil {
+			errString = fmt.Sprintf("%v", err)
+		} else {
+			errString = patchRes.String()
+		}
+		return fmt.Errorf("Subscription request to patch creator failed with status: %d, err: '%s'", patchRes.Status(), errString)
 	}
 	fmt.Printf("Patched creator on subscription\n")
 
@@ -777,7 +1017,7 @@ func (o *transferOwnerOptions) run() error {
 	err = deleteOldRoleBinding(ocm, subscriptionID)
 
 	if err != nil {
-		fmt.Printf("can't delete old rolebinding %v \n", err)
+		fmt.Printf("Warning, can't delete old rolebinding, err: %v \n", err)
 	}
 
 	// create new rolebinding
@@ -786,13 +1026,13 @@ func (o *transferOwnerOptions) run() error {
 
 	// don't fail if the rolebinding already exists, could be rerun
 	if err != nil {
-		return fmt.Errorf("request failed '%w'", err)
+		return fmt.Errorf("Account new roleBinding request failed, err: '%w'", err)
 	} else if postRes.Status() == 201 {
 		fmt.Printf("Created new role binding.\n")
 	} else if postRes.Status() == 409 {
 		fmt.Printf("can't add new rolebinding, rolebinding already exists\n")
 	} else {
-		return fmt.Errorf("request failed with status: %d, '%w'", postRes.Status(), err)
+		return fmt.Errorf("Account new roleBinding request failed with status: %d, err: '%w'", postRes.Status(), err)
 	}
 
 	// If the organization id has changed, re-register the cluster with CS with the new organization id
@@ -800,19 +1040,19 @@ func (o *transferOwnerOptions) run() error {
 
 		request, err := createNewRegisterClusterRequest(ocm, externalClusterID, subscriptionID, newOrganizationId, clusterURL, displayName)
 		if err != nil {
-			return fmt.Errorf("can't create RegisterClusterRequest with CS, '%w'", err)
+			return fmt.Errorf("can't create RegisterClusterRequest with CS, err:'%w'", err)
 		}
 
 		response, err := request.Send()
 		if err != nil || (response.Status() != 200 && response.Status() != 201) {
-			return fmt.Errorf("request failed with status: %d, '%w'", response.Status(), err)
+			return fmt.Errorf("NewRegisterClusterRequest failed with status: %d, err:'%w'", response.Status(), err)
 		}
 		fmt.Print("Re-registered cluster\n")
 	}
 
 	err = validateTransfer(ocm, subscription.ClusterID(), newOrganizationId)
 	if err != nil {
-		return fmt.Errorf("error while validating transfer %w", err)
+		return fmt.Errorf("error while validating transfer. %w", err)
 	}
 	fmt.Print("Transfer complete\n")
 
@@ -834,7 +1074,7 @@ func getRoleBinding(ocm *sdk.Connection, subscriptionID string) (*amv1.RoleBindi
 		Send()
 
 	if err != nil {
-		return nil, fmt.Errorf("can't send request: %v", err)
+		return nil, fmt.Errorf("RoleBindings list, can't send request: %v", err)
 	}
 
 	if response.Total() == 0 {
@@ -855,19 +1095,19 @@ func deleteOldRoleBinding(ocm *sdk.Connection, subscriptionID string) error {
 	oldRoleBinding, err := getRoleBinding(ocm, subscriptionID)
 
 	if err != nil {
-		return fmt.Errorf("can't get old owners rolebinding %w", err)
+		return fmt.Errorf("can't get old owners rolebinding: %w", err)
 	}
 
 	oldRoleBindingID, ok := oldRoleBinding.GetID()
 	if !ok {
-		return fmt.Errorf("old rolebinding has no id %w", err)
+		return fmt.Errorf("old rolebinding has no id, err: %w", err)
 	}
 	oldRoleBindingClient := ocm.AccountsMgmt().V1().RoleBindings().RoleBinding(oldRoleBindingID)
 
 	response, err := oldRoleBindingClient.Delete().Send()
 
 	if err != nil {
-		return fmt.Errorf("request failed '%w'", err)
+		return fmt.Errorf("request failed, err: '%w'", err)
 	}
 	if response.Status() == 204 {
 		fmt.Printf("Deleted old rolebinding: %v\n", oldRoleBindingID)
@@ -877,7 +1117,7 @@ func deleteOldRoleBinding(ocm *sdk.Connection, subscriptionID string) error {
 		fmt.Printf("can't find old rolebinding: %v\n", oldRoleBindingID)
 		return nil
 	}
-	fmt.Printf("request failed with status: %d\n", response.Status())
+	fmt.Printf("delete RoleBindingrequest failed with status: %d\n", response.Status())
 	return nil
 }
 
@@ -898,7 +1138,7 @@ func createSubscriptionCreatorPatchRequest(ocm *sdk.Connection, subscriptionID s
 
 	body, err := json.Marshal(CreatorPatch{accountID})
 	if err != nil {
-		return nil, fmt.Errorf("cannot create body for request '%w'", err)
+		return nil, fmt.Errorf("cannot create body for request, err: '%w'", err)
 	}
 
 	request.Bytes(body)
@@ -932,7 +1172,7 @@ func createNewRegisterClusterRequest(ocm *sdk.Connection, externalClusterID stri
 
 	body, err := json.Marshal(RegisterCluster{externalClusterID, subscriptionID, organizationID, consoleURL, displayName})
 	if err != nil {
-		return nil, fmt.Errorf("cannot create body for request '%w'", err)
+		return nil, fmt.Errorf("cannot create body for request, err: '%w'", err)
 	}
 
 	request.Bytes(body)
@@ -949,7 +1189,7 @@ func validateTransfer(ocm *sdk.Connection, clusterID string, newOrgID string) er
 		Send()
 
 	if err != nil || response.Status() != 200 {
-		return fmt.Errorf("request failed with status: %d, '%w'", response.Status(), err)
+		return fmt.Errorf("list clusters request failed with status: %d, err: '%w'", response.Status(), err)
 	}
 
 	if response.Total() == 0 {


### PR DESCRIPTION

This PR attempts to allow a user to update a cluster's pull secret w/o transferring ownership for both classic and HCP clusters. 

- This adds a new CLI arg '--pull-secret-only' (bool) which is mutually exclusive with '--new-owner'. 
- When ''--pull-secret-only' is used the utility will now exit after the pull secret is updated with the account's OCM accessToken values. 
- The pull secret only op prompts user to choose to send an internal service log before the operation begins, and prompts to send a customer service log after the operation completes. 
- This adds additional programmatic checks/comparisons of the resulting on cluster pull-secret auths for the end user to review, in addition the previous printed raw data and added indented/pretty printed data for visual comparison and user confirmation(s).  
- Additional information and formatting of errors 

Example usage:
```
osdctl -S cluster transfer-owner -C 2ho9npdt3oeq3t604ria3lq3vcABC123  --reason "testing OSD-26415" --pull-secret-only
```


