### PR TITLE
Restarted/Cycled pod logs by namespace in DT gather-logs

### DIFF
--- a/cmd/dynatrace/hcpGatherLogsCmd.go
+++ b/cmd/dynatrace/hcpGatherLogsCmd.go
@@ -115,11 +115,9 @@ func (g *GatherLogsOpts) GatherLogs(clusterID string) (error error) {
 			return err
 		}
 
-		if gatherNS != "" {
-			err = g.dumpRestartedPodLogs(pods, nsDir, gatherNS, hcpCluster.managementClusterName, hcpCluster.DynatraceURL, accessToken)
-			if err != nil {
-				return err
-			}
+		err = g.dumpRestartedPodLogs(pods, nsDir, gatherNS, hcpCluster.managementClusterName, hcpCluster.DynatraceURL, accessToken)
+		if err != nil {
+			return err
 		}
 
 	}

--- a/cmd/dynatrace/hcpGatherLogsCmd.go
+++ b/cmd/dynatrace/hcpGatherLogsCmd.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/openshift/osdctl/cmd/common"
 	"github.com/spf13/cobra"
@@ -112,6 +113,13 @@ func (g *GatherLogsOpts) GatherLogs(clusterID string) (error error) {
 		err = g.dumpEvents(deployments, nsDir, gatherNS, hcpCluster.managementClusterName, hcpCluster.DynatraceURL, accessToken, g.Since, g.Tail, g.SortOrder)
 		if err != nil {
 			return err
+		}
+
+		if gatherNS != "" {
+			err = g.dumpRestartedPodLogs(pods, nsDir, gatherNS, hcpCluster.managementClusterName, hcpCluster.DynatraceURL, accessToken)
+			if err != nil {
+				return err
+			}
 		}
 
 	}
@@ -232,6 +240,45 @@ func (g *GatherLogsOpts) dumpPodLogs(pods *corev1.PodList, parentDir string, tar
 	return nil
 }
 
+func (g *GatherLogsOpts) dumpRestartedPodLogs(pods *corev1.PodList, parentDir string, targetNS string, managementClusterName string, DTURL string, accessToken string) error {
+	var podList []string
+	for _, p := range pods.Items {
+		podList = append(podList, p.Name)
+	}
+	fmt.Printf("Collecting Restarted Pod logs for %s\n", targetNS)
+
+	restartedPodLogsQuery, err := getRestartedPodQuery(podList, targetNS, g.Since, g.Tail, g.SortOrder, managementClusterName)
+	if err != nil {
+		return err
+	}
+	restartedPodLogsQuery.Build()
+
+	restartedPodLogFileName := "pods.log"
+	podDirPath, err := addDir([]string{parentDir, "restarted-pods"}, []string{restartedPodLogFileName})
+	if err != nil {
+		return err
+	}
+
+	restartedPodLogsFilePath := filepath.Join(podDirPath, restartedPodLogFileName)
+	f, err := os.OpenFile(restartedPodLogsFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0655)
+	if err != nil {
+		return err
+	}
+
+	podLogsRequestToken, err := getDTQueryExecution(DTURL, accessToken, restartedPodLogsQuery.finalQuery)
+	if err != nil {
+		log.Print("failed to get request token", err)
+
+	}
+	err = getLogs(DTURL, accessToken, podLogsRequestToken, f)
+	f.Close()
+	if err != nil {
+		log.Printf("failed to get restarted pod logs: %v. Query: %v", err, restartedPodLogsQuery.finalQuery)
+	}
+
+	return nil
+}
+
 func setupGatherDir(destBaseDir string, dirName string) (logsDir string, error error) {
 	dirPath := filepath.Join(destBaseDir, fmt.Sprintf("hcp-logs-dump-%s", dirName))
 	err := os.MkdirAll(dirPath, 0750)
@@ -269,6 +316,38 @@ func getPodQuery(pod string, namespace string, since int, tail int, sortOrder st
 
 	if pod != "" {
 		q.Pods([]string{pod})
+	}
+
+	if sortOrder != "" {
+		q, err := q.Sort(sortOrder)
+		if err != nil {
+			return *q, err
+		}
+	}
+
+	if tail > 0 {
+		q.Limit(tail)
+	}
+
+	return q, nil
+}
+
+func getRestartedPodQuery(pods []string, namespace string, since int, tail int, sortOrder string, srcCluster string) (query DTQuery, error error) {
+	q := DTQuery{}
+	q.InitLogs(since).Cluster(srcCluster)
+
+	if namespace != "" {
+		q.Namespaces([]string{namespace})
+	}
+
+	if len(pods) > 0 {
+		q.Pods(pods)
+		for i := 0; i < len(q.fragments); i++ {
+			if strings.Contains(q.fragments[i], "k8s.pod.name") {
+				q.fragments[i] = strings.Replace(q.fragments[i], "and (", "and not (", 1)
+				break
+			}
+		}
 	}
 
 	if sortOrder != "" {


### PR DESCRIPTION
The `gather-logs` command will only gather the logs for the current running pods, the logs of the restarted/cycled pods will miss in the gather-logs.
Restarted/Cycled pod logs will now be available namespace wise and dumped under one file i.e. pods.log

Ref Tickets: https://issues.redhat.com/browse/OSD-24996