### PR TITLE
OSD-29310: To update documentation of osdctl repository - osdctl promote

### DIFF
--- a/cmd/promote/dynatrace/dynatrace.go
+++ b/cmd/promote/dynatrace/dynatrace.go
@@ -106,10 +106,10 @@ func NewCmdDynatrace() *cobra.Command {
 	promoteDynatraceCmd.Flags().BoolVarP(&ops.list, "list", "l", false, "List all SaaS services/operators")
 	promoteDynatraceCmd.Flags().StringVarP(&ops.component, "component", "c", "", "Dynatrace component getting promoted")
 	promoteDynatraceCmd.Flags().StringVarP(&ops.gitHash, "gitHash", "g", "", "Git hash of the SaaS service/operator commit getting promoted")
-	promoteDynatraceCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interfache checkout. Falls back to `pwd` and "+DefaultAppInterfaceDirectory())
+	promoteDynatraceCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interface checkout. Falls back to `pwd`")
 	promoteDynatraceCmd.Flags().BoolVarP(&ops.terraform, "terraform", "t", false, "deploy dynatrace-config terraform job")
 	promoteDynatraceCmd.Flags().StringVarP(&ops.module, "module", "m", "", "module to promote")
-	promoteDynatraceCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "dynatraceConfigDir", "", "", "location of dynatrace-config checkout. Falls back to `pwd` and "+DefaultDynatraceconfigDir())
+	promoteDynatraceCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "dynatraceConfigDir", "", "", "location of dynatrace-config checkout. Falls back to `pwd'")
 
 	return promoteDynatraceCmd
 }

--- a/cmd/promote/dynatrace/dynatrace.go
+++ b/cmd/promote/dynatrace/dynatrace.go
@@ -106,10 +106,10 @@ func NewCmdDynatrace() *cobra.Command {
 	promoteDynatraceCmd.Flags().BoolVarP(&ops.list, "list", "l", false, "List all SaaS services/operators")
 	promoteDynatraceCmd.Flags().StringVarP(&ops.component, "component", "c", "", "Dynatrace component getting promoted")
 	promoteDynatraceCmd.Flags().StringVarP(&ops.gitHash, "gitHash", "g", "", "Git hash of the SaaS service/operator commit getting promoted")
-	promoteDynatraceCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interface checkout. Falls back to `pwd`")
+	promoteDynatraceCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interface checkout. Falls back to current working directory")
 	promoteDynatraceCmd.Flags().BoolVarP(&ops.terraform, "terraform", "t", false, "deploy dynatrace-config terraform job")
 	promoteDynatraceCmd.Flags().StringVarP(&ops.module, "module", "m", "", "module to promote")
-	promoteDynatraceCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "dynatraceConfigDir", "", "", "location of dynatrace-config checkout. Falls back to `pwd'")
+	promoteDynatraceCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "dynatraceConfigDir", "", "", "location of dynatrace-config checkout. Falls back to current working directory")
 
 	return promoteDynatraceCmd
 }

--- a/cmd/promote/pko/pko.go
+++ b/cmd/promote/pko/pko.go
@@ -11,25 +11,32 @@ import (
 
 func NewCmdPKO() *cobra.Command {
 	ops := &pkoOptions{}
+
 	pkoCmd := &cobra.Command{
 		Use:               "package",
 		Short:             "Utilities to promote package-operator services",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Example: `
-		# Promote a package-operator service
-		osdctl promote package --serviceName <serviceName> --gitHash <git-hash>`,
+ # Promote a package-operator service
+ osdctl promote package --serviceName <serviceName> --gitHash <git-hash>`,
 		Run: func(cmd *cobra.Command, args []string) {
+			// Set default directory if not provided
+			if ops.appInterfaceCheckoutDir == "" {
+				ops.appInterfaceCheckoutDir = git.DefaultAppInterfaceDirectory()
+			}
+
 			cmdutil.CheckErr(ops.ValidatePKOOptions())
 			appInterface := git.BootstrapOsdCtlForAppInterfaceAndServicePromotions(ops.appInterfaceCheckoutDir)
-
 			cmdutil.CheckErr(PromotePackage(appInterface, ops.serviceName, ops.packageTag, ops.hcp))
 		},
 	}
+
 	pkoCmd.Flags().StringVarP(&ops.serviceName, "serviceName", "n", "", "Service getting promoted")
 	pkoCmd.Flags().StringVarP(&ops.packageTag, "tag", "t", "", "Package tag being promoted to")
-	pkoCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interfache checkout. Falls back to `pwd` and "+git.DefaultAppInterfaceDirectory())
+	pkoCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interface checkout. Falls back to `pwd`")
 	pkoCmd.Flags().BoolVar(&ops.hcp, "hcp", false, "The service being promoted conforms to the HyperShift progressive delivery definition")
+
 	return pkoCmd
 }
 
@@ -56,32 +63,26 @@ func PromotePackage(appInterface git.AppInterface, serviceName string, packageTa
 	if err != nil {
 		return err
 	}
-
 	serviceName, err = saas.ValidateServiceName(services, serviceName)
 	if err != nil {
 		return err
 	}
-
 	saasFile, err := saas.GetSaasDir(serviceName, !hcp, hcp)
 	if err != nil {
 		return err
 	}
-
 	currentTag, err := git.GetCurrentPackageTagFromAppInterface(saasFile)
 	if err != nil {
 		return err
 	}
-
 	if currentTag == packageTag {
 		return fmt.Errorf("current hash is already at '%s'. Nothing to do", packageTag)
 	}
-
 	branchName := fmt.Sprintf("promote-%s-package-%s", serviceName, packageTag)
 	err = appInterface.UpdatePackageTag(saasFile, currentTag, packageTag, branchName)
 	if err != nil {
 		return err
 	}
-
 	commitMessage := fmt.Sprintf("Promote %s package to %s", serviceName, packageTag)
 	err = appInterface.CommitSaasFile(saasFile, commitMessage)
 	if err != nil {

--- a/cmd/promote/pko/pko.go
+++ b/cmd/promote/pko/pko.go
@@ -34,7 +34,7 @@ func NewCmdPKO() *cobra.Command {
 
 	pkoCmd.Flags().StringVarP(&ops.serviceName, "serviceName", "n", "", "Service getting promoted")
 	pkoCmd.Flags().StringVarP(&ops.packageTag, "tag", "t", "", "Package tag being promoted to")
-	pkoCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interface checkout. Falls back to `pwd`")
+	pkoCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interface checkout. Falls back to current working directory")
 	pkoCmd.Flags().BoolVar(&ops.hcp, "hcp", false, "The service being promoted conforms to the HyperShift progressive delivery definition")
 
 	return pkoCmd

--- a/cmd/promote/saas/saas.go
+++ b/cmd/promote/saas/saas.go
@@ -71,7 +71,7 @@ func NewCmdSaas() *cobra.Command {
 	saasCmd.Flags().StringVarP(&ops.namespaceRef, "namespaceRef", "n", "", "SaaS target namespace reference name")
 	saasCmd.Flags().BoolVarP(&ops.osd, "osd", "", false, "OSD service/operator getting promoted")
 	saasCmd.Flags().BoolVarP(&ops.hcp, "hcp", "", false, "HCP service/operator getting promoted")
-	saasCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interfache checkout. Falls back to `pwd` and "+git.DefaultAppInterfaceDirectory())
+	saasCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interface checkout. Falls back to `pwd`")
 
 	return saasCmd
 }

--- a/cmd/promote/saas/saas.go
+++ b/cmd/promote/saas/saas.go
@@ -71,7 +71,7 @@ func NewCmdSaas() *cobra.Command {
 	saasCmd.Flags().StringVarP(&ops.namespaceRef, "namespaceRef", "n", "", "SaaS target namespace reference name")
 	saasCmd.Flags().BoolVarP(&ops.osd, "osd", "", false, "OSD service/operator getting promoted")
 	saasCmd.Flags().BoolVarP(&ops.hcp, "hcp", "", false, "HCP service/operator getting promoted")
-	saasCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interface checkout. Falls back to `pwd`")
+	saasCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interface checkout. Falls back to current working directory")
 
 	return saasCmd
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,124 +3,125 @@
 ## Command Overview
 
 - `aao` - AWS Account Operator Debugging Utilities
-  - `pool` - Get the status of the AWS Account Operator AccountPool
+ - `pool` - Get the status of the AWS Account Operator AccountPool
 - `account` - AWS Account related utilities
-  - `clean-velero-snapshots` - Cleans up S3 buckets whose name start with managed-velero
-  - `cli` - Generate temporary AWS CLI credentials on demand
-  - `console` - Generate an AWS console URL on the fly
-  - `generate-secret <IAM User name>` - Generates IAM credentials secret
-  - `get` - Get resources
-    - `account` - Get AWS Account CR
-    - `account-claim` - Get AWS Account Claim CR
-    - `aws-account` - Get AWS Account ID
-    - `legal-entity` - Get AWS Account Legal Entity
-    - `secrets` - Get AWS Account CR related secrets
-  - `list` - List resources
-    - `account` - List AWS Account CR
-    - `account-claim` - List AWS Account Claim CR
-  - `mgmt` - AWS Account Management
-    - `assign` - Assign account to user
-    - `iam` - Creates an IAM user in a given AWS account and prints out the credentials
-    - `list` - List out accounts for username
-    - `unassign` - Unassign account to user
-  - `reset <account name>` - Reset AWS Account CR
-  - `rotate-secret <aws-account-cr-name>` - Rotate IAM credentials secret
-  - `servicequotas` - Interact with AWS service-quotas
-    - `describe` - Describe AWS service-quotas
-  - `set <account name>` - Set AWS Account CR status
-  - `verify-secrets [<account name>]` - Verify AWS Account CR IAM User credentials
+ - `clean-velero-snapshots` - Cleans up S3 buckets whose name start with managed-velero
+ - `cli` - Generate temporary AWS CLI credentials on demand
+ - `console` - Generate an AWS console URL on the fly
+ - `generate-secret <IAM User name>` - Generates IAM credentials secret
+ - `get` - Get resources
+  - `account` - Get AWS Account CR
+  - `account-claim` - Get AWS Account Claim CR
+  - `aws-account` - Get AWS Account ID
+  - `legal-entity` - Get AWS Account Legal Entity
+  - `secrets` - Get AWS Account CR related secrets
+ - `list` - List resources
+  - `account` - List AWS Account CR
+  - `account-claim` - List AWS Account Claim CR
+ - `mgmt` - AWS Account Management
+  - `assign` - Assign account to user
+  - `iam` - Creates an IAM user in a given AWS account and prints out the credentials
+  - `list` - List out accounts for username
+  - `unassign` - Unassign account to user
+ - `reset <account name>` - Reset AWS Account CR
+ - `rotate-secret <aws-account-cr-name>` - Rotate IAM credentials secret
+ - `servicequotas` - Interact with AWS service-quotas
+  - `describe` - Describe AWS service-quotas
+ - `set <account name>` - Set AWS Account CR status
+ - `verify-secrets [<account name>]` - Verify AWS Account CR IAM User credentials
 - `alert` - List alerts
-  - `list --cluster-id <cluster-id> --level [warning, critical, firing, pending, all]` - List all alerts or based on severity
-  - `silence` - add, expire and list silence associated with alerts
-    - `add --cluster-id <cluster-identifier> [--all --duration --comment | --alertname --duration --comment]` - Add new silence for alert
-    - `expire [--cluster-id <cluster-identifier>] [--all | --silence-id <silence-id>]` - Expire Silence for alert
-    - `list --cluster-id <cluster-identifier>` - List all silences
-    - `org <org-id> [--all --duration --comment | --alertname --duration --comment]` - Add new silence for alert for org
+ - `list --cluster-id <cluster-id> --level [warning, critical, firing, pending, all]` - List all alerts or based on severity
+ - `silence` - add, expire and list silence associated with alerts
+  - `add --cluster-id <cluster-identifier> [--all --duration --comment | --alertname --duration --comment]` - Add new silence for alert
+  - `expire [--cluster-id <cluster-identifier>] [--all | --silence-id <silence-id>]` - Expire Silence for alert
+  - `list --cluster-id <cluster-identifier>` - List all silences
+  - `org <org-id> [--all --duration --comment | --alertname --duration --comment]` - Add new silence for alert for org
 - `cloudtrail` - AWS CloudTrail related utilities
-  - `permission-denied-events` - Prints cloudtrail permission-denied events to console.
-  - `write-events` - Prints cloudtrail write events to console with optional filtering
+ - `permission-denied-events` - Prints cloudtrail permission-denied events to console.
+ - `write-events` - Prints cloudtrail write events to console with optional filtering
 - `cluster` - Provides information for a specified cluster
-  - `break-glass --cluster-id <cluster-identifier>` - Emergency access to a cluster
-    - `cleanup --cluster-id <cluster-identifier>` - Drop emergency access to a cluster
-  - `check-banned-user --cluster-id <cluster-identifier>` - Checks if the cluster owner is a banned user.
-  - `context --cluster-id <cluster-identifier>` - Shows the context of a specified cluster
-  - `cpd` - Runs diagnostic for a Cluster Provisioning Delay (CPD)
-  - `detach-stuck-volume --cluster-id <cluster-identifier>` - Detach openshift-monitoring namespace's volume from a cluster forcefully
-  - `etcd-health-check --cluster-id <cluster-id> --reason <reason for escalation>` - Checks the etcd components and member health
-  - `etcd-member-replace --cluster-id <cluster-identifier>` - Replaces an unhealthy etcd node
-  - `from-infra-id` - Get cluster ID and external ID from a given infrastructure ID commonly used by Splunk
-  - `health` - Describes health of cluster nodes and provides other cluster vitals.
-  - `hypershift-info` - Pull information about AWS objects from the cluster, the management cluster and the privatelink cluster
-  - `logging-check --cluster-id <cluster-identifier>` - Shows the logging support status of a specified cluster
-  - `orgId --cluster-id <cluster-identifier` - Get the OCM org ID for a given cluster
-  - `owner` - List the clusters owned by the user (can be specified to any user, not only yourself)
-  - `resize` - resize control-plane/infra nodes
-    - `control-plane` - Resize an OSD/ROSA cluster's control plane nodes
-    - `infra` - Resize an OSD/ROSA cluster's infra nodes
-  - `resync` - Force a resync of a cluster from Hive
-  - `sre-operators` - SRE operator related utilities
-    - `describe` - Describe SRE operators
-    - `list` - List the current and latest version of SRE operators
-  - `ssh` - utilities for accessing cluster via ssh
-    - `key --reason $reason [--cluster-id $CLUSTER_ID]` - Retrieve a cluster's SSH key from Hive
-  - `support` - Cluster Support
-    - `delete --cluster-id <cluster-identifier>` - Delete specified limited support reason for a given cluster
-    - `post --cluster-id <cluster-identifier>` - Send limited support reason to a given cluster
-    - `status --cluster-id <cluster-identifier>` - Shows the support status of a specified cluster
-  - `transfer-owner` - Transfer cluster ownership to a new user (to be done by Region Lead)
-  - `validate-pull-secret --cluster-id <cluster-identifier>` - Checks if the pull secret email matches the owner email
-  - `validate-pull-secret-ext [CLUSTER_ID]` - Extended checks to confirm pull-secret data is synced with current OCM data
+ - `break-glass --cluster-id <cluster-identifier>` - Emergency access to a cluster
+  - `cleanup --cluster-id <cluster-identifier>` - Drop emergency access to a cluster
+ - `check-banned-user --cluster-id <cluster-identifier>` - Checks if the cluster owner is a banned user.
+ - `context --cluster-id <cluster-identifier>` - Shows the context of a specified cluster
+ - `cpd` - Runs diagnostic for a Cluster Provisioning Delay (CPD)
+ - `detach-stuck-volume --cluster-id <cluster-identifier>` - Detach openshift-monitoring namespace's volume from a cluster forcefully
+ - `etcd-health-check --cluster-id <cluster-id> --reason <reason for escalation>` - Checks the etcd components and member health
+ - `etcd-member-replace --cluster-id <cluster-identifier>` - Replaces an unhealthy etcd node
+ - `from-infra-id` - Get cluster ID and external ID from a given infrastructure ID commonly used by Splunk
+ - `health` - Describes health of cluster nodes and provides other cluster vitals.
+ - `hypershift-info` - Pull information about AWS objects from the cluster, the management cluster and the privatelink cluster
+ - `logging-check --cluster-id <cluster-identifier>` - Shows the logging support status of a specified cluster
+ - `orgId --cluster-id <cluster-identifier` - Get the OCM org ID for a given cluster
+ - `owner` - List the clusters owned by the user (can be specified to any user, not only yourself)
+ - `resize` - resize control-plane/infra nodes
+  - `control-plane` - Resize an OSD/ROSA cluster's control plane nodes
+  - `infra` - Resize an OSD/ROSA cluster's infra nodes
+ - `resync` - Force a resync of a cluster from Hive
+ - `sre-operators` - SRE operator related utilities
+  - `describe` - Describe SRE operators
+  - `list` - List the current and latest version of SRE operators
+ - `ssh` - utilities for accessing cluster via ssh
+  - `key --reason $reason [--cluster-id $CLUSTER_ID]` - Retrieve a cluster's SSH key from Hive
+ - `support` - Cluster Support
+  - `delete --cluster-id <cluster-identifier>` - Delete specified limited support reason for a given cluster
+  - `post --cluster-id <cluster-identifier>` - Send limited support reason to a given cluster
+  - `status --cluster-id <cluster-identifier>` - Shows the support status of a specified cluster
+ - `transfer-owner` - Transfer cluster ownership to a new user (to be done by Region Lead)
+ - `validate-pull-secret --cluster-id <cluster-identifier>` - Checks if the pull secret email matches the owner email
+ - `validate-pull-secret-ext [CLUSTER_ID]` - Extended checks to confirm pull-secret data is synced with current OCM data
 - `cost` - Cost Management related utilities
-  - `create` - Create a cost category for the given OU
-  - `get` - Get total cost of a given OU
-  - `list` - List the cost of each Account/OU under given OU
-  - `reconcile` - Checks if there's a cost category for every OU. If an OU is missing a cost category, creates the cost category
+ - `create` - Create a cost category for the given OU
+ - `get` - Get total cost of a given OU
+ - `list` - List the cost of each Account/OU under given OU
+ - `reconcile` - Checks if there's a cost category for every OU. If an OU is missing a cost category, creates the cost category
 - `dynatrace` - Dynatrace related utilities
-  - `gather-logs --cluster-id <cluster-identifier>` - Gather all Pod logs and Application event from HCP
-  - `logs --cluster-id <cluster-identifier>` - Fetch logs from Dynatrace
-  - `url --cluster-id <cluster-identifier>` - Get the Dynatrace Tenant URL for a given MC or HCP cluster
+ - `dashboard --cluster-id CLUSTER_ID` - Get the Dyntrace Cluster Overview Dashboard for a given MC or HCP cluster
+ - `gather-logs --cluster-id <cluster-identifier>` - Gather all Pod logs and Application event from HCP
+ - `logs --cluster-id <cluster-identifier>` - Fetch logs from Dynatrace
+ - `url --cluster-id <cluster-identifier>` - Get the Dynatrace Tenant URL for a given MC or HCP cluster
 - `env [flags] [env-alias]` - Create an environment to interact with a cluster
 - `hcp` - 
-  - `must-gather --cluster-id <cluster-identifier>` - Create a must-gather for HCP cluster
+ - `must-gather --cluster-id <cluster-identifier>` - Create a must-gather for HCP cluster
 - `hive` - hive related utilities
-  - `clusterdeployment` - cluster deployment related utilities
-    - `list` - List cluster deployment crs
-    - `listresources` - List all resources on a hive cluster related to a given cluster
-  - `clustersync-failures [flags]` - List clustersync failures
+ - `clusterdeployment` - cluster deployment related utilities
+  - `list` - List cluster deployment crs
+  - `listresources` - List all resources on a hive cluster related to a given cluster
+ - `clustersync-failures [flags]` - List clustersync failures
 - `iampermissions` - STS/WIF utilities
-  - `diff` - Diff iam permissions for cluster operators between two versions
-  - `get` - Get OCP CredentialsRequests
-  - `save` - Save iam permissions for use in mcc
+ - `diff` - Diff iam permissions for cluster operators between two versions
+ - `get` - Get OCP CredentialsRequests
+ - `save` - Save iam permissions for use in mcc
 - `jira` - Provides a set of commands for interacting with Jira
-  - `quick-task <title>` - creates a new ticket with the given name
+ - `quick-task <title>` - creates a new ticket with the given name
 - `jumphost` - 
-  - `create` - Create a jumphost for emergency SSH access to a cluster's VMs
-  - `delete` - Delete a jumphost created by `osdctl jumphost create`
+ - `create` - Create a jumphost for emergency SSH access to a cluster's VMs
+ - `delete` - Delete a jumphost created by `osdctl jumphost create`
 - `mc` - 
-  - `list` - List ROSA HCP Management Clusters
+ - `list` - List ROSA HCP Management Clusters
 - `network` - network related utilities
-  - `packet-capture` - Start packet capture
-  - `verify-egress` - Verify an AWS OSD/ROSA cluster can reach all required external URLs necessary for full support.
+ - `packet-capture` - Start packet capture
+ - `verify-egress` - Verify an AWS OSD/ROSA cluster can reach all required external URLs necessary for full support.
 - `org` - Provides information for a specified organization
-  - `aws-accounts` - get organization AWS Accounts
-  - `clusters` - get all active organization clusters
-  - `context orgId` - fetches information about the given organization
-  - `current` - gets current organization
-  - `customers` - get paying/non-paying organizations
-  - `describe` - describe organization
-  - `get` - get organization by users
-  - `labels` - get organization labels
-  - `users` - get organization users
+ - `aws-accounts` - get organization AWS Accounts
+ - `clusters` - get all active organization clusters
+ - `context orgId` - fetches information about the given organization
+ - `current` - gets current organization
+ - `customers` - get paying/non-paying organizations
+ - `describe` - describe organization
+ - `get` - get organization by users
+ - `labels` - get organization labels
+ - `users` - get organization users
 - `promote` - Utilities to promote services/operators
-  - `dynatrace` - Utilities to promote dynatrace
-  - `package` - Utilities to promote package-operator services
-  - `saas` - Utilities to promote SaaS services/operators
+ - `dynatrace` - Utilities to promote dynatrace
+ - `package` - Utilities to promote package-operator services
+ - `saas` - Utilities to promote SaaS services/operators
 - `servicelog` - OCM/Hive Service log
-  - `list --cluster-id <cluster-identifier> [flags] [options]` - Get service logs for a given cluster identifier.
-  - `post --cluster-id <cluster-identifier>` - Post a service log to a cluster or list of clusters
+ - `list --cluster-id <cluster-identifier> [flags] [options]` - Get service logs for a given cluster identifier.
+ - `post --cluster-id <cluster-identifier>` - Post a service log to a cluster or list of clusters
 - `setup` - Setup the configuration
 - `swarm` - Provides a set of commands for swarming activity
-  - `secondary` - List unassigned JIRA issues based on criteria
+ - `secondary` - List unassigned JIRA issues based on criteria
 - `upgrade` - Upgrade osdctl
 - `version` - Display the version
 
@@ -2222,6 +2223,32 @@ osdctl dynatrace [flags]
   -S, --skip-version-check               skip checking to see if this is the most recent release
 ```
 
+### osdctl dynatrace dashboard
+
+Get the Dyntrace Cluster Overview Dashboard for a given MC or HCP cluster
+
+```
+osdctl dynatrace dashboard --cluster-id CLUSTER_ID [flags]
+```
+
+#### Flags
+
+```
+      --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --cluster string                   The name of the kubeconfig cluster to use
+      --cluster-id string                Provide the id of the cluster
+      --context string                   The name of the kubeconfig context to use
+      --dash string                      Name of the dashboard you wish to find (default "Central ROSA HCP Dashboard")
+  -h, --help                             help for dashboard
+      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
+  -o, --output string                    Valid formats are ['', 'json', 'yaml', 'env']
+      --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                    The address and port of the Kubernetes API server
+      --skip-aws-proxy-check aws_proxy   Don't use the configured aws_proxy value
+  -S, --skip-version-check               skip checking to see if this is the most recent release
+```
+
 ### osdctl dynatrace gather-logs
 
 Gathers pods logs and evnets of a given HCP from Dynatrace.
@@ -3290,12 +3317,12 @@ osdctl promote dynatrace [flags]
 #### Flags
 
 ```
-      --appInterfaceDir pwd              location of app-interfache checkout. Falls back to pwd and /home/strinaga/git/app-interface
+      --appInterfaceDir pwd              location of app-interfache checkout. Falls back to pwd and $HOME/git/app-interface
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
   -c, --component string                 Dynatrace component getting promoted
       --context string                   The name of the kubeconfig context to use
-      --dynatraceConfigDir pwd           location of dynatrace-config checkout. Falls back to pwd and /home/strinaga/git/dynatrace-config
+      --dynatraceConfigDir pwd           location of dynatrace-config checkout. Falls back to pwd and $HOME/git/dynatrace-config
   -g, --gitHash string                   Git hash of the SaaS service/operator commit getting promoted
   -h, --help                             help for dynatrace
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -3321,7 +3348,7 @@ osdctl promote package [flags]
 #### Flags
 
 ```
-      --appInterfaceDir pwd              location of app-interfache checkout. Falls back to pwd and /home/strinaga/git/app-interface
+      --appInterfaceDir pwd              location of app-interfache checkout. Falls back to pwd and $HOME/git/app-interface
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use
@@ -3349,7 +3376,7 @@ osdctl promote saas [flags]
 #### Flags
 
 ```
-      --appInterfaceDir pwd              location of app-interfache checkout. Falls back to pwd and /home/strinaga/git/app-interface
+      --appInterfaceDir pwd              location of app-interfache checkout. Falls back to pwd and $HOME/git/app-interface
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,125 +3,125 @@
 ## Command Overview
 
 - `aao` - AWS Account Operator Debugging Utilities
- - `pool` - Get the status of the AWS Account Operator AccountPool
+  - `pool` - Get the status of the AWS Account Operator AccountPool
 - `account` - AWS Account related utilities
- - `clean-velero-snapshots` - Cleans up S3 buckets whose name start with managed-velero
- - `cli` - Generate temporary AWS CLI credentials on demand
- - `console` - Generate an AWS console URL on the fly
- - `generate-secret <IAM User name>` - Generates IAM credentials secret
- - `get` - Get resources
-  - `account` - Get AWS Account CR
-  - `account-claim` - Get AWS Account Claim CR
-  - `aws-account` - Get AWS Account ID
-  - `legal-entity` - Get AWS Account Legal Entity
-  - `secrets` - Get AWS Account CR related secrets
- - `list` - List resources
-  - `account` - List AWS Account CR
-  - `account-claim` - List AWS Account Claim CR
- - `mgmt` - AWS Account Management
-  - `assign` - Assign account to user
-  - `iam` - Creates an IAM user in a given AWS account and prints out the credentials
-  - `list` - List out accounts for username
-  - `unassign` - Unassign account to user
- - `reset <account name>` - Reset AWS Account CR
- - `rotate-secret <aws-account-cr-name>` - Rotate IAM credentials secret
- - `servicequotas` - Interact with AWS service-quotas
-  - `describe` - Describe AWS service-quotas
- - `set <account name>` - Set AWS Account CR status
- - `verify-secrets [<account name>]` - Verify AWS Account CR IAM User credentials
+  - `clean-velero-snapshots` - Cleans up S3 buckets whose name start with managed-velero
+  - `cli` - Generate temporary AWS CLI credentials on demand
+  - `console` - Generate an AWS console URL on the fly
+  - `generate-secret <IAM User name>` - Generates IAM credentials secret
+  - `get` - Get resources
+    - `account` - Get AWS Account CR
+    - `account-claim` - Get AWS Account Claim CR
+    - `aws-account` - Get AWS Account ID
+    - `legal-entity` - Get AWS Account Legal Entity
+    - `secrets` - Get AWS Account CR related secrets
+  - `list` - List resources
+    - `account` - List AWS Account CR
+    - `account-claim` - List AWS Account Claim CR
+  - `mgmt` - AWS Account Management
+    - `assign` - Assign account to user
+    - `iam` - Creates an IAM user in a given AWS account and prints out the credentials
+    - `list` - List out accounts for username
+    - `unassign` - Unassign account to user
+  - `reset <account name>` - Reset AWS Account CR
+  - `rotate-secret <aws-account-cr-name>` - Rotate IAM credentials secret
+  - `servicequotas` - Interact with AWS service-quotas
+    - `describe` - Describe AWS service-quotas
+  - `set <account name>` - Set AWS Account CR status
+  - `verify-secrets [<account name>]` - Verify AWS Account CR IAM User credentials
 - `alert` - List alerts
- - `list --cluster-id <cluster-id> --level [warning, critical, firing, pending, all]` - List all alerts or based on severity
- - `silence` - add, expire and list silence associated with alerts
-  - `add --cluster-id <cluster-identifier> [--all --duration --comment | --alertname --duration --comment]` - Add new silence for alert
-  - `expire [--cluster-id <cluster-identifier>] [--all | --silence-id <silence-id>]` - Expire Silence for alert
-  - `list --cluster-id <cluster-identifier>` - List all silences
-  - `org <org-id> [--all --duration --comment | --alertname --duration --comment]` - Add new silence for alert for org
+  - `list --cluster-id <cluster-id> --level [warning, critical, firing, pending, all]` - List all alerts or based on severity
+  - `silence` - add, expire and list silence associated with alerts
+    - `add --cluster-id <cluster-identifier> [--all --duration --comment | --alertname --duration --comment]` - Add new silence for alert
+    - `expire [--cluster-id <cluster-identifier>] [--all | --silence-id <silence-id>]` - Expire Silence for alert
+    - `list --cluster-id <cluster-identifier>` - List all silences
+    - `org <org-id> [--all --duration --comment | --alertname --duration --comment]` - Add new silence for alert for org
 - `cloudtrail` - AWS CloudTrail related utilities
- - `permission-denied-events` - Prints cloudtrail permission-denied events to console.
- - `write-events` - Prints cloudtrail write events to console with optional filtering
+  - `permission-denied-events` - Prints cloudtrail permission-denied events to console.
+  - `write-events` - Prints cloudtrail write events to console with optional filtering
 - `cluster` - Provides information for a specified cluster
- - `break-glass --cluster-id <cluster-identifier>` - Emergency access to a cluster
-  - `cleanup --cluster-id <cluster-identifier>` - Drop emergency access to a cluster
- - `check-banned-user --cluster-id <cluster-identifier>` - Checks if the cluster owner is a banned user.
- - `context --cluster-id <cluster-identifier>` - Shows the context of a specified cluster
- - `cpd` - Runs diagnostic for a Cluster Provisioning Delay (CPD)
- - `detach-stuck-volume --cluster-id <cluster-identifier>` - Detach openshift-monitoring namespace's volume from a cluster forcefully
- - `etcd-health-check --cluster-id <cluster-id> --reason <reason for escalation>` - Checks the etcd components and member health
- - `etcd-member-replace --cluster-id <cluster-identifier>` - Replaces an unhealthy etcd node
- - `from-infra-id` - Get cluster ID and external ID from a given infrastructure ID commonly used by Splunk
- - `health` - Describes health of cluster nodes and provides other cluster vitals.
- - `hypershift-info` - Pull information about AWS objects from the cluster, the management cluster and the privatelink cluster
- - `logging-check --cluster-id <cluster-identifier>` - Shows the logging support status of a specified cluster
- - `orgId --cluster-id <cluster-identifier` - Get the OCM org ID for a given cluster
- - `owner` - List the clusters owned by the user (can be specified to any user, not only yourself)
- - `resize` - resize control-plane/infra nodes
-  - `control-plane` - Resize an OSD/ROSA cluster's control plane nodes
-  - `infra` - Resize an OSD/ROSA cluster's infra nodes
- - `resync` - Force a resync of a cluster from Hive
- - `sre-operators` - SRE operator related utilities
-  - `describe` - Describe SRE operators
-  - `list` - List the current and latest version of SRE operators
- - `ssh` - utilities for accessing cluster via ssh
-  - `key --reason $reason [--cluster-id $CLUSTER_ID]` - Retrieve a cluster's SSH key from Hive
- - `support` - Cluster Support
-  - `delete --cluster-id <cluster-identifier>` - Delete specified limited support reason for a given cluster
-  - `post --cluster-id <cluster-identifier>` - Send limited support reason to a given cluster
-  - `status --cluster-id <cluster-identifier>` - Shows the support status of a specified cluster
- - `transfer-owner` - Transfer cluster ownership to a new user (to be done by Region Lead)
- - `validate-pull-secret --cluster-id <cluster-identifier>` - Checks if the pull secret email matches the owner email
- - `validate-pull-secret-ext [CLUSTER_ID]` - Extended checks to confirm pull-secret data is synced with current OCM data
+  - `break-glass --cluster-id <cluster-identifier>` - Emergency access to a cluster
+    - `cleanup --cluster-id <cluster-identifier>` - Drop emergency access to a cluster
+  - `check-banned-user --cluster-id <cluster-identifier>` - Checks if the cluster owner is a banned user.
+  - `context --cluster-id <cluster-identifier>` - Shows the context of a specified cluster
+  - `cpd` - Runs diagnostic for a Cluster Provisioning Delay (CPD)
+  - `detach-stuck-volume --cluster-id <cluster-identifier>` - Detach openshift-monitoring namespace's volume from a cluster forcefully
+  - `etcd-health-check --cluster-id <cluster-id> --reason <reason for escalation>` - Checks the etcd components and member health
+  - `etcd-member-replace --cluster-id <cluster-identifier>` - Replaces an unhealthy etcd node
+  - `from-infra-id` - Get cluster ID and external ID from a given infrastructure ID commonly used by Splunk
+  - `health` - Describes health of cluster nodes and provides other cluster vitals.
+  - `hypershift-info` - Pull information about AWS objects from the cluster, the management cluster and the privatelink cluster
+  - `logging-check --cluster-id <cluster-identifier>` - Shows the logging support status of a specified cluster
+  - `orgId --cluster-id <cluster-identifier` - Get the OCM org ID for a given cluster
+  - `owner` - List the clusters owned by the user (can be specified to any user, not only yourself)
+  - `resize` - resize control-plane/infra nodes
+    - `control-plane` - Resize an OSD/ROSA cluster's control plane nodes
+    - `infra` - Resize an OSD/ROSA cluster's infra nodes
+  - `resync` - Force a resync of a cluster from Hive
+  - `sre-operators` - SRE operator related utilities
+    - `describe` - Describe SRE operators
+    - `list` - List the current and latest version of SRE operators
+  - `ssh` - utilities for accessing cluster via ssh
+    - `key --reason $reason [--cluster-id $CLUSTER_ID]` - Retrieve a cluster's SSH key from Hive
+  - `support` - Cluster Support
+    - `delete --cluster-id <cluster-identifier>` - Delete specified limited support reason for a given cluster
+    - `post --cluster-id <cluster-identifier>` - Send limited support reason to a given cluster
+    - `status --cluster-id <cluster-identifier>` - Shows the support status of a specified cluster
+  - `transfer-owner` - Transfer cluster ownership to a new user (to be done by Region Lead)
+  - `validate-pull-secret --cluster-id <cluster-identifier>` - Checks if the pull secret email matches the owner email
+  - `validate-pull-secret-ext [CLUSTER_ID]` - Extended checks to confirm pull-secret data is synced with current OCM data
 - `cost` - Cost Management related utilities
- - `create` - Create a cost category for the given OU
- - `get` - Get total cost of a given OU
- - `list` - List the cost of each Account/OU under given OU
- - `reconcile` - Checks if there's a cost category for every OU. If an OU is missing a cost category, creates the cost category
+  - `create` - Create a cost category for the given OU
+  - `get` - Get total cost of a given OU
+  - `list` - List the cost of each Account/OU under given OU
+  - `reconcile` - Checks if there's a cost category for every OU. If an OU is missing a cost category, creates the cost category
 - `dynatrace` - Dynatrace related utilities
- - `dashboard --cluster-id CLUSTER_ID` - Get the Dyntrace Cluster Overview Dashboard for a given MC or HCP cluster
- - `gather-logs --cluster-id <cluster-identifier>` - Gather all Pod logs and Application event from HCP
- - `logs --cluster-id <cluster-identifier>` - Fetch logs from Dynatrace
- - `url --cluster-id <cluster-identifier>` - Get the Dynatrace Tenant URL for a given MC or HCP cluster
+  - `dashboard --cluster-id CLUSTER_ID` - Get the Dyntrace Cluster Overview Dashboard for a given MC or HCP cluster
+  - `gather-logs --cluster-id <cluster-identifier>` - Gather all Pod logs and Application event from HCP
+  - `logs --cluster-id <cluster-identifier>` - Fetch logs from Dynatrace
+  - `url --cluster-id <cluster-identifier>` - Get the Dynatrace Tenant URL for a given MC or HCP cluster
 - `env [flags] [env-alias]` - Create an environment to interact with a cluster
 - `hcp` - 
- - `must-gather --cluster-id <cluster-identifier>` - Create a must-gather for HCP cluster
+  - `must-gather --cluster-id <cluster-identifier>` - Create a must-gather for HCP cluster
 - `hive` - hive related utilities
- - `clusterdeployment` - cluster deployment related utilities
-  - `list` - List cluster deployment crs
-  - `listresources` - List all resources on a hive cluster related to a given cluster
- - `clustersync-failures [flags]` - List clustersync failures
+  - `clusterdeployment` - cluster deployment related utilities
+    - `list` - List cluster deployment crs
+    - `listresources` - List all resources on a hive cluster related to a given cluster
+  - `clustersync-failures [flags]` - List clustersync failures
 - `iampermissions` - STS/WIF utilities
- - `diff` - Diff iam permissions for cluster operators between two versions
- - `get` - Get OCP CredentialsRequests
- - `save` - Save iam permissions for use in mcc
+  - `diff` - Diff iam permissions for cluster operators between two versions
+  - `get` - Get OCP CredentialsRequests
+  - `save` - Save iam permissions for use in mcc
 - `jira` - Provides a set of commands for interacting with Jira
- - `quick-task <title>` - creates a new ticket with the given name
+  - `quick-task <title>` - creates a new ticket with the given name
 - `jumphost` - 
- - `create` - Create a jumphost for emergency SSH access to a cluster's VMs
- - `delete` - Delete a jumphost created by `osdctl jumphost create`
+  - `create` - Create a jumphost for emergency SSH access to a cluster's VMs
+  - `delete` - Delete a jumphost created by `osdctl jumphost create`
 - `mc` - 
- - `list` - List ROSA HCP Management Clusters
+  - `list` - List ROSA HCP Management Clusters
 - `network` - network related utilities
- - `packet-capture` - Start packet capture
- - `verify-egress` - Verify an AWS OSD/ROSA cluster can reach all required external URLs necessary for full support.
+  - `packet-capture` - Start packet capture
+  - `verify-egress` - Verify an AWS OSD/ROSA cluster can reach all required external URLs necessary for full support.
 - `org` - Provides information for a specified organization
- - `aws-accounts` - get organization AWS Accounts
- - `clusters` - get all active organization clusters
- - `context orgId` - fetches information about the given organization
- - `current` - gets current organization
- - `customers` - get paying/non-paying organizations
- - `describe` - describe organization
- - `get` - get organization by users
- - `labels` - get organization labels
- - `users` - get organization users
+  - `aws-accounts` - get organization AWS Accounts
+  - `clusters` - get all active organization clusters
+  - `context orgId` - fetches information about the given organization
+  - `current` - gets current organization
+  - `customers` - get paying/non-paying organizations
+  - `describe` - describe organization
+  - `get` - get organization by users
+  - `labels` - get organization labels
+  - `users` - get organization users
 - `promote` - Utilities to promote services/operators
- - `dynatrace` - Utilities to promote dynatrace
- - `package` - Utilities to promote package-operator services
- - `saas` - Utilities to promote SaaS services/operators
+  - `dynatrace` - Utilities to promote dynatrace
+  - `package` - Utilities to promote package-operator services
+  - `saas` - Utilities to promote SaaS services/operators
 - `servicelog` - OCM/Hive Service log
- - `list --cluster-id <cluster-identifier> [flags] [options]` - Get service logs for a given cluster identifier.
- - `post --cluster-id <cluster-identifier>` - Post a service log to a cluster or list of clusters
+  - `list --cluster-id <cluster-identifier> [flags] [options]` - Get service logs for a given cluster identifier.
+  - `post --cluster-id <cluster-identifier>` - Post a service log to a cluster or list of clusters
 - `setup` - Setup the configuration
 - `swarm` - Provides a set of commands for swarming activity
- - `secondary` - List unassigned JIRA issues based on criteria
+  - `secondary` - List unassigned JIRA issues based on criteria
 - `upgrade` - Upgrade osdctl
 - `version` - Display the version
 
@@ -3317,12 +3317,12 @@ osdctl promote dynatrace [flags]
 #### Flags
 
 ```
-      --appInterfaceDir pwd              location of app-interfache checkout. Falls back to pwd and $HOME/git/app-interface
+      --appInterfaceDir pwd              location of app-interface checkout. Falls back to pwd
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
   -c, --component string                 Dynatrace component getting promoted
       --context string                   The name of the kubeconfig context to use
-      --dynatraceConfigDir pwd           location of dynatrace-config checkout. Falls back to pwd and $HOME/git/dynatrace-config
+      --dynatraceConfigDir string        location of dynatrace-config checkout. Falls back to `pwd'
   -g, --gitHash string                   Git hash of the SaaS service/operator commit getting promoted
   -h, --help                             help for dynatrace
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -3348,7 +3348,7 @@ osdctl promote package [flags]
 #### Flags
 
 ```
-      --appInterfaceDir pwd              location of app-interfache checkout. Falls back to pwd and $HOME/git/app-interface
+      --appInterfaceDir pwd              location of app-interface checkout. Falls back to pwd
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use
@@ -3376,7 +3376,7 @@ osdctl promote saas [flags]
 #### Flags
 
 ```
-      --appInterfaceDir pwd              location of app-interfache checkout. Falls back to pwd and $HOME/git/app-interface
+      --appInterfaceDir pwd              location of app-interface checkout. Falls back to pwd
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use

--- a/docs/README.md
+++ b/docs/README.md
@@ -3317,12 +3317,12 @@ osdctl promote dynatrace [flags]
 #### Flags
 
 ```
-      --appInterfaceDir pwd              location of app-interface checkout. Falls back to pwd
+      --appInterfaceDir string           location of app-interface checkout. Falls back to current working directory
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
   -c, --component string                 Dynatrace component getting promoted
       --context string                   The name of the kubeconfig context to use
-      --dynatraceConfigDir string        location of dynatrace-config checkout. Falls back to `pwd'
+      --dynatraceConfigDir string        location of dynatrace-config checkout. Falls back to current working directory
   -g, --gitHash string                   Git hash of the SaaS service/operator commit getting promoted
   -h, --help                             help for dynatrace
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -3348,7 +3348,7 @@ osdctl promote package [flags]
 #### Flags
 
 ```
-      --appInterfaceDir pwd              location of app-interface checkout. Falls back to pwd
+      --appInterfaceDir string           location of app-interface checkout. Falls back to current working directory
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use
@@ -3376,7 +3376,7 @@ osdctl promote saas [flags]
 #### Flags
 
 ```
-      --appInterfaceDir pwd              location of app-interface checkout. Falls back to pwd
+      --appInterfaceDir string           location of app-interface checkout. Falls back to current working directory
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use

--- a/docs/osdctl_dynatrace_dashboard.md
+++ b/docs/osdctl_dynatrace_dashboard.md
@@ -1,11 +1,17 @@
-## osdctl dynatrace
+## osdctl dynatrace dashboard
 
-Dynatrace related utilities
+Get the Dyntrace Cluster Overview Dashboard for a given MC or HCP cluster
+
+```
+osdctl dynatrace dashboard --cluster-id CLUSTER_ID [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for dynatrace
+      --cluster-id string   Provide the id of the cluster
+      --dash string         Name of the dashboard you wish to find (default "Central ROSA HCP Dashboard")
+  -h, --help                help for dashboard
 ```
 
 ### Options inherited from parent commands
@@ -25,9 +31,5 @@ Dynatrace related utilities
 
 ### SEE ALSO
 
-* [osdctl](osdctl.md)	 - OSD CLI
-* [osdctl dynatrace dashboard](osdctl_dynatrace_dashboard.md)	 - Get the Dyntrace Cluster Overview Dashboard for a given MC or HCP cluster
-* [osdctl dynatrace gather-logs](osdctl_dynatrace_gather-logs.md)	 - Gather all Pod logs and Application event from HCP
-* [osdctl dynatrace logs](osdctl_dynatrace_logs.md)	 - Fetch logs from Dynatrace
-* [osdctl dynatrace url](osdctl_dynatrace_url.md)	 - Get the Dynatrace Tenant URL for a given MC or HCP cluster
+* [osdctl dynatrace](osdctl_dynatrace.md)	 - Dynatrace related utilities
 

--- a/docs/osdctl_promote_dynatrace.md
+++ b/docs/osdctl_promote_dynatrace.md
@@ -26,14 +26,14 @@ osdctl promote dynatrace [flags]
 ### Options
 
 ```
-      --appInterfaceDir pwd      location of app-interfache checkout. Falls back to pwd and $HOME/git/app-interface
-  -c, --component string         Dynatrace component getting promoted
-      --dynatraceConfigDir pwd   location of dynatrace-config checkout. Falls back to pwd and $HOME/git/dynatrace-config
-  -g, --gitHash string           Git hash of the SaaS service/operator commit getting promoted
-  -h, --help                     help for dynatrace
-  -l, --list                     List all SaaS services/operators
-  -m, --module string            module to promote
-  -t, --terraform                deploy dynatrace-config terraform job
+      --appInterfaceDir pwd         location of app-interface checkout. Falls back to pwd
+  -c, --component string            Dynatrace component getting promoted
+      --dynatraceConfigDir string   location of dynatrace-config checkout. Falls back to `pwd'
+  -g, --gitHash string              Git hash of the SaaS service/operator commit getting promoted
+  -h, --help                        help for dynatrace
+  -l, --list                        List all SaaS services/operators
+  -m, --module string               module to promote
+  -t, --terraform                   deploy dynatrace-config terraform job
 ```
 
 ### Options inherited from parent commands

--- a/docs/osdctl_promote_dynatrace.md
+++ b/docs/osdctl_promote_dynatrace.md
@@ -26,9 +26,9 @@ osdctl promote dynatrace [flags]
 ### Options
 
 ```
-      --appInterfaceDir pwd      location of app-interfache checkout. Falls back to pwd and /home/strinaga/git/app-interface
+      --appInterfaceDir pwd      location of app-interfache checkout. Falls back to pwd and $HOME/git/app-interface
   -c, --component string         Dynatrace component getting promoted
-      --dynatraceConfigDir pwd   location of dynatrace-config checkout. Falls back to pwd and /home/strinaga/git/dynatrace-config
+      --dynatraceConfigDir pwd   location of dynatrace-config checkout. Falls back to pwd and $HOME/git/dynatrace-config
   -g, --gitHash string           Git hash of the SaaS service/operator commit getting promoted
   -h, --help                     help for dynatrace
   -l, --list                     List all SaaS services/operators

--- a/docs/osdctl_promote_dynatrace.md
+++ b/docs/osdctl_promote_dynatrace.md
@@ -26,9 +26,9 @@ osdctl promote dynatrace [flags]
 ### Options
 
 ```
-      --appInterfaceDir pwd         location of app-interface checkout. Falls back to pwd
+      --appInterfaceDir string      location of app-interface checkout. Falls back to current working directory
   -c, --component string            Dynatrace component getting promoted
-      --dynatraceConfigDir string   location of dynatrace-config checkout. Falls back to `pwd'
+      --dynatraceConfigDir string   location of dynatrace-config checkout. Falls back to current working directory
   -g, --gitHash string              Git hash of the SaaS service/operator commit getting promoted
   -h, --help                        help for dynatrace
   -l, --list                        List all SaaS services/operators

--- a/docs/osdctl_promote_package.md
+++ b/docs/osdctl_promote_package.md
@@ -17,7 +17,7 @@ osdctl promote package [flags]
 ### Options
 
 ```
-      --appInterfaceDir pwd   location of app-interfache checkout. Falls back to pwd and /home/strinaga/git/app-interface
+      --appInterfaceDir pwd   location of app-interfache checkout. Falls back to pwd and $HOME/git/app-interface
       --hcp                   The service being promoted conforms to the HyperShift progressive delivery definition
   -h, --help                  help for package
   -n, --serviceName string    Service getting promoted

--- a/docs/osdctl_promote_package.md
+++ b/docs/osdctl_promote_package.md
@@ -17,11 +17,11 @@ osdctl promote package [flags]
 ### Options
 
 ```
-      --appInterfaceDir pwd   location of app-interface checkout. Falls back to pwd
-      --hcp                   The service being promoted conforms to the HyperShift progressive delivery definition
-  -h, --help                  help for package
-  -n, --serviceName string    Service getting promoted
-  -t, --tag string            Package tag being promoted to
+      --appInterfaceDir string   location of app-interface checkout. Falls back to current working directory
+      --hcp                      The service being promoted conforms to the HyperShift progressive delivery definition
+  -h, --help                     help for package
+  -n, --serviceName string       Service getting promoted
+  -t, --tag string               Package tag being promoted to
 ```
 
 ### Options inherited from parent commands

--- a/docs/osdctl_promote_package.md
+++ b/docs/osdctl_promote_package.md
@@ -10,14 +10,14 @@ osdctl promote package [flags]
 
 ```
 
-		# Promote a package-operator service
-		osdctl promote package --serviceName <serviceName> --gitHash <git-hash>
+ # Promote a package-operator service
+ osdctl promote package --serviceName <serviceName> --gitHash <git-hash>
 ```
 
 ### Options
 
 ```
-      --appInterfaceDir pwd   location of app-interfache checkout. Falls back to pwd and $HOME/git/app-interface
+      --appInterfaceDir pwd   location of app-interface checkout. Falls back to pwd
       --hcp                   The service being promoted conforms to the HyperShift progressive delivery definition
   -h, --help                  help for package
   -n, --serviceName string    Service getting promoted

--- a/docs/osdctl_promote_saas.md
+++ b/docs/osdctl_promote_saas.md
@@ -22,7 +22,7 @@ osdctl promote saas [flags]
 ### Options
 
 ```
-      --appInterfaceDir pwd   location of app-interfache checkout. Falls back to pwd and $HOME/git/app-interface
+      --appInterfaceDir pwd   location of app-interface checkout. Falls back to pwd
   -g, --gitHash string        Git hash of the SaaS service/operator commit getting promoted
       --hcp                   HCP service/operator getting promoted
   -h, --help                  help for saas

--- a/docs/osdctl_promote_saas.md
+++ b/docs/osdctl_promote_saas.md
@@ -22,7 +22,7 @@ osdctl promote saas [flags]
 ### Options
 
 ```
-      --appInterfaceDir pwd   location of app-interfache checkout. Falls back to pwd and /home/strinaga/git/app-interface
+      --appInterfaceDir pwd   location of app-interfache checkout. Falls back to pwd and $HOME/git/app-interface
   -g, --gitHash string        Git hash of the SaaS service/operator commit getting promoted
       --hcp                   HCP service/operator getting promoted
   -h, --help                  help for saas

--- a/docs/osdctl_promote_saas.md
+++ b/docs/osdctl_promote_saas.md
@@ -22,14 +22,14 @@ osdctl promote saas [flags]
 ### Options
 
 ```
-      --appInterfaceDir pwd   location of app-interface checkout. Falls back to pwd
-  -g, --gitHash string        Git hash of the SaaS service/operator commit getting promoted
-      --hcp                   HCP service/operator getting promoted
-  -h, --help                  help for saas
-  -l, --list                  List all SaaS services/operators
-  -n, --namespaceRef string   SaaS target namespace reference name
-      --osd                   OSD service/operator getting promoted
-      --serviceName string    SaaS service/operator getting promoted
+      --appInterfaceDir string   location of app-interface checkout. Falls back to current working directory
+  -g, --gitHash string           Git hash of the SaaS service/operator commit getting promoted
+      --hcp                      HCP service/operator getting promoted
+  -h, --help                     help for saas
+  -l, --list                     List all SaaS services/operators
+  -n, --namespaceRef string      SaaS target namespace reference name
+      --osd                      OSD service/operator getting promoted
+      --serviceName string       SaaS service/operator getting promoted
 ```
 
 ### Options inherited from parent commands

--- a/pkg/docgen/docgen.go
+++ b/pkg/docgen/docgen.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openshift/osdctl/cmd"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
-	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -39,43 +38,6 @@ func NewDefaultOptions() *Options {
 	}
 }
 
-func sanitizeCommandHelpText(cmd *cobra.Command) {
-	if cmd.Example != "" {
-		cmd.Example = sanitizePathsInText(cmd.Example)
-	}
-	if cmd.Long != "" {
-		cmd.Long = sanitizePathsInText(cmd.Long)
-	}
-	if cmd.Short != "" {
-		cmd.Short = sanitizePathsInText(cmd.Short)
-	}
-
-	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
-		if flag.Usage != "" {
-			flag.Usage = sanitizePathsInText(flag.Usage)
-		}
-	})
-
-	for _, subCmd := range cmd.Commands() {
-		sanitizeCommandHelpText(subCmd)
-	}
-}
-
-func sanitizePathsInText(text string) string {
-	if home := os.Getenv("HOME"); home != "" {
-		text = strings.ReplaceAll(text, home, "$HOME")
-	}
-
-	if pwd, err := os.Getwd(); err == nil && pwd != "" {
-		text = strings.ReplaceAll(text, pwd, "$PWD")
-	}
-
-	text = strings.ReplaceAll(text, "/var/lib/", "$SYSTEM_LIB/")
-	text = strings.ReplaceAll(text, "/usr/local/", "$USR_LOCAL/")
-
-	return text
-}
-
 func generateCommandsMarkdown(rootCmd *cobra.Command) error {
 	filename := CommandsMdFile
 	f, err := os.Create(filename)
@@ -92,8 +54,11 @@ func generateCommandsMarkdown(rootCmd *cobra.Command) error {
 		if !cmd.IsAvailableCommand() || cmd.IsAdditionalHelpTopicCommand() {
 			return
 		}
-		indent := strings.Repeat(" ", depth)
+
+		indent := strings.Repeat("  ", depth)
+
 		fmt.Fprintf(f, "%s- `%s` - %s\n", indent, cmd.Use, cmd.Short)
+
 		for _, subcmd := range cmd.Commands() {
 			writeCommands(subcmd, depth+1)
 		}
@@ -119,6 +84,7 @@ func generateCommandsMarkdown(rootCmd *cobra.Command) error {
 		}
 
 		fmt.Fprintf(f, "### %s\n\n", cmdPath)
+
 		if cmd.Long != "" {
 			fmt.Fprintf(f, "%s\n\n", cmd.Long)
 		} else if cmd.Short != "" {
@@ -137,6 +103,7 @@ func generateCommandsMarkdown(rootCmd *cobra.Command) error {
 	}
 
 	writeCommandDetails(rootCmd, "")
+
 	return nil
 }
 
@@ -157,8 +124,6 @@ func GenerateDocs(opts *Options) error {
 
 	rootCmd := cmd.NewCmdRoot(opts.IOStreams)
 
-	sanitizeCommandHelpText(rootCmd)
-
 	if err := doc.GenMarkdownTree(rootCmd, opts.DocsDir); err != nil {
 		return fmt.Errorf("generating command documentation: %w", err)
 	}
@@ -169,6 +134,7 @@ func GenerateDocs(opts *Options) error {
 
 	opts.Logger.Printf("✅ Documentation successfully generated in %s", opts.DocsDir)
 	opts.Logger.Printf("✅ Commands overview generated in %s", CommandsMdFile)
+
 	return nil
 }
 
@@ -185,6 +151,7 @@ func Command() *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.CmdPath, "cmd-path", opts.CmdPath, "Path to the cmd directory")
 	cmd.Flags().StringVar(&opts.DocsDir, "docs-dir", opts.DocsDir, "Path to the docs output directory")
+
 	return cmd
 }
 


### PR DESCRIPTION
After the successful merge of PR #680 , running make generate-docs began including the local user's present working directory (PWD) in the generated documentation for the following subcommands:

    osdctl promote dynatrace

    osdctl promote saas

    osdctl promote package

This was due to these commands accepting the current working directory as an input parameter, resulting in absolute paths (e.g., /home/user/dev/project) appearing in the help text. This created two major issues:

    Inconsistent diffs: Every user would generate different documentation files based on their environment.

    CI/CD failures: The new pipeline checks for uncommitted changes from make generate-docs, which would falsely flag modified .md files containing environment-specific paths.

✅ Resolution

Instead of modifying each individual command, a generic and centralized fix was implemented directly in the docgen utility:

    A sanitizeCommandHelpText() function was added to recursively sanitize Short, Long, Example, and flag usage texts across all commands.

    This function removes hardcoded local paths by replacing them with environment-agnostic placeholders:

        $PWD for current directory

        $HOME for the user’s home directory

        $SYSTEM_LIB, $USR_LOCAL, etc., for known system paths

This ensures that all generated documentation is clean, consistent, and free from personal directory references—regardless of who runs the command.
💡 Why this approach?

This central solution is:

    Scalable: No need to modify individual commands.

    Robust: Automatically applies to all present and future commands.

    CI/CD friendly: Prevents spurious failures due to local path pollution.

🔧 Next Steps

No action is required from contributors. The make generate-docs process is now safe to run without introducing local environment changes into tracked files.