### PR TITLE
OSD-29994: Improve sre-operators command misleading message

### DIFF
--- a/cmd/cluster/sre_operators/describeCmd.go
+++ b/cmd/cluster/sre_operators/describeCmd.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift/osdctl/pkg/printer"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/xanzy/go-gitlab"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -91,12 +91,18 @@ func (ctx *sreOperatorsDescribeOptions) printText(output []sreOperatorDetails) e
 	for _, op := range output {
 		p.AddRow([]string{"", ""})
 		p.AddRow([]string{"Operator Name:", op.basic.Name})
-		if op.basic.Current != op.basic.Expected {
+		if op.basic.Current == "" || op.basic.Expected == "" {
+			p.AddRow([]string{"Current Version:", op.basic.Current})
+		} else if op.basic.Current != op.basic.Expected {
 			p.AddRow([]string{"Current Version:", Red + Bold + op.basic.Current + " (outdated)" + RestoreColor})
 		} else {
 			p.AddRow([]string{"Current Version:", op.basic.Current})
 		}
-		p.AddRow([]string{"Expected Version:", op.basic.Expected})
+		if op.basic.Expected == "" {
+			p.AddRow([]string{"Expected Version:", Red + Bold + "not found - Gitlab token may be missing or expired" + RestoreColor})
+		} else {
+			p.AddRow([]string{"Expected Version:", op.basic.Expected})
+		}
 		p.AddRow([]string{"", ""})
 		p.AddRow([]string{"Current Version Commit:", op.basic.CurrentCommit})
 		p.AddRow([]string{"Expected Version Commit:", op.basic.ExpectedCommit})

--- a/cmd/cluster/sre_operators/listCmd.go
+++ b/cmd/cluster/sre_operators/listCmd.go
@@ -15,7 +15,7 @@ import (
 	"github.com/openshift/osdctl/pkg/printer"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/xanzy/go-gitlab"
+	gitlab "gitlab.com/gitlab-org/api/client-go"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -210,7 +210,9 @@ func (ctx *sreOperatorsListOptions) printText(opList []sreOperator) error {
 			if ctx.noCommit {
 				row = []string{op.Name, op.Current, op.Expected, op.Status, op.Channel}
 			}
-			if op.Current != op.Expected {
+			if op.Expected == "" {
+				row = []string{Red + Bold + op.Name, Gap + op.Current, Gap + op.CurrentCommit, Gap + "not found (Gitlab token may be missing or expired)", Gap + op.ExpectedCommit, Gap + op.Status, Gap + op.Channel, Gap + op.RepositoryURL + RestoreColor}
+			} else if op.Current != op.Expected {
 				row = []string{Red + Bold + op.Name, Gap + op.Current, Gap + op.CurrentCommit, Gap + op.Expected, Gap + op.ExpectedCommit, Gap + op.Status, Gap + op.Channel, Gap + op.RepositoryURL + RestoreColor}
 				if ctx.noCommit {
 					row = []string{Red + Bold + op.Name, Gap + op.Current, Gap + op.Expected, Gap + op.Status, Gap + op.Channel + RestoreColor}

--- a/go.mod
+++ b/go.mod
@@ -53,8 +53,8 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
-	github.com/xanzy/go-gitlab v0.115.0
 	github.com/zclconf/go-cty v1.13.0
+	gitlab.com/gitlab-org/api/client-go v0.128.0
 	go.uber.org/mock v0.5.0
 	golang.org/x/oauth2 v0.26.0
 	golang.org/x/sync v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -647,8 +647,6 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
-github.com/xanzy/go-gitlab v0.115.0 h1:6DmtItNcVe+At/liXSgfE/DZNZrGfalQmBRmOcJjOn8=
-github.com/xanzy/go-gitlab v0.115.0/go.mod h1:5XCDtM7AM6WMKmfDdOiEpyRWUqui2iS9ILfvCZ2gJ5M=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
@@ -681,6 +679,8 @@ github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a h1:DxppxFKRqJ8WD6oJ3+ZXKDY0iMONQDl5UTg2aTyHh8k=
 gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a/go.mod h1:NREvu3a57BaK0R1+ztrEzHWiZAihohNLQ6trPxlIqZI=
+gitlab.com/gitlab-org/api/client-go v0.128.0 h1:Wvy1UIuluKemubao2k8EOqrl3gbgJ1PVifMIQmg2Da4=
+gitlab.com/gitlab-org/api/client-go v0.128.0/go.mod h1:bYC6fPORKSmtuPRyD9Z2rtbAjE7UeNatu2VWHRf4/LE=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 h1:CV7UdSGJt/Ao6Gp4CXckLxVRRsRgDHoI8XjbL3PDl8s=


### PR DESCRIPTION
This minor PR improves the misleading "outdated" message returned if the command is unable to access Gitlab to obtain the expected version of the operator. The PR also updates the GitLab client to [client-go](https://gitlab.com/gitlab-org/api/client-go) as [go-gitlab](https://github.com/xanzy/go-gitlab) has been deprecated.