### PR TITLE
Fix the linting config and a selection of failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ osdctl
 
 # goReleaser 
 dist/
-bin/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,17 +1,40 @@
+version: "2"
 run:
-  # Our CI expects a vendor directory, hence we have to use -mod=readonly here as well.
-  modules-download-mode: readonly
-
-issues:
-  # on default, golangci-lint excludes gosec. Hence, we have to
-  # explicitly disable the exclude-use-default: https://github.com/golangci/golangci-lint/issues/1504
-  exclude-use-default: false
-
-# individual linter configs go here
-linters-settings:
-
-# default linters are enabled `golangci-lint help linters`
+  concurrency: 10
 linters:
-  disable-all: true
+  default: none
   enable:
+    - errcheck
     - gosec
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unused
+  settings:
+    misspell:
+      extra-words:
+        - typo: openshit
+          correction: OpenShift
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party/
+      - builtin/
+      - examples/
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  new-from-rev: 8d912e328ca7d7a640fc1c39d3fd9e365b6d5bf7
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party/
+      - builtin/
+      - examples/

--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,12 @@ ARCH := $(shell go env GOARCH)
 download-goreleaser:
 	GOBIN=${BASE_DIR}/bin/ go install github.com/goreleaser/goreleaser/v2@v2.6.1 # TODO: bump once we move to Go 1.24
 
-#Update documentation as a part of every release
-
+# Update documentation as a part of every release
 .PHONY: generate-docs
 generate-docs:
 	@go run utils/docgen/main.go --cmd-path=./cmd --docs-dir=./docs
 	
-#Verify documents using PROW as a part of every PR raised for osdctl
-
+# Verify documents using PROW as a part of every PR raised for osdctl
 .PHONY: verify-docs
 verify-docs:
 	./scripts/verify-docs.sh

--- a/cmd/account/mgmt/account-assign.go
+++ b/cmd/account/mgmt/account-assign.go
@@ -332,7 +332,6 @@ var (
 	ErrAwsAccountLimitExceeded = fmt.Errorf("ErrAwsAccountLimitExceeded")
 	ErrEmailAlreadyExist       = fmt.Errorf("ErrEmailAlreadyExist")
 	ErrAwsInternalFailure      = fmt.Errorf("ErrAwsInternalFailure")
-	ErrAwsTooManyRequests      = fmt.Errorf("ErrAwsTooManyRequests")
 	ErrAwsFailedCreateAccount  = fmt.Errorf("ErrAwsFailedCreateAccount")
 )
 

--- a/cmd/account/rotate-secret.go
+++ b/cmd/account/rotate-secret.go
@@ -308,7 +308,11 @@ func (o *rotateSecretOptions) run() error {
 	}
 
 	fmt.Printf("Watching Cluster Sync Status for deployment...")
-	hiveinternalv1alpha1.AddToScheme(o.kubeCli.Scheme())
+	err = hiveinternalv1alpha1.AddToScheme(o.kubeCli.Scheme())
+	if err != nil {
+		return err
+	}
+
 	searchStatus := &hiveinternalv1alpha1.ClusterSync{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cdName,

--- a/cmd/cloudtrail/cmd.go
+++ b/cmd/cloudtrail/cmd.go
@@ -9,8 +9,8 @@ func NewCloudtrailCmd() *cobra.Command {
 	cloudtrailCmd := &cobra.Command{
 		Use:   "cloudtrail",
 		Short: "AWS CloudTrail related utilities",
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
 		},
 	}
 

--- a/cmd/cloudtrail/permission-denied.go
+++ b/cmd/cloudtrail/permission-denied.go
@@ -38,7 +38,7 @@ func newCmdPermissionDenied() *cobra.Command {
 	permissionDeniedCmd.Flags().StringVarP(&opts.StartTime, "since", "", "5m", "Specifies that only events that occur within the specified time are returned.Defaults to 5m. Valid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\".")
 	permissionDeniedCmd.Flags().BoolVarP(&opts.PrintUrl, "url", "u", false, "Generates Url link to cloud console cloudtrail event")
 	permissionDeniedCmd.Flags().BoolVarP(&opts.PrintRaw, "raw-event", "r", false, "Prints the cloudtrail events to the console in raw json format")
-	permissionDeniedCmd.MarkFlagRequired("cluster-id")
+	_ = permissionDeniedCmd.MarkFlagRequired("cluster-id")
 	return permissionDeniedCmd
 }
 

--- a/cmd/cloudtrail/write-events.go
+++ b/cmd/cloudtrail/write-events.go
@@ -60,7 +60,7 @@ func newCmdWriteEvents() *cobra.Command {
 	listEventsCmd.Flags().BoolVarP(&ops.PrintUrl, "url", "u", false, "Generates Url link to cloud console cloudtrail event")
 	listEventsCmd.Flags().BoolVarP(&ops.PrintRaw, "raw-event", "r", false, "Prints the cloudtrail events to the console in raw json format")
 	listEventsCmd.Flags().BoolVarP(&ops.PrintAll, "all", "A", false, "Prints all cloudtrail write events without filtering")
-	listEventsCmd.MarkFlagRequired("cluster-id")
+	_ = listEventsCmd.MarkFlagRequired("cluster-id")
 	return listEventsCmd
 }
 

--- a/cmd/cluster/access/cleanup.go
+++ b/cmd/cluster/access/cleanup.go
@@ -35,7 +35,8 @@ func newCmdCleanup(client *k8s.LazyClient, streams genericclioptions.IOStreams) 
 	}
 	cleanupCmd.Flags().StringVar(&ops.clusterID, "cluster-id", "", "[Mandatory] Provide the Internal ID of the cluster")
 	cleanupCmd.Flags().StringVar(&ops.reason, "reason", "", "[Mandatory for PrivateLink clusters] The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)")
-	cleanupCmd.MarkFlagRequired("cluster-id")
+
+	_ = cleanupCmd.MarkFlagRequired("cluster-id")
 
 	return cleanupCmd
 }

--- a/cmd/cluster/checkbanneduser.go
+++ b/cmd/cluster/checkbanneduser.go
@@ -23,7 +23,7 @@ func newCmdCheckBannedUser() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&clusterID, "cluster-id", "c", "", "Provide internal ID of the cluster")
-	cmd.MarkFlagRequired("cluster-id")
+	_ = cmd.MarkFlagRequired("cluster-id")
 
 	return cmd
 }

--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -33,8 +33,8 @@ import (
 
 const (
 	JiraBaseURL                   = "https://issues.redhat.com"
-	JiraTokenRegistrationPath     = "/secure/ViewProfile.jspa?selectedTab=com.atlassian.pats.pats-plugin:jira-user-personal-access-tokens"
-	PagerDutyTokenRegistrationUrl = "https://martindstone.github.io/PDOAuth/"
+	JiraTokenRegistrationPath     = "/secure/ViewProfile.jspa?selectedTab=com.atlassian.pats.pats-plugin:jira-user-personal-access-tokens" // #nosec G101
+	PagerDutyTokenRegistrationUrl = "https://martindstone.github.io/PDOAuth/"                                                              // #nosec G101
 	ClassicSplunkURL              = "https://osdsecuritylogs.splunkcloud.com/en-US/app/search/search?q=search%%20index%%3D%%22%s%%22%%20clusterid%%3D%%22%s%%22\n\n"
 	HCPSplunkURL                  = "https://osdsecuritylogs.splunkcloud.com/en-US/app/search/search?q=search%%20index%%3D%%22%s%%22%%20annotations.managed.openshift.io%%2Fhosted-cluster-id%%3Docm-%s-%s-%s\n\n"
 	shortOutputConfigValue        = "short"

--- a/cmd/cluster/etcd_replace.go
+++ b/cmd/cluster/etcd_replace.go
@@ -53,9 +53,9 @@ func newCmdEtcdMemberReplacement() *cobra.Command {
 	replaceCmd.Flags().StringVar(&opts.clusterID, "cluster-id", "", "Provide internal Cluster ID")
 	replaceCmd.Flags().StringVar(&opts.nodeId, "node", "", "Node ID (required)")
 	replaceCmd.Flags().StringVar(&opts.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket)")
-	replaceCmd.MarkFlagRequired("cluster-id")
-	replaceCmd.MarkFlagRequired("node")
-	replaceCmd.MarkFlagRequired("reason")
+	_ = replaceCmd.MarkFlagRequired("cluster-id")
+	_ = replaceCmd.MarkFlagRequired("node")
+	_ = replaceCmd.MarkFlagRequired("reason")
 	return replaceCmd
 }
 
@@ -157,8 +157,8 @@ func (opts *etcdOptions) removeEtcdMember(kconfig *rest.Config, clientset *kuber
 		return fmt.Errorf("operation cancelled by user")
 	}
 
-	remove_cmd := "etcdctl member remove " + memberId
-	output, err := Etcdctlhealth(kconfig, clientset, remove_cmd, pod)
+	removeCmd := "etcdctl member remove " + memberId
+	output, err := Etcdctlhealth(kconfig, clientset, removeCmd, pod)
 	if err != nil {
 		fmt.Println("[ERROR] Could not replace pod. Refer error below")
 		return err

--- a/cmd/cluster/hypershift_info.go
+++ b/cmd/cluster/hypershift_info.go
@@ -379,7 +379,10 @@ func (i *infoOptions) getAWSSessions(clusters *infoClusters) (*hypershiftAWSClie
 	customerConfig, err := osdCloud.CreateAWSV2Config(ocmClient, clusters.customerCluster)
 	// We have to overwrite the fact that backplane just mangled our configuration.
 	// TODO: Do not use the global configuration instead (https://issues.redhat.com/browse/OSD-19773)
-	osdctlConfig.EnsureConfigFile()
+	err = osdctlConfig.EnsureConfigFile()
+	if err != nil {
+		return nil, err
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cluster/resize/controlplane_node.go
+++ b/cmd/cluster/resize/controlplane_node.go
@@ -76,9 +76,9 @@ func newCmdResizeControlPlane() *cobra.Command {
 	resizeControlPlaneNodeCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "c", "", "The internal ID of the cluster to perform actions on")
 	resizeControlPlaneNodeCmd.Flags().StringVar(&ops.newMachineType, "machine-type", "", "The target AWS machine type to resize to (e.g. m5.2xlarge)")
 	resizeControlPlaneNodeCmd.Flags().StringVar(&ops.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket)")
-	resizeControlPlaneNodeCmd.MarkFlagRequired("cluster-id")
-	resizeControlPlaneNodeCmd.MarkFlagRequired("machine-type")
-	resizeControlPlaneNodeCmd.MarkFlagRequired("reason")
+	_ = resizeControlPlaneNodeCmd.MarkFlagRequired("cluster-id")
+	_ = resizeControlPlaneNodeCmd.MarkFlagRequired("machine-type")
+	_ = resizeControlPlaneNodeCmd.MarkFlagRequired("reason")
 
 	return resizeControlPlaneNodeCmd
 }

--- a/cmd/cluster/ssh/key.go
+++ b/cmd/cluster/ssh/key.go
@@ -121,7 +121,10 @@ func PrintKey(identifier string, opts *clusterSSHKeyOpts) error {
 	}
 
 	scheme := runtime.NewScheme()
-	corev1.AddToScheme(scheme)
+	err = corev1.AddToScheme(scheme)
+	if err != nil {
+		return fmt.Errorf("failed to add corev1 api scheme: %w", err)
+	}
 	hiveClient, err := k8s.NewAsBackplaneClusterAdmin(hive.ID(), client.Options{Scheme: scheme}, []string{
 		opts.elevationReason,
 		fmt.Sprintf("Need elevation for %s hive cluster in order to get ssh key for %s", hive.ID(), clusterID),

--- a/cmd/cluster/support/delete.go
+++ b/cmd/cluster/support/delete.go
@@ -52,7 +52,7 @@ func newCmddelete(streams genericclioptions.IOStreams, globalOpts *globalflags.G
 	deleteCmd.Flags().BoolVarP(&ops.verbose, "verbose", "", false, "Verbose output")
 
 	// Mark cluster-id as required
-	deleteCmd.MarkFlagRequired("cluster-id")
+	_ = deleteCmd.MarkFlagRequired("cluster-id")
 
 	return deleteCmd
 }

--- a/cmd/cluster/support/status.go
+++ b/cmd/cluster/support/status.go
@@ -35,8 +35,9 @@ func newCmdstatus(streams genericclioptions.IOStreams, globalOpts *globalflags.G
 	}
 
 	statusCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "c", "", "Cluster ID for which to get support status")
-	statusCmd.MarkFlagRequired("cluster-id")
 	statusCmd.Flags().BoolVarP(&ops.verbose, "verbose", "", false, "Verbose output")
+
+	_ = statusCmd.MarkFlagRequired("cluster-id")
 
 	return statusCmd
 }

--- a/cmd/cost/list_test.go
+++ b/cmd/cost/list_test.go
@@ -65,10 +65,10 @@ func TestPrintCostList(t *testing.T) {
 			r, w, _ := os.Pipe()
 			os.Stdout = w
 			printCostList(tt.cost, tt.unit, tt.ou, tt.ops, tt.isChild)
-			w.Close()
+			_ = w.Close()
 			os.Stdout = oldStdout
 			var buf bytes.Buffer
-			buf.ReadFrom(r)
+			_, _ = buf.ReadFrom(r)
 			output := buf.String()
 
 			if tt.isJSON {

--- a/cmd/dynatrace/urlCmd.go
+++ b/cmd/dynatrace/urlCmd.go
@@ -25,7 +25,7 @@ func newCmdURL() *cobra.Command {
 	}
 
 	urlCmd.Flags().StringVar(&clusterID, "cluster-id", "", "ID of the cluster")
-	urlCmd.MarkFlagRequired("cluster-id")
+	_ = urlCmd.MarkFlagRequired("cluster-id")
 
 	return urlCmd
 }

--- a/cmd/env/env.go
+++ b/cmd/env/env.go
@@ -265,7 +265,7 @@ func (e *OcEnv) Delete() {
 
 func (e *OcEnv) ensureEnvDir() {
 	if _, err := os.Stat(e.Path); errors.Is(err, os.ErrNotExist) {
-		err := os.MkdirAll(e.Path, os.ModePerm)
+		err := os.MkdirAll(e.Path, 0750)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -310,7 +310,7 @@ var f embed.FS
 
 func (e *OcEnv) createBins() {
 	if _, err := os.Stat(e.binPath()); errors.Is(err, os.ErrNotExist) {
-		err := os.Mkdir(e.binPath(), os.ModePerm)
+		err := os.Mkdir(e.binPath(), 0750)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/hcp/mustgather/mustGather.go
+++ b/cmd/hcp/mustgather/mustGather.go
@@ -107,7 +107,10 @@ func (mg *mustGather) Run() error {
 	tarballName := fmt.Sprintf("cluster_dump_%s_%s.tar.gz", mg.clusterId, timestamp)
 	outputTarballTmp := fmt.Sprintf("%s/%s", baseDir, tarballName)
 	outputTarballPath := fmt.Sprintf("%s/%s", outputDir, tarballName)
-	os.MkdirAll(outputDir, os.ModePerm)
+	err = os.MkdirAll(outputDir, 0750)
+	if err != nil {
+		return err
+	}
 
 	// Prints with color :)
 	fmt.Printf("\033[1;34mCreating must-gather with targets '%s'. Output directory: '%s'\033[0m\n", mg.gatherTargets, outputDir)

--- a/cmd/hcp/mustgather/mustGather_test.go
+++ b/cmd/hcp/mustgather/mustGather_test.go
@@ -66,7 +66,7 @@ func TestCreateKubeconfigFileForRestConfig_Success(t *testing.T) {
 // Test creating a tarball with actual files in a directory
 func TestCreateTarball_Success(t *testing.T) {
 	dir := "/tmp/osdctl-targz-test"
-	err := os.MkdirAll(dir, 0755)
+	err := os.MkdirAll(dir, 0750)
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 

--- a/cmd/iampermissions/diff.go
+++ b/cmd/iampermissions/diff.go
@@ -45,8 +45,8 @@ func newCmdDiff() *cobra.Command {
 
 	policyCmd.Flags().StringVarP(&ops.BaseVersion, baseVersionFlagName, "b", "", "")
 	policyCmd.Flags().StringVarP(&ops.TargetVersion, targetVersionFlagName, "t", "", "")
-	policyCmd.MarkFlagRequired(baseVersionFlagName)
-	policyCmd.MarkFlagRequired(targetVersionFlagName)
+	_ = policyCmd.MarkFlagRequired(baseVersionFlagName)
+	_ = policyCmd.MarkFlagRequired(targetVersionFlagName)
 
 	return policyCmd
 }

--- a/cmd/iampermissions/get.go
+++ b/cmd/iampermissions/get.go
@@ -37,7 +37,7 @@ func newCmdGet() *cobra.Command {
 	}
 
 	policyCmd.Flags().StringVarP(&ops.ReleaseVersion, "release-version", "r", "", "")
-	policyCmd.MarkFlagRequired("release-version")
+	_ = policyCmd.MarkFlagRequired("release-version")
 
 	return policyCmd
 }

--- a/cmd/iampermissions/save.go
+++ b/cmd/iampermissions/save.go
@@ -58,14 +58,14 @@ func newCmdSave() *cobra.Command {
 	saveCmd.Flags().StringVarP(&op.ReleaseVersion, "release-version", "r", "", "ocp version for which the policies should be downloaded")
 	saveCmd.Flags().BoolVarP(&op.Force, "force", "f", false, "Overwrite existing files")
 
-	saveCmd.MarkFlagRequired("dir")
-	saveCmd.MarkFlagRequired("release-version")
+	_ = saveCmd.MarkFlagRequired("dir")
+	_ = saveCmd.MarkFlagRequired("release-version")
 
 	return saveCmd
 }
 
 func (o *saveOptions) run() error {
-	if err := o.MkdirAll(o.OutFolder, 0755); err != nil {
+	if err := o.MkdirAll(o.OutFolder, 0750); err != nil {
 		return err
 	}
 
@@ -126,7 +126,7 @@ func (o *saveOptions) run() error {
 			continue
 		}
 
-		o.Print("Writing %s\n", path)
+		_, _ = o.Print("Writing %s\n", path)
 		if err := o.WriteFile(path, content, 0600); err != nil {
 			return err
 		}

--- a/cmd/jumphost/create.go
+++ b/cmd/jumphost/create.go
@@ -78,9 +78,9 @@ func newCmdCreateJumphost() *cobra.Command {
 		},
 	}
 
-	// create.Flags().StringVarP(&clusterId, "cluster-id", "c", "", "OCM internal/external cluster id trying to access via a jumphost")
 	create.Flags().StringVar(&subnetId, "subnet-id", "", "public subnet id to create a jumphost in")
-	create.MarkFlagRequired("subnet-id")
+
+	_ = create.MarkFlagRequired("subnet-id")
 
 	return create
 }

--- a/cmd/jumphost/create_test.go
+++ b/cmd/jumphost/create_test.go
@@ -302,7 +302,7 @@ func TestCreateKeyPair(t *testing.T) {
 				data, err := os.ReadFile(j.keyFilepath)
 				assert.NoError(t, err, "should be able to read the key file")
 				assert.Equal(t, tt.expectedKey, string(data), "private key should match")
-				os.Remove(j.keyFilepath) // Cleanup
+				_ = os.Remove(j.keyFilepath) // Cleanup
 			} else {
 				assert.Empty(t, j.keyFilepath, "key file path should be empty on failure")
 			}

--- a/cmd/jumphost/delete.go
+++ b/cmd/jumphost/delete.go
@@ -69,7 +69,8 @@ func newCmdDeleteJumphost() *cobra.Command {
 	}
 
 	create.Flags().StringVar(&subnetId, "subnet-id", "", "subnet id to search for and delete a jumphost in")
-	create.MarkFlagRequired("subnet-id")
+
+	_ = create.MarkFlagRequired("subnet-id")
 
 	return create
 }

--- a/cmd/org/aws-accounts.go
+++ b/cmd/org/aws-accounts.go
@@ -85,7 +85,10 @@ func printAccounts(children *organizations.ListChildrenOutput) {
 		}
 
 		table.AddRow([]string{})
-		table.Flush()
+		err := table.Flush()
+		if err != nil {
+			panic(err)
+		}
 	}
 
 }

--- a/cmd/org/common.go
+++ b/cmd/org/common.go
@@ -73,7 +73,7 @@ func printOrg(org Organization) {
 		table.AddRow([]string{"Updated:", org.Updated})
 
 		table.AddRow([]string{})
-		table.Flush()
+		_ = table.Flush()
 	}
 }
 

--- a/cmd/org/customers_test.go
+++ b/cmd/org/customers_test.go
@@ -17,7 +17,7 @@ var (
 	testToken, _  = jwt.New(jwt.SigningMethodHS256).SignedString([]byte("test-secret"))
 	clientID      = "fake-id"
 	clientSecret  = "fake-secret"
-	tokenPath     = "/fake-path/token"
+	tokenPath     = "/fake-path/token" // #nosec G101
 	testCustomers = []Customer{
 		{ID: "cust-1", OrganizationID: "org-1", SKU: "sku-1"},
 		{ID: "cust-2", OrganizationID: "org-2", SKU: "sku-2"},

--- a/cmd/org/describe_test.go
+++ b/cmd/org/describe_test.go
@@ -17,7 +17,7 @@ func TestDescribeOrg(t *testing.T) {
 	testToken, _ := jwt.New(jwt.SigningMethodHS256).SignedString([]byte("test-secret"))
 	clientID := "fake-id"
 	clientSecret := "fake-secret"
-	tokenPath := "/fake-path/token"
+	tokenPath := "/fake-path/token" // #nosec G101
 
 	tokenResponse := map[string]interface{}{
 		"access_token": testToken,

--- a/cmd/org/get_test.go
+++ b/cmd/org/get_test.go
@@ -107,8 +107,8 @@ func TestGetSearchQuery(t *testing.T) {
 func TestSearchOrgs(t *testing.T) {
 	testToken, _ = jwt.New(jwt.SigningMethodHS256).SignedString([]byte("test-secret"))
 	clientID = "fake-id"
-	clientSecret = "fake-secret"
-	tokenPath = "/fake-path/token"
+	clientSecret = "fake-secret"   // #nosec G101
+	tokenPath = "/fake-path/token" // #nosec G101
 	tokenResponse := map[string]interface{}{
 		"access_token": testToken,
 		"token_type":   "Bearer",

--- a/cmd/promote/dynatrace/dt_app_interface.go
+++ b/cmd/promote/dynatrace/dt_app_interface.go
@@ -145,7 +145,7 @@ func (a AppInterface) UpdateAppInterface(component, saasFile, currentGitHash, pr
 	// Replace the hash in the file content
 	newContent := strings.ReplaceAll(string(fileContent), currentGitHash, promotionGitHash)
 
-	err = os.WriteFile(saasFile, []byte(newContent), 0644)
+	err = os.WriteFile(saasFile, []byte(newContent), 0600)
 	if err != nil {
 		return fmt.Errorf("failed to write to file %s: %v", saasFile, err)
 	}
@@ -170,7 +170,7 @@ func (a AppInterface) UpdatePackageTag(saasFile, oldTag, promotionTag, branchNam
 	// Replace the hash in the file content
 	newContent := strings.ReplaceAll(string(fileContent), oldTag, promotionTag)
 
-	err = os.WriteFile(saasFile, []byte(newContent), 0644)
+	err = os.WriteFile(saasFile, []byte(newContent), 0600)
 	if err != nil {
 		return fmt.Errorf("failed to write to file %s: %v", saasFile, err)
 	}

--- a/cmd/promote/dynatrace/tf_file_update.go
+++ b/cmd/promote/dynatrace/tf_file_update.go
@@ -39,7 +39,7 @@ func UpdateDefaultValue(file *hclwrite.File, name string, value string) bool {
 }
 
 func Save(filename string, file *hclwrite.File) error {
-	if err := os.WriteFile(filename, file.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(filename, file.Bytes(), 0600); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/promote/dynatrace/tf_file_update_test.go
+++ b/cmd/promote/dynatrace/tf_file_update_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Dynatrace", func() {
 		Expect(err).NotTo(HaveOccurred())
 		testFilePath = filepath.Join(tempDir, "test.hcl")
 		content := `module "example" { source = "old_value" }`
-		_ = os.WriteFile(testFilePath, []byte(content), 0644)
+		_ = os.WriteFile(testFilePath, []byte(content), 0600)
 	})
 
 	AfterEach(func() {
@@ -33,7 +33,7 @@ var _ = Describe("Dynatrace", func() {
 	Describe("Open", func() {
 		BeforeEach(func() {
 			content := `module "example" { source = "old_value" }`
-			_ = os.WriteFile(testFilePath, []byte(content), 0644)
+			_ = os.WriteFile(testFilePath, []byte(content), 0600)
 		})
 
 		It("should open an existing HCL file successfully", func() {
@@ -90,7 +90,7 @@ var _ = Describe("Dynatrace", func() {
 
 		It("should return an error if the file cannot be written", func() {
 			file := hclwrite.NewEmptyFile()
-			_ = os.Mkdir("output.hcl", 0755) // Create a directory instead of a file
+			_ = os.Mkdir("output.hcl", 0750) // Create a directory instead of a file
 			err := dynatrace.Save("output.hcl", file)
 			Expect(err).To(HaveOccurred())
 			_ = os.Remove("output.hcl")

--- a/cmd/promote/git/app_interface.go
+++ b/cmd/promote/git/app_interface.go
@@ -278,7 +278,7 @@ func (a AppInterface) UpdateAppInterface(serviceName, saasFile, currentGitHash, 
 		newContent = strings.ReplaceAll(string(fileContent), currentGitHash, promotionGitHash)
 	}
 
-	err = os.WriteFile(saasFile, []byte(newContent), 0644)
+	err = os.WriteFile(saasFile, []byte(newContent), 0600)
 	if err != nil {
 		return fmt.Errorf("failed to write to file %s: %v", saasFile, err)
 	}
@@ -305,7 +305,7 @@ func (a AppInterface) UpdatePackageTag(saasFile, oldTag, promotionTag, branchNam
 	// Replace the hash in the file content
 	newContent := strings.ReplaceAll(string(fileContent), oldTag, promotionTag)
 
-	err = os.WriteFile(saasFile, []byte(newContent), 0644)
+	err = os.WriteFile(saasFile, []byte(newContent), 0600)
 	if err != nil {
 		return fmt.Errorf("failed to write to file %s: %v", saasFile, err)
 	}

--- a/cmd/promote/git/app_interface_test.go
+++ b/cmd/promote/git/app_interface_test.go
@@ -71,7 +71,7 @@ func TestCommitSaasFile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			file := filepath.Join(tmpDir, "saas.yaml")
-			_ = os.WriteFile(file, []byte("dummy content"), 0644)
+			_ = os.WriteFile(file, []byte("dummy content"), 0600)
 
 			mockExec := new(MockExec)
 			tc.setupMock(mockExec, tmpDir, file, tc.commitMessage)
@@ -332,7 +332,7 @@ resourceTemplates: []
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			saasFilePath := filepath.Join(tmpDir, "saas.yaml")
-			err := os.WriteFile(saasFilePath, []byte(tt.yamlData), 0644)
+			err := os.WriteFile(saasFilePath, []byte(tt.yamlData), 0600)
 			require.NoError(t, err)
 
 			actual, err := GetCurrentPackageTagFromAppInterface(saasFilePath)
@@ -364,7 +364,7 @@ func TestUpdatePackageTag(t *testing.T) {
 				tmpDir := t.TempDir()
 				saasFile := filepath.Join(tmpDir, "test.yaml")
 
-				_ = os.WriteFile(saasFile, []byte("tag: old123"), 0644)
+				_ = os.WriteFile(saasFile, []byte("tag: old123"), 0600)
 
 				mockExec.On("Run", tmpDir, "git", []string{"checkout", "master"}).Return(nil).Once()
 				mockExec.On("Run", tmpDir, "git", []string{"branch", "-D", "feature-branch"}).Return(errors.New("branch does not exist")).Once()
@@ -384,7 +384,7 @@ func TestUpdatePackageTag(t *testing.T) {
 				tmpDir := t.TempDir()
 				saasFile := filepath.Join(tmpDir, "test.yaml")
 
-				_ = os.WriteFile(saasFile, []byte("tag: old123"), 0644)
+				_ = os.WriteFile(saasFile, []byte("tag: old123"), 0600)
 
 				mockExec.On("Run", tmpDir, "git", []string{"checkout", "master"}).Return(errors.New("checkout failed")).Once()
 
@@ -490,7 +490,7 @@ resourceTemplates:
       - name: "target-canary"
         ref: "currentGitHash"
 `
-				if err := os.WriteFile(saas_file, []byte(yaml_content), 0644); err != nil {
+				if err := os.WriteFile(saas_file, []byte(yaml_content), 0600); err != nil {
 					t.Fatalf("failed to write saas file: %v", err)
 				}
 
@@ -525,7 +525,7 @@ resourceTemplates:
       - name: "target-prod"
         ref: "currentGitHash"
 `
-				if err := os.WriteFile(saas_file, []byte(yaml_content), 0644); err != nil {
+				if err := os.WriteFile(saas_file, []byte(yaml_content), 0600); err != nil {
 					t.Fatalf("failed to write saas file: %v", err)
 				}
 

--- a/cmd/promote/saas/saas.go
+++ b/cmd/promote/saas/saas.go
@@ -2,8 +2,6 @@ package saas
 
 import (
 	"fmt"
-	"os"
-
 	"github.com/openshift/osdctl/cmd/promote/git"
 	"github.com/openshift/osdctl/cmd/promote/iexec"
 	"github.com/spf13/cobra"
@@ -36,33 +34,31 @@ func NewCmdSaas() *cobra.Command {
 		osdctl promote saas --serviceName <service-name> --gitHash <git-hash> --osd
 		or
 		osdctl promote saas --serviceName <service-name> --gitHash <git-hash> --hcp`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			ops.validateSaasFlow()
 			appInterface := git.BootstrapOsdCtlForAppInterfaceAndServicePromotions(ops.appInterfaceCheckoutDir)
 			appInterface.GitExecutor = iexec.Exec{}
 			if ops.list {
 				if ops.serviceName != "" || ops.gitHash != "" || ops.osd || ops.hcp {
 					fmt.Printf("Error: --list cannot be used with any other flags\n\n")
-					cmd.Help()
-					os.Exit(1)
+
+					return cmd.Help()
 				}
-				listServiceNames(appInterface)
-				os.Exit(0)
+				return listServiceNames(appInterface)
 			}
 
 			if !(ops.osd || ops.hcp) && ops.serviceName != "" {
 				fmt.Printf("Error: --serviceName cannot be used without either --osd or --hcp\n\n")
-				cmd.Help()
-				os.Exit(1)
+
+				return cmd.Help()
 			}
 
 			err := servicePromotion(appInterface, ops.serviceName, ops.gitHash, ops.namespaceRef, ops.osd, ops.hcp)
 			if err != nil {
 				fmt.Printf("Error while promoting service: %v\n", err)
-				os.Exit(1)
 			}
 
-			os.Exit(0)
+			return nil
 		},
 	}
 

--- a/cmd/servicelog/post_test.go
+++ b/cmd/servicelog/post_test.go
@@ -186,7 +186,7 @@ var _ = Describe("Test posting service logs", func() {
 		It("reads a URL successfully", func() {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("test content"))
+				_, _ = w.Write([]byte("test content"))
 			}))
 			defer server.Close()
 
@@ -547,7 +547,7 @@ func TestReadTemplate(t *testing.T) {
 					"description": "Test Description",
 					"internal_only": true
 				}`
-				if err := os.WriteFile("template.json", []byte(fileContent), 0644); err != nil {
+				if err := os.WriteFile("template.json", []byte(fileContent), 0600); err != nil {
 					t.Fatalf("Failed to create template file: %v", err)
 				}
 			},
@@ -562,7 +562,7 @@ func TestReadTemplate(t *testing.T) {
 			tt.options.readTemplate()
 			assert.Equal(t, tt.expectedMsg, tt.options.Message)
 			if tt.options.Template == "template.json" {
-				os.Remove(tt.options.Template)
+				_ = os.Remove(tt.options.Template)
 			}
 		})
 	}
@@ -639,7 +639,7 @@ func TestReadFilterFile(t *testing.T) {
 			tt.options.readFilterFile()
 			assert.Equal(t, tt.expectedFilter, tt.options.filtersFromFile)
 			for _, filterFile := range tt.options.filterFiles {
-				os.Remove(filterFile)
+				_ = os.Remove(filterFile)
 			}
 		})
 	}

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -16,20 +16,20 @@ const (
 	ProdJumproleConfigKey   = "prod_jumprole_account_id"
 	AwsProxy                = "aws_proxy"
 	StageJumproleConfigKey  = "stage_jumprole_account_id"
-	PdUserToken             = "pd_user_token"
+	PdUserToken             = "pd_user_token" // #nosec G101
 	JiraToken               = "jira_token"
 	DtVaultPath             = "dt_vault_path"
 	VaultAddress            = "vault_address"
 	CloudTrailCmdLists      = "cloudtrail_cmd_lists"
 	GitLabToken             = "gitlab_access"
-	JiraTokenRegex          = "^[A-Z0-9]{7}$"
-	PdTokenRegex            = "^[a-zA-Z0-9+_-]{20}$"
+	JiraTokenRegex          = "^[A-Z0-9]{7}$"        // #nosec G101
+	PdTokenRegex            = "^[a-zA-Z0-9+_-]{20}$" // #nosec G101
 	AwsAccountRegex         = "^[0-9]{12}$"
 	AWSProxyRegex           = `^http:\/\/[a-zA-Z0-9.-]+(:\d+)?$`
 	VaultURLRegex           = `^https:\/\/[a-zA-Z0-9.-]+\/?$`
 	DtVaultPathRegex        = `^[a-zA-Z0-9\-/]+$`
 	CloudTrailCmdListsRegex = `^\s*-\s+.*$`
-	GitLabTokenRegex        = `^[a-zA-Z0-9]{20}$`
+	GitLabTokenRegex        = `^[a-zA-Z0-9]{20}$` // #nosec G101
 )
 
 // NewCmdSetup implements the setup command

--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -48,7 +48,7 @@ func CreateFile(filepath string) error {
 
 	// Create the parent directory if doesn't exist
 	if directory := osFile.Dir(filepath); !FolderExists(directory) {
-		if err := os.MkdirAll(directory, os.ModePerm); err != nil {
+		if err := os.MkdirAll(directory, 0750); err != nil {
 			return fmt.Errorf("failed to create directory %v", directory)
 		}
 	}

--- a/pkg/docgen/docgen.go
+++ b/pkg/docgen/docgen.go
@@ -112,7 +112,7 @@ func GenerateDocs(opts *Options) error {
 		opts = NewDefaultOptions()
 	}
 
-	if err := os.MkdirAll(opts.DocsDir, 0755); err != nil {
+	if err := os.MkdirAll(opts.DocsDir, 0750); err != nil {
 		return fmt.Errorf("creating docs directory: %w", err)
 	}
 

--- a/pkg/envConfig/config.go
+++ b/pkg/envConfig/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"encoding/json"
 	"log"
 	"os"
 	"path/filepath"
@@ -52,41 +51,19 @@ func LoadYaml(paramFilePath string) Config {
 	return config
 }
 
-func LoadPDConfig(paramFilePath string) PDConfig {
-	config := PDConfig{
-		MySubdomain: []Subdomain{},
-	}
-
-	configFilePath := os.Getenv("HOME") + paramFilePath
-	configFilePath = filepath.Clean(configFilePath)
-	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
-		log.Println("Config does not exist")
-		return config
-	}
-
-	// ignore linter error: filepath has to be static
-	jsonFile, err := os.ReadFile(configFilePath) //#nosec G304 -- filepath cannot be constant
-	if err != nil {
-		log.Printf("Failed to read PagerDuty config json %s: %v ", configFilePath, err)
-	}
-
-	err = json.Unmarshal(jsonFile, &config)
-	if err != nil {
-		log.Fatalf("Failed to unmarshal PagerDuty config json %s: %v", configFilePath, err)
-	}
-	return config
-}
-
 // Loads ~/.config/osdctl
 func LoadCloudTrailConfig() ([]string, error) {
 	var configuration *CloudTrailConfig
-	osdctlConfig.EnsureConfigFile()
-	err := viper.Unmarshal(&configuration)
+	err := osdctlConfig.EnsureConfigFile()
+	if err != nil {
+		return nil, err
+	}
+
+	err = viper.Unmarshal(&configuration)
 	if err != nil {
 		log.Printf("[ERROR] Failed to unmarshal Cloudtrail config yaml %s %v", viper.ConfigFileUsed(), err)
 		return nil, err
 	}
-	osdctlConfig.EnsureConfigFile()
 
 	return configuration.CloudTrailList.FilterPatternList, err
 }

--- a/pkg/osdCloud/aws.go
+++ b/pkg/osdCloud/aws.go
@@ -354,7 +354,7 @@ func (a *AwsCluster) GetAllVirtualMachines(string) ([]VirtualMachine, error) {
 		}
 		for idx := range instances.Reservations {
 			for _, instance := range instances.Reservations[idx].Instances {
-				stringTags := make(map[string]string, 0)
+				stringTags := make(map[string]string)
 				var name string
 				size := instance.InstanceType
 				state := instance.State.Name

--- a/pkg/osdCloud/gcp.go
+++ b/pkg/osdCloud/gcp.go
@@ -96,7 +96,7 @@ func (g *GcpCluster) Login() error {
 
 func (g *GcpCluster) Close() {
 	if g.ComputeClient != nil {
-		g.ComputeClient.Close()
+		_ = g.ComputeClient.Close()
 	}
 }
 

--- a/pkg/osdctlConfig/osdctlConfig.go
+++ b/pkg/osdctlConfig/osdctlConfig.go
@@ -19,7 +19,7 @@ func EnsureConfigFile() error {
 	configFileDir := configHomePath + "/.config/"
 	configFilePath := configFileDir + ConfigFileName
 	if _, err := os.Stat(configFilePath); errors.Is(err, os.ErrNotExist) {
-		err = os.MkdirAll(configFileDir, 0755)
+		err = os.MkdirAll(configFileDir, 0750)
 		if err != nil {
 			return err
 		}

--- a/pkg/provider/pagerduty/pagerduty.go
+++ b/pkg/provider/pagerduty/pagerduty.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	PagerDutyUserTokenConfigKey  = "pd_user_token"
-	PagerDutyOauthTokenConfigKey = "pd_oauth_token"
+	PagerDutyUserTokenConfigKey  = "pd_user_token"  // #nosec G101
+	PagerDutyOauthTokenConfigKey = "pd_oauth_token" // #nosec G101
 	PagerDutyTeamIDsKey          = "team_ids"
 )
 


### PR DESCRIPTION
After reviewing our prow config I noticed that we are never actually running linting, which means this project has gotten really behind in linting failures. https://github.com/openshift/release/blob/cdb6d2d55b95d6b8e84ea547dc9ad9b6337a6614/ci-operator/config/openshift/osdctl/openshift-osdctl-master.yaml#L26-L30

I upgraded to `golangci-lint` v2, including the config file we use in `boilerplate`, and configured it to ignore any failures prior to the latest commit for the project.

The reason I did that is I spent 2 hours fixing failures and there are still so many. This way we can fix them in batches, while ensuring any new PRs start getting linting.

Once this merges I will open a PR on `openshift/release` to fix the lint target.