### PR TITLE
Fix: promote saas-osd-rhobs-rules-and-dashboards

### DIFF
--- a/cmd/promote/git/app_interface.go
+++ b/cmd/promote/git/app_interface.go
@@ -165,7 +165,7 @@ func GetCurrentGitHashFromAppInterface(saarYamlFile []byte, serviceName string, 
 	} else if strings.Contains(service.Name, "rhobs-rules-and-dashboards") {
 		for _, resourceTemplate := range service.ResourceTemplates {
 			for _, target := range resourceTemplate.Targets {
-				if strings.Contains(service.Name, "production") {
+				if strings.Contains(target.Namespace["$ref"], "production") {
 					currentGitHash = target.Ref
 					break
 				}


### PR DESCRIPTION
The promotions for `saas-osd-rhobs-rules-and-dashboards` failed because we're looking in the wrong place for the current hash. 
```
osdctl promote saas --serviceName saas-osd-rhobs-rules-and-dashboards --osd
### Checking if service saas-osd-rhobs-rules-and-dashboards exists ###
Service saas-osd-rhobs-rules-and-dashboards found
SAAS Directory: /home/cbusse/sandbox/app-interface/data/services/osd-operators/cicd/saas/saas-osd-rhobs-rules-and-dashboards.yaml
Error while promoting service: failed to get current git hash or service repo: production namespace not found for service saas-osd-rhobs-rules-and-dashboards
```

This PR fixes the logic to find the hash in the right place.

A successful promotion has been created with this build. 