### PR TITLE
Bump goreleaser to v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: osdctl
 builds:
   - env:
@@ -35,7 +36,7 @@ checksum:
   algorithm: sha256
 
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 
 changelog:
   sort: asc

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ OS := $(shell go env GOOS | sed 's/[a-z]/\U&/')
 ARCH := $(shell go env GOARCH)
 .PHONY: download-goreleaser
 download-goreleaser:
-	GOBIN=${BASE_DIR}/bin/ go install github.com/goreleaser/goreleaser@v1.21.2
+	GOBIN=${BASE_DIR}/bin/ go install github.com/goreleaser/goreleaser/v2@v2.6.1 # TODO: bump once we move to Go 1.24
 
 #Update documentation as a part of every release
 


### PR DESCRIPTION
If a user has a newer goreleaser installed than v1, we would receive deprecation warnings. This updates goreleaser to the latest v2 that is still using Go 1.23.

Included one deprecated field update as well. 

Build
```
> make build
goreleaser build --clean --snapshot --single-target=false
  • skipping validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=056f100c3535bb80492f76733299bf9c8a0a5f3a branch=master current_tag=v0.39.0 previous_tag=v0.38.0 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=v0.39.0-next
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/osdctl_darwin_arm64_v8.0/osdctl
    • building                                       binary=dist/osdctl_linux_arm64_v8.0/osdctl
    • building                                       binary=dist/osdctl_linux_amd64_v1/osdctl
    • building                                       binary=dist/osdctl_darwin_amd64_v1/osdctl
    • took: 12s
  • writing artifacts metadata
  • build succeeded after 12s
  • thanks for using GoReleaser!
```