### PR TITLE
OSD-29549 : Added unit test case for infra_node and controlplane_node under resize pkg

### DIFF
--- a/cmd/cluster/resize/controlplane_node_test.go
+++ b/cmd/cluster/resize/controlplane_node_test.go
@@ -1,0 +1,49 @@
+package resize
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPromptGenerateResizeSL(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedError error
+	}{
+		{
+			name:          "User cancels service log generation",
+			input:         "n\n",
+			expectedError: nil,
+		},
+		{
+			name:          "Failed to search for clusters",
+			input:         "y\nJIRA-123\njustification text\n",
+			expectedError: errors.New("failed to search for clusters with provided filters"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pr, pw, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			os.Stdin = pr
+			go func() {
+				pw.Write([]byte(tt.input))
+				pw.Close()
+			}()
+
+			err = promptGenerateResizeSL("cluster-123", "new-instance-type")
+			if tt.expectedError != nil {
+				assert.Contains(t, err.Error(), tt.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/cluster/resize/infra_node.go
+++ b/cmd/cluster/resize/infra_node.go
@@ -9,8 +9,10 @@ import (
 	"strings"
 	"time"
 
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/smithy-go"
+	sdk "github.com/openshift-online/ocm-sdk-go"
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -576,30 +578,62 @@ func (r *Infra) terminateCloudInstances(ctx context.Context, nodeList *corev1.No
 
 	switch r.cluster.CloudProvider().ID() {
 	case "aws":
-		ocmClient, err := utils.CreateConnection()
-		if err != nil {
-			return err
-		}
-		defer ocmClient.Close()
-		cfg, err := osdCloud.CreateAWSV2Config(ocmClient, r.cluster)
-		if err != nil {
-			return err
+		var ocmClient interface{}
+		if mOCM, ok := ctx.Value("ocm").(interface{ ClustersMgmt() interface{} }); ok {
+			ocmClient = mOCM
+		} else {
+			var err error
+			ocmClient, err = utils.CreateConnection()
+			if err != nil {
+				return err
+			}
+			defer ocmClient.(*sdk.Connection).Close()
 		}
 
-		awsClient := ec2.NewFromConfig(cfg)
-		_, err = awsClient.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
-			InstanceIds: instanceIDs,
-		})
-		if err != nil {
-			var apiErr smithy.APIError
-			if errors.As(err, &apiErr) {
-				code := apiErr.ErrorCode()
-				message := apiErr.ErrorMessage()
-				log.Printf("AWS ERROR: %v - %v\n", code, message)
-			} else {
-				log.Printf("ERROR: %v\n", err.Error())
+		if mBuilder, ok := ctx.Value("aws_builder").(interface {
+			CreateAWSV2Config(interface{}, *cmv1.Cluster) (awssdk.Config, error)
+		}); ok {
+			cfg, err := mBuilder.CreateAWSV2Config(ocmClient, r.cluster)
+			if err != nil {
+				return err
 			}
-			return err
+			
+			cfg.Region = r.cluster.Region().ID()
+			awsClient := ec2.NewFromConfig(cfg)
+			_, err = awsClient.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+				InstanceIds: instanceIDs,
+			})
+			if err != nil {
+				var apiErr smithy.APIError
+				if errors.As(err, &apiErr) {
+					code := apiErr.ErrorCode()
+					message := apiErr.ErrorMessage()
+					log.Printf("AWS ERROR: %v - %v\n", code, message)
+				} else {
+					log.Printf("ERROR: %v\n", err.Error())
+				}
+				return err
+			}
+		} else {
+			cfg, err := osdCloud.CreateAWSV2Config(ocmClient.(*sdk.Connection), r.cluster)
+			if err != nil {
+				return err
+			}
+			awsClient := ec2.NewFromConfig(cfg)
+			_, err = awsClient.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+				InstanceIds: instanceIDs,
+			})
+			if err != nil {
+				var apiErr smithy.APIError
+				if errors.As(err, &apiErr) {
+					code := apiErr.ErrorCode()
+					message := apiErr.ErrorMessage()
+					log.Printf("AWS ERROR: %v - %v\n", code, message)
+				} else {
+					log.Printf("ERROR: %v\n", err.Error())
+				}
+				return err
+			}
 		}
 
 	case "gcp":

--- a/cmd/cluster/resize/infra_node_test.go
+++ b/cmd/cluster/resize/infra_node_test.go
@@ -1,12 +1,19 @@
 package resize
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hivev1aws "github.com/openshift/hive/apis/hive/v1/aws"
 	hivev1gcp "github.com/openshift/hive/apis/hive/v1/gcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // newTestCluster assembles a *cmv1.Cluster while handling the error to help out with inline test-case generation
@@ -128,4 +135,457 @@ func TestConvertProviderIDtoInstanceID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSkipError(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   result
+		msg      string
+		expected bool
+	}{
+		{
+			name: "no error",
+			result: result{
+				condition: true,
+				err:       nil,
+			},
+			msg:      "test message",
+			expected: true,
+		},
+		{
+			name: "with error",
+			result: result{
+				condition: false,
+				err:       fmt.Errorf("test error"),
+			},
+			msg:      "test message",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := skipError(test.result, test.msg)
+			if err != nil {
+				t.Errorf("expected nil error, got %v", err)
+			}
+			if actual != test.expected {
+				t.Errorf("expected condition %v, got %v", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestNodesMatchExpectedCount(t *testing.T) {
+	tests := []struct {
+		name          string
+		labelSelector labels.Selector
+		expectedCount int
+		mockNodeList  *corev1.NodeList
+		mockListError error
+		expectedMatch bool
+		expectedError error
+	}{
+		{
+			name:          "matching count",
+			labelSelector: labels.NewSelector(),
+			expectedCount: 2,
+			mockNodeList: &corev1.NodeList{
+				Items: []corev1.Node{
+					{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
+				},
+			},
+			expectedMatch: true,
+		},
+		{
+			name:          "non-matching count",
+			labelSelector: labels.NewSelector(),
+			expectedCount: 2,
+			mockNodeList: &corev1.NodeList{
+				Items: []corev1.Node{
+					{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+				},
+			},
+			expectedMatch: false,
+		},
+		{
+			name:          "list error",
+			labelSelector: labels.NewSelector(),
+			expectedCount: 2,
+			mockListError: fmt.Errorf("list error"),
+			expectedError: fmt.Errorf("list error"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create mock client
+			mockClient := &MockClient{}
+			mockClient.On("List", mock.Anything, mock.Anything, mock.Anything).
+				Return(test.mockListError).
+				Run(func(args mock.Arguments) {
+					if test.mockNodeList != nil {
+						arg := args.Get(1).(*corev1.NodeList)
+						*arg = *test.mockNodeList
+					}
+				})
+
+			// Create Infra instance with mock client
+			r := &Infra{
+				client: mockClient,
+			}
+
+			// Call the function
+			match, err := r.nodesMatchExpectedCount(context.Background(), test.labelSelector, test.expectedCount)
+
+			// Verify results
+			if test.expectedError != nil {
+				if err == nil || err.Error() != test.expectedError.Error() {
+					t.Errorf("expected error %v, got %v", test.expectedError, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if match != test.expectedMatch {
+					t.Errorf("expected match %v, got %v", test.expectedMatch, match)
+				}
+			}
+
+			// Verify mock was called correctly
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGenerateServiceLog(t *testing.T) {
+	tests := []struct {
+		name             string
+		mp               *hivev1.MachinePool
+		instanceType     string
+		justification    string
+		clusterId        string
+		ohss             string
+		expectedTemplate string
+		expectedParams   []string
+	}{
+		{
+			name: "AWS case",
+			mp: &hivev1.MachinePool{
+				Spec: hivev1.MachinePoolSpec{
+					Platform: hivev1.MachinePoolPlatform{
+						AWS: &hivev1aws.MachinePoolPlatform{
+							InstanceType: "r5.xlarge",
+						},
+					},
+				},
+			},
+			instanceType:     "r5.2xlarge",
+			justification:    "test justification",
+			clusterId:        "test-cluster",
+			ohss:             "test-ohss",
+			expectedTemplate: resizedInfraNodeServiceLogTemplate,
+			expectedParams: []string{
+				"INSTANCE_TYPE=r5.2xlarge",
+				"JUSTIFICATION=test justification",
+				"JIRA_ID=test-ohss",
+			},
+		},
+		{
+			name: "GCP case",
+			mp: &hivev1.MachinePool{
+				Spec: hivev1.MachinePoolSpec{
+					Platform: hivev1.MachinePoolPlatform{
+						GCP: &hivev1gcp.MachinePool{
+							InstanceType: "custom-4-32768-ext",
+						},
+					},
+				},
+			},
+			instanceType:     "custom-8-65536-ext",
+			justification:    "test justification",
+			clusterId:        "test-cluster",
+			ohss:             "test-ohss",
+			expectedTemplate: GCPresizedInfraNodeServiceLogTemplate,
+			expectedParams: []string{
+				"INSTANCE_TYPE=custom-8-65536-ext",
+				"JUSTIFICATION=test justification",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := generateServiceLog(test.mp, test.instanceType, test.justification, test.clusterId, test.ohss)
+
+			if actual.Template != test.expectedTemplate {
+				t.Errorf("expected template %s, got %s", test.expectedTemplate, actual.Template)
+			}
+
+			if actual.ClusterId != test.clusterId {
+				t.Errorf("expected cluster ID %s, got %s", test.clusterId, actual.ClusterId)
+			}
+
+			if len(actual.TemplateParams) != len(test.expectedParams) {
+				t.Errorf("expected %d params, got %d", len(test.expectedParams), len(actual.TemplateParams))
+			}
+
+			for i, param := range actual.TemplateParams {
+				if param != test.expectedParams[i] {
+					t.Errorf("expected param %s, got %s", test.expectedParams[i], param)
+				}
+			}
+		})
+	}
+}
+
+func TestTerminateCloudInstances(t *testing.T) {
+	testCases := []struct {
+		name        string
+		provider    string
+		nodes       []string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "AWS_error",
+			provider:    "AWS",
+			nodes:       []string{"i-1234567890abcdef0"},
+			expectError: true,
+		},
+		{
+			name:        "AWS_error_no_config",
+			provider:    "aws",
+			nodes:       []string{"i-1234567890abcdef0"},
+			expectError: true,
+			errorMsg:    "failed to load backplane-cli config",
+		},
+		{
+			name:        "GCP_not_supported",
+			provider:    "gcp",
+			nodes:       []string{"gce://project/zone/instance-1"},
+			expectError: false,
+		},
+		{
+			name:        "unsupported_provider",
+			provider:    "azure",
+			nodes:       []string{"azure://subscription/resource-group/instance-1"},
+			expectError: true,
+			errorMsg:    "cloud provider not supported: azure, only AWS is supported",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// mockOCM := &MockOCMConnection{}
+			// mockAWSBuilder := &MockAWSBuilder{}
+
+			cluster, err := cmv1.NewCluster().CloudProvider(
+				cmv1.NewCloudProvider().ID(tc.provider),
+			).Build()
+			if err != nil {
+				t.Fatalf("Failed to build cluster: %v", err)
+			}
+
+			infra := &Infra{
+				cluster: cluster,
+				// ocm:        mockOCM,
+				// awsBuilder: mockAWSBuilder,
+			}
+
+			// Create node list
+			nodeList := &corev1.NodeList{
+				Items: make([]corev1.Node, len(tc.nodes)),
+			}
+			for i, id := range tc.nodes {
+				nodeList.Items[i] = corev1.Node{
+					Spec: corev1.NodeSpec{
+						ProviderID: id,
+					},
+				}
+			}
+
+			err = infra.terminateCloudInstances(context.TODO(), nodeList)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				if tc.errorMsg != "" {
+					assert.Contains(t, err.Error(), tc.errorMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetInfraMachinePool(t *testing.T) {
+	// Create a test namespace
+	testNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-namespace",
+			Labels: map[string]string{
+				"api.openshift.com/id": "test-cluster",
+			},
+		},
+	}
+
+	// Create a test machine pool with name exactly matching "infra"
+	testMachinePool := &hivev1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-infra", // Name in metadata
+			Namespace: "test-namespace",
+		},
+		Spec: hivev1.MachinePoolSpec{
+			Name: "infra", // This is what the code checks for
+			Platform: hivev1.MachinePoolPlatform{
+				AWS: &hivev1aws.MachinePoolPlatform{
+					InstanceType: "r5.xlarge",
+				},
+			},
+		},
+	}
+
+	// Create mock client
+	mockHive := &MockClient{}
+
+	// Set up mock expectations for namespace list - first call
+	firstCall := mockHive.On("List", mock.Anything, mock.MatchedBy(func(obj interface{}) bool {
+		_, ok := obj.(*corev1.NamespaceList)
+		return ok
+	}), mock.Anything)
+	firstCall.Return(nil).Run(func(args mock.Arguments) {
+		nsList := args.Get(1).(*corev1.NamespaceList)
+		nsList.Items = []corev1.Namespace{*testNamespace}
+	})
+
+	// Set up mock expectations for machine pool list - second call
+	secondCall := mockHive.On("List", mock.Anything, mock.MatchedBy(func(obj interface{}) bool {
+		_, ok := obj.(*hivev1.MachinePoolList)
+		return ok
+	}), mock.Anything)
+	secondCall.Return(nil).Run(func(args mock.Arguments) {
+		mpList := args.Get(1).(*hivev1.MachinePoolList)
+		mpList.Items = []hivev1.MachinePool{*testMachinePool}
+	})
+
+	// Create Infra instance
+	infra := &Infra{
+		clusterId: "test-cluster",
+		hive:      mockHive,
+	}
+
+	// Call the function
+	mp, err := infra.getInfraMachinePool(context.Background())
+
+	// Verify results
+	assert.NoError(t, err)
+	assert.NotNil(t, mp)
+	assert.Equal(t, "infra", mp.Spec.Name)
+	assert.Equal(t, "r5.xlarge", mp.Spec.Platform.AWS.InstanceType)
+
+	// Verify mock was called correctly
+	mockHive.AssertExpectations(t)
+}
+
+func TestGetInfraMachinePoolNoNamespace(t *testing.T) {
+	// Create mock client
+	mockHive := &MockClient{}
+
+	// Set up mock expectations for namespace list - empty list
+	firstCall := mockHive.On("List", mock.Anything, mock.MatchedBy(func(obj interface{}) bool {
+		_, ok := obj.(*corev1.NamespaceList)
+		return ok
+	}), mock.Anything)
+	firstCall.Return(nil).Run(func(args mock.Arguments) {
+		nsList := args.Get(1).(*corev1.NamespaceList)
+		nsList.Items = []corev1.Namespace{} // Empty list
+	})
+
+	// Create Infra instance
+	infra := &Infra{
+		clusterId: "test-cluster",
+		hive:      mockHive,
+	}
+
+	// Call the function
+	mp, err := infra.getInfraMachinePool(context.Background())
+
+	// Verify results
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected 1 namespace, found 0 namespaces with tag: api.openshift.com/id=test-cluster")
+	assert.Nil(t, mp)
+
+	// Verify mock was called correctly
+	mockHive.AssertExpectations(t)
+}
+
+func TestGetInfraMachinePoolNoInfraPool(t *testing.T) {
+	// Create a test namespace
+	testNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-namespace",
+			Labels: map[string]string{
+				"api.openshift.com/id": "test-cluster",
+			},
+		},
+	}
+
+	// Create a test machine pool (worker, not infra)
+	testMachinePool := &hivev1.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-worker",
+			Namespace: "test-namespace",
+		},
+		Spec: hivev1.MachinePoolSpec{
+			Name: "worker", // Not "infra"
+			Platform: hivev1.MachinePoolPlatform{
+				AWS: &hivev1aws.MachinePoolPlatform{
+					InstanceType: "r5.xlarge",
+				},
+			},
+		},
+	}
+
+	// Create mock client
+	mockHive := &MockClient{}
+
+	// Set up mock expectations for namespace list - first call
+	firstCall := mockHive.On("List", mock.Anything, mock.MatchedBy(func(obj interface{}) bool {
+		_, ok := obj.(*corev1.NamespaceList)
+		return ok
+	}), mock.Anything)
+	firstCall.Return(nil).Run(func(args mock.Arguments) {
+		nsList := args.Get(1).(*corev1.NamespaceList)
+		nsList.Items = []corev1.Namespace{*testNamespace}
+	})
+
+	// Set up mock expectations for machine pool list - second call
+	secondCall := mockHive.On("List", mock.Anything, mock.MatchedBy(func(obj interface{}) bool {
+		_, ok := obj.(*hivev1.MachinePoolList)
+		return ok
+	}), mock.Anything)
+	secondCall.Return(nil).Run(func(args mock.Arguments) {
+		mpList := args.Get(1).(*hivev1.MachinePoolList)
+		mpList.Items = []hivev1.MachinePool{*testMachinePool}
+	})
+
+	// Create Infra instance
+	infra := &Infra{
+		clusterId: "test-cluster",
+		hive:      mockHive,
+	}
+
+	// Call the function
+	mp, err := infra.getInfraMachinePool(context.Background())
+
+	// Verify results
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "did not find the infra machinepool in namespace: test-namespace")
+	assert.Nil(t, mp)
+
+	// Verify mock was called correctly
+	mockHive.AssertExpectations(t)
 }

--- a/cmd/cluster/resize/mocks.go
+++ b/cmd/cluster/resize/mocks.go
@@ -1,0 +1,94 @@
+package resize
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// MockClient is a mock implementation of the client.Client interface
+type MockClient struct {
+	mock.Mock
+}
+
+// List implements the client.Client interface
+func (m *MockClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	args := m.Called(ctx, list, opts)
+	return args.Error(0)
+}
+
+// Get implements the client.Client interface
+func (m *MockClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	args := m.Called(ctx, key, obj, opts)
+	return args.Error(0)
+}
+
+// Create implements the client.Client interface
+func (m *MockClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	args := m.Called(ctx, obj, opts)
+	return args.Error(0)
+}
+
+// Delete implements the client.Client interface
+func (m *MockClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	args := m.Called(ctx, obj, opts)
+	return args.Error(0)
+}
+
+// Update implements the client.Client interface
+func (m *MockClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	args := m.Called(ctx, obj, opts)
+	return args.Error(0)
+}
+
+// Patch implements the client.Client interface
+func (m *MockClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	args := m.Called(ctx, obj, patch, opts)
+	return args.Error(0)
+}
+
+// DeleteAllOf implements the client.Client interface
+func (m *MockClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	args := m.Called(ctx, obj, opts)
+	return args.Error(0)
+}
+
+// GroupVersionKindFor implements the client.Client interface
+func (m *MockClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	args := m.Called(obj)
+	return args.Get(0).(schema.GroupVersionKind), args.Error(1)
+}
+
+// IsObjectNamespaced implements the client.Client interface
+func (m *MockClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	args := m.Called(obj)
+	return args.Bool(0), args.Error(1)
+}
+
+// RESTMapper implements the client.Client interface
+func (m *MockClient) RESTMapper() meta.RESTMapper {
+	args := m.Called()
+	return args.Get(0).(meta.RESTMapper)
+}
+
+// Scheme implements the client.Client interface
+func (m *MockClient) Scheme() *runtime.Scheme {
+	args := m.Called()
+	return args.Get(0).(*runtime.Scheme)
+}
+
+// Status implements the client.Client interface
+func (m *MockClient) Status() client.StatusWriter {
+	args := m.Called()
+	return args.Get(0).(client.StatusWriter)
+}
+
+// SubResource implements the client.Client interface
+func (m *MockClient) SubResource(subResource string) client.SubResourceClient {
+	args := m.Called(subResource)
+	return args.Get(0).(client.SubResourceClient)
+}


### PR DESCRIPTION
This PR enhances test coverage and improves maintainability by adding unit test cases for the the resize package with dependency injection for better testability.

Coverage Details:
Increased unit test coverage for resize package

Verification:
All tests pass successfully, ensuring correctness and improved test coverage.

JIRA Ticket:

[OSD-29549](https://issues.redhat.com/browse/OSD-29549)