### PR TITLE
SREP-325: Use our `boilerplate` base image in CI

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
-  name: release
+  name: boilerplate
   namespace: openshift
-  tag: golang-1.23
+  tag: image-v7.2.0


### PR DESCRIPTION
Switch to using our base boilerplate image in CI, which provides the benefit of ensuring common tools like `golangci-lint` are installed.

Needed to resolve https://github.com/openshift/release/pull/64870