### PR TITLE
Fix panic and other misc code issues for 'osdctl cluster support post'

### DIFF
--- a/cmd/cluster/support/cmd.go
+++ b/cmd/cluster/support/cmd.go
@@ -22,7 +22,7 @@ func NewCmdSupport(streams genericclioptions.IOStreams, client client.Client, gl
 	}
 
 	supportCmd.AddCommand(newCmdstatus(streams, globalOpts))
-	supportCmd.AddCommand(newCmdpost())
+	supportCmd.AddCommand(newCmdPost())
 	supportCmd.AddCommand(newCmddelete(streams, globalOpts))
 
 	return supportCmd


### PR DESCRIPTION
When running `osdctl cluster support post` with no flags this would panic. I fixed the panic in `setup()` and made a few other changes to simplify things and handle errors better.