### PR TITLE
Updating SL template URLs to RAW urls in github

### DIFF
--- a/cmd/cluster/transferowner.go
+++ b/cmd/cluster/transferowner.go
@@ -38,8 +38,8 @@ import (
 const (
 	CheckSyncMaxAttempts = 24
 
-	SL_TRANSFER_INITIATED = "https://github.com/openshift/managed-notifications/raw/refs/heads/master/osd/clustertransfer_starting.json"
-	SL_TRANSFER_COMPLETE  = "https://github.com/openshift/managed-notifications/raw/refs/heads/master/osd/clustertransfer_completed.json"
+	SL_TRANSFER_INITIATED = "https://raw.githubusercontent.com/openshift/managed-notifications/refs/heads/master/osd/clustertransfer_starting.json"
+	SL_TRANSFER_COMPLETE  = "https://raw.githubusercontent.com/openshift/managed-notifications/refs/heads/master/osd/clustertransfer_completed.json"
 )
 
 // transferOwnerOptions defines the struct for running transferOwner command


### PR DESCRIPTION
In almost all the instances where I had to transfer cluster ownership, the transfer completed SL sent fails with can't find the template. I believe this is due to URL redirect. 
I have updated both SL template URL to direct RAW URLS in github. 
Have tested it and did not face any SL log send failures. 