### PR TITLE
[OSD-28483] Add an `osdctl dt dash` command

### DIFF
--- a/cmd/dynatrace/cluster.go
+++ b/cmd/dynatrace/cluster.go
@@ -18,6 +18,7 @@ import (
 type HCPCluster struct {
 	name                  string
 	internalID            string
+	externalID            string
 	managementClusterID   string
 	klusterletNS          string
 	hostedNS              string
@@ -86,6 +87,7 @@ func FetchClusterDetails(clusterKey string) (hcpCluster HCPCluster, error error)
 
 	hcpCluster.DynatraceURL = url
 	hcpCluster.internalID = cluster.ID()
+	hcpCluster.externalID = cluster.ExternalID()
 	hcpCluster.managementClusterID = mgmtCluster.ID()
 	hcpCluster.name = cluster.Name()
 	hcpCluster.managementClusterName = mgmtCluster.Name()

--- a/cmd/dynatrace/dashCmd.go
+++ b/cmd/dynatrace/dashCmd.go
@@ -1,0 +1,53 @@
+package dynatrace
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+var (
+	dashboardName string
+	clusterId     string
+)
+
+func newCmdDashboard() *cobra.Command {
+	urlCmd := &cobra.Command{
+		Use:               "dashboard --cluster-id CLUSTER_ID",
+		Aliases:           []string{"dash"},
+		Short:             "Get the Dyntrace Cluster Overview Dashboard for a given MC or HCP cluster",
+		DisableAutoGenTag: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			// We need the Dynatrace URL
+			hcpCluster, err := FetchClusterDetails(clusterId)
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+
+			// Get credentials
+			accessToken, err := getDocumentAccessToken()
+			if err != nil {
+				fmt.Printf("Could not get access token %s\n", err)
+				return
+			}
+
+			// Search for the dashboard
+			id, err := getDocumentIDByNameAndType(hcpCluster.DynatraceURL, accessToken, dashboardName, DTDashboardType)
+			if err != nil {
+				fmt.Printf("Could not find dashboard named '%s': %s\n", dashboardName, err)
+				return
+			}
+
+			// Tell the user
+			dashUrl := hcpCluster.DynatraceURL + "ui/apps/dynatrace.dashboards/dashboard/" + id + "#vfilter__id=" + hcpCluster.externalID
+			fmt.Printf("\n\nDashboard URL:\n  %s\n", dashUrl)
+		},
+	}
+
+	urlCmd.Flags().StringVar(&dashboardName, "dash", "Central ROSA HCP Dashboard", "Name of the dashboard you wish to find")
+	urlCmd.Flags().StringVar(&clusterId, "cluster-id", "", "Provide the id of the cluster")
+	_ = urlCmd.MarkFlagRequired("cluster-id")
+
+	return urlCmd
+}

--- a/cmd/dynatrace/hcpGatherLogsCmd.go
+++ b/cmd/dynatrace/hcpGatherLogsCmd.go
@@ -58,7 +58,7 @@ func NewCmdHCPMustGather() *cobra.Command {
 }
 
 func (g *GatherLogsOpts) GatherLogs(clusterID string) (error error) {
-	accessToken, err := getAccessToken()
+	accessToken, err := getStorageAccessToken()
 	if err != nil {
 		return fmt.Errorf("failed to acquire access token %v", err)
 	}

--- a/cmd/dynatrace/logsCmd.go
+++ b/cmd/dynatrace/logsCmd.go
@@ -174,7 +174,7 @@ func main(clusterID string) error {
 		return nil
 	}
 
-	accessToken, err := getAccessToken()
+	accessToken, err := getStorageAccessToken()
 	if err != nil {
 		return fmt.Errorf("failed to acquire access token %v", err)
 	}

--- a/cmd/dynatrace/rootCmd.go
+++ b/cmd/dynatrace/rootCmd.go
@@ -15,6 +15,7 @@ func NewCmdDynatrace() *cobra.Command {
 
 	dtCmd.AddCommand(NewCmdLogs())
 	dtCmd.AddCommand(newCmdURL())
+	dtCmd.AddCommand(newCmdDashboard())
 	dtCmd.AddCommand(NewCmdHCPMustGather())
 
 	return dtCmd


### PR DESCRIPTION
This command allows you to find the overview dashboard for a cluster in the right tenant for the cluster in question. The cluster's external ID id passed to the cluster as it `$_id` variable (if it has one).

You can also override the dashboard name to see another dashboard.

Example (sanitised) Execution:

```sh
$ osdctl dt dash --dash "Example Dashboard name" --cluster-id 00000000-0000-0000-0000-000000000000
Successfully authenticated with DynaTrace


Dynatrace Environment URL:
  https://xxx00000.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/11111111-1111-1111-1111-111111111111#vfilter__id=00000000-0000-0000-0000-000000000000
```