### PR TITLE
[OSD-29837] Use v2 `sre-capabilities` label to find DT tenant info

### DIFF
--- a/pkg/utils/ocm.go
+++ b/pkg/utils/ocm.go
@@ -26,7 +26,7 @@ const (
 	integrationGovURL          = "https://api-admin.int.openshiftusgov.com"
 	stagingGovURL              = "https://api-admin.stage.openshiftusgov.com"
 	HypershiftClusterTypeLabel = "ext-hypershift.openshift.io/cluster-type"
-	DynatraceTenantKeyLabel    = "sre-capabilities.dtp.tenant"
+	DynatraceTenantKeyLabel    = "sre-capabilities.dtp.v2.tenant"
 )
 
 var urlAliases = map[string]string{


### PR DESCRIPTION
# Overview
OSDFM no longer includes the `sre-capabilities.dtp.tenant` label on clusters by default (per: https://redhat-internal.slack.com/archives/C051MR6AJRJ/p1743062986867459?thread_ts=1742864495.176279&cid=C051MR6AJRJ)

We need to swap to the `v2` labels so that any new clusters can be looked up. 
The `sre-capabilities.dtp.v2` label is populated from this: https://gitlab.cee.redhat.com/service/sre-capabilities/-/blob/7018ebdf3c1f63843674b5791f533434caf56efc/data/dynatrace/hypershift-cluster-labels-prod.yaml#L11 

# Validation
Ran the following in STG/INT/PRD, and every cluster that still has the original label passed the validation check. 
_(There are actually more clusters missing this old label than I expected, so we're fixing a bunch)_
```
#!/bin/bash

# Define color codes
RED='\033[0;31m'
GREEN='\033[0;32m'
NC='\033[0m' # No Color


for i in `ocm get /api/osd_fleet_mgmt/v1/management_clusters | jq -r '.items[] | .name'`; do
  echo "############################################################"
  echo "# $i"
  echo "############################################################"
  
  CURR=$(/Users/jdagosti/.local/bin/backplane/latest/osdctl dynatrace url --cluster-id $i 2>/dev/null)
  echo " : Current Response:  $CURR"

  NEW=$(/Users/jdagosti/git/jimdaga/osdctl/dist/osdctl_darwin_arm64_v8.0/osdctl dynatrace url --cluster-id $i --skip-version-check 2>/dev/null)
  echo " : New Code Response: $NEW"

  if [[ "$CURR" != "$NEW" ]]; then
    echo -e " - ${RED}[ERROR] THE RESPONSES DO NOT MATCH${NC}"
  else
    echo -e " - ${GREEN}[INFO] Response Matches!${NC}"
  fi

  echo
done
```

# Fixes
https://issues.redhat.com/browse/OSD-29837