### PR TITLE
OSD-28497: Fixes to allow `osdctl account rotate-secret` to work with `rh-aws-saml-login`.

### DIFF
--- a/cmd/account/rotate-secret.go
+++ b/cmd/account/rotate-secret.go
@@ -70,6 +70,10 @@ func newRotateSecretOptions(streams genericclioptions.IOStreams, client *k8s.Laz
 	}
 }
 
+func getSessionNameFromUserId(userid string) string {
+	return strings.Replace(userid, ":", "-", 1)
+}
+
 func (o *rotateSecretOptions) complete(cmd *cobra.Command, args []string) error {
 
 	if len(args) != 1 {
@@ -77,10 +81,6 @@ func (o *rotateSecretOptions) complete(cmd *cobra.Command, args []string) error 
 	}
 
 	o.accountCRName = args[0]
-
-	if o.profile == "" {
-		o.profile = "default"
-	}
 
 	// The aws account timeout. The min the API supports is 15mins.
 	// 900 sec is 15min
@@ -131,6 +131,7 @@ func (o *rotateSecretOptions) run() error {
 	if err != nil {
 		return err
 	}
+	roleSessionName := getSessionNameFromUserId(*callerIdentityOutput.UserId)
 
 	var credentials *stsTypes.Credentials
 	// Need to role chain if the cluster is CCS
@@ -148,7 +149,7 @@ func (o *rotateSecretOptions) run() error {
 		}
 
 		// Assume the ARN
-		srepRoleCredentials, err := awsprovider.GetAssumeRoleCredentials(awsSetupClient, o.awsAccountTimeout, callerIdentityOutput.UserId, &SREAccessARN)
+		srepRoleCredentials, err := awsprovider.GetAssumeRoleCredentials(awsSetupClient, o.awsAccountTimeout, &roleSessionName, &SREAccessARN)
 		if err != nil {
 			return err
 		}
@@ -170,7 +171,7 @@ func (o *rotateSecretOptions) run() error {
 			return fmt.Errorf("jump Access ARN is missing from configmap")
 		}
 		// Assume the ARN
-		jumpRoleCreds, err := awsprovider.GetAssumeRoleCredentials(srepRoleClient, o.awsAccountTimeout, callerIdentityOutput.UserId, &JumpARN)
+		jumpRoleCreds, err := awsprovider.GetAssumeRoleCredentials(srepRoleClient, o.awsAccountTimeout, &roleSessionName, &JumpARN)
 		if err != nil {
 			return err
 		}
@@ -187,7 +188,7 @@ func (o *rotateSecretOptions) run() error {
 		// Role chain to assume ManagedOpenShift-Support-{uid}
 		roleArn := awsSdk.String(fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, "ManagedOpenShift-Support-"+accountIDSuffixLabel))
 		credentials, err = awsprovider.GetAssumeRoleCredentials(jumpRoleClient, o.awsAccountTimeout,
-			callerIdentityOutput.UserId, roleArn)
+			&roleSessionName, roleArn)
 		if err != nil {
 			return err
 		}
@@ -196,7 +197,7 @@ func (o *rotateSecretOptions) run() error {
 		// Assume the OrganizationAdminAccess role
 		roleArn := awsSdk.String(fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, awsv1alpha1.AccountOperatorIAMRole))
 		credentials, err = awsprovider.GetAssumeRoleCredentials(awsSetupClient, o.awsAccountTimeout,
-			callerIdentityOutput.UserId, roleArn)
+			&roleSessionName, roleArn)
 		if err != nil {
 			return err
 		}

--- a/cmd/account/rotate-secret_test.go
+++ b/cmd/account/rotate-secret_test.go
@@ -34,12 +34,12 @@ func TestRotateSecretOptions_Complete(t *testing.T) {
 			expectedProfile: "custom",
 		},
 		{
-			name:            "default_profile_used",
+			name:            "default_profile_not_used",
 			args:            []string{"another-cr"},
 			flags:           map[string]string{"reason": "PD-789"},
 			expectedErr:     false,
 			expectedName:    "another-cr",
-			expectedProfile: "default",
+			expectedProfile: "",
 		},
 		{
 			name:           "invalid_admin_username",


### PR DESCRIPTION
* Allow the profile to be blank so that env variables can be used
* Make sure that `:` is not used in the AWS session name, as it is invalid

Jira: [OSD-28497](https://issues.redhat.com/browse/OSD-28497)