### PR TITLE
SDCICD-1418 show inscope rollout link in promotion PR description

### DIFF
--- a/cmd/promote/saas/utils.go
+++ b/cmd/promote/saas/utils.go
@@ -81,7 +81,7 @@ func servicePromotion(appInterface git.AppInterface, serviceName, gitHash string
 	prefix := "saas-"
 	operatorName := strings.TrimPrefix(serviceName, prefix)
 	commitMessage := fmt.Sprintf("Promote %s to %s\n\nMonitor rollout status here https://inscope.corp.redhat.com/catalog/default/component/%s/rollout\n\n", serviceName, promotionGitHash, operatorName)
-	commitMessage += fmt.Sprintf("See %s/compare/%s...%s for contents of the promotion. clog:\n%s", serviceRepo, currentGitHash, promotionGitHash, commitLog)
+	commitMessage += fmt.Sprintf("See %s/compare/%s...%s for contents of the promotion. clog:\n\n%s", serviceRepo, currentGitHash, promotionGitHash, commitLog)
 	err = appInterface.CommitSaasFile(saasDir, commitMessage)
 	if err != nil {
 		return fmt.Errorf("failed to commit changes to app-interface: %w", err)

--- a/cmd/promote/saas/utils.go
+++ b/cmd/promote/saas/utils.go
@@ -78,8 +78,10 @@ func servicePromotion(appInterface git.AppInterface, serviceName, gitHash string
 	if err != nil {
 		fmt.Printf("FAILURE: %v\n", err)
 	}
-
-	commitMessage := fmt.Sprintf("Promote %s to %s\n\nSee %s/compare/%s...%s for contents of the promotion.\n clog:%s", serviceName, promotionGitHash, serviceRepo, currentGitHash, promotionGitHash, commitLog)
+	prefix := "saas-"
+	operatorName := strings.TrimPrefix(serviceName, prefix)
+	commitMessage := fmt.Sprintf("Promote %s to %s\n\nMonitor rollout status here https://inscope.corp.redhat.com/catalog/default/component/%s/rollout\n\n", serviceName, promotionGitHash, operatorName)
+	commitMessage += fmt.Sprintf("See %s/compare/%s...%s for contents of the promotion. clog:\n%s", serviceRepo, currentGitHash, promotionGitHash, commitLog)
 	err = appInterface.CommitSaasFile(saasDir, commitMessage)
 	if err != nil {
 		return fmt.Errorf("failed to commit changes to app-interface: %w", err)


### PR DESCRIPTION
show inscope rollout link in promotion PR description

why
after progressive delivery, prod promotion requires previous jobs to succeed. Link to monitor their status will help promoters know this in the PR itself. 

Example commit message:

Existing:
```
Promote saas-managed-upgrade-operator to 816604ef7f1aec0d9f76b1241bacc9b51e0e11c2

See https://github.com/openshift/managed-upgrade-operator/compare/310e1d5a9a3d241e303928eeb60a4ad87db3e507...816604ef7f1aec0d9f76b1241bacc9b51e0e11c2 for contents of the promotion.
clog:commit 740428043842043a1e9d7951a736cd36782bc114
Author: Abhishek Abhishek <aabhishe@redhat.com>
Date:   Mon Apr 7 09:14:00 2025 +0530

    update boilerplate
```

Update: 
```
Promote saas-managed-upgrade-operator to 816604ef7f1aec0d9f76b1241bacc9b51e0e11c2

Monitor rollout status here https://inscope.corp.redhat.com/catalog/default/component/managed-upgrade-operator/rollout

See https://github.com/openshift/managed-upgrade-operator/compare/310e1d5a9a3d241e303928eeb60a4ad87db3e507...816604ef7f1aec0d9f76b1241bacc9b51e0e11c2 for contents of the promotion. clog:

commit 740428043842043a1e9d7951a736cd36782bc114
Author: Abhishek Abhishek <aabhishe@redhat.com>
Date:   Mon Apr 7 09:14:00 2025 +0530

    update boilerplate
```