### PR TITLE
OSD-29210: Add gcp instance types to cluster resize command

### DIFF
--- a/cmd/cluster/resize/cmd.go
+++ b/cmd/cluster/resize/cmd.go
@@ -5,8 +5,32 @@ import (
 )
 
 var supportedInstanceTypes = map[string][]string{
-	"controlplane": {"m5.4xlarge", "m5.8xlarge", "m5.12xlarge", "m5.16xlarge", "m5.24xlarge"},
-	"infra":        {"r5.4xlarge", "r5.8xlarge", "r5.12xlarge", "r5.16xlarge", "r5.24xlarge"},
+	"controlplane": {
+		"m5.4xlarge",
+		"m5.8xlarge",
+		"m5.12xlarge",
+		"m5.16xlarge",
+		"m5.24xlarge",
+		"custom-8-32768",
+		"custom-16-65536",
+		"custom-32-131072",
+		"n2-standard-8",
+		"n2-standard-16",
+		"n2-standard-32",
+	},
+	"infra": {
+		"r5.4xlarge",
+		"r5.8xlarge",
+		"r5.12xlarge",
+		"r5.16xlarge",
+		"r5.24xlarge",
+		"custom-4-32768-ext",
+		"custom-8-65536-ext",
+		"custom-16-131072-ext",
+		"n2-highmem-4",
+		"n2-highmem-8",
+		"n2-highmem-16",
+	},
 }
 
 func NewCmdResize() *cobra.Command {

--- a/cmd/cluster/resize/infra_node.go
+++ b/cmd/cluster/resize/infra_node.go
@@ -499,6 +499,8 @@ func (r *Infra) embiggenMachinePool(mp *hivev1.MachinePool) (*hivev1.MachinePool
 		// GCP
 		"custom-4-32768-ext": "custom-8-65536-ext",
 		"custom-8-65536-ext": "custom-16-131072-ext",
+		"n2-highmem-4":       "n2-highmem-8",
+		"n2-highmem-8":       "n2-highmem-16",
 	}
 
 	newMp := &hivev1.MachinePool{}


### PR DESCRIPTION
Adding all machine types https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/planning_your_environment/osd-limits-scalability#node-sizing-during-installation_osd-limits-scalability