### PR TITLE
Refactors version check logic

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"runtime/debug"
 	"strings"
@@ -249,7 +250,7 @@ func GetRegistryCredentials(connection *sdk.Connection, accountId string) ([]*am
 }
 
 func ConfirmPrompt() bool {
-	fmt.Print("Continue? (y/N): ")
+	fmt.Fprint(os.Stderr, "Continue? (y/N): ")
 
 	var response = "n"
 	_, _ = fmt.Scanln(&response) // Erroneous input will be handled by the default case below
@@ -260,7 +261,7 @@ func ConfirmPrompt() bool {
 	case "n", "no":
 		return false
 	default:
-		fmt.Println("Invalid input. Expecting (y)es or (N)o")
+		fmt.Fprintln(os.Stderr, "Invalid input. Expecting (y)es or (N)o")
 		return ConfirmPrompt()
 	}
 }

--- a/pkg/version_check/version_check.go
+++ b/pkg/version_check/version_check.go
@@ -1,0 +1,66 @@
+package version_check
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/slice"
+)
+
+// A list of command exempt from version checking
+var exemptCommands = []string{
+	"upgrade",
+	"version",
+}
+
+// Runs the Version Check, if necessary
+func Run(cmd *cobra.Command) error {
+	// We are explicitly not reading this from viper because we do not want to persistently override this
+	skipVersionCheck, err := cmd.Flags().GetBool("skip-version-check")
+	if err != nil {
+		return fmt.Errorf("flag --skip-version-check/-S undefined")
+	}
+
+	if shouldRunVersionCheck(skipVersionCheck, cmd.Use) {
+		latestVersion, err := utils.GetLatestVersion()
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, "WARN: Unable to verify that osdctl is running under the latest released version. Error trying to reach GitHub:")
+			_, _ = fmt.Fprintln(os.Stderr, err)
+			_, _ = fmt.Fprintln(os.Stderr, "Please be aware that you are possibly running an outdated or unreleased version.")
+		}
+
+		latestVersionTrimmed := trimVersionString(latestVersion)
+		currentVersionTrimmed := trimVersionString(utils.Version)
+
+		if latestVersionTrimmed != currentVersionTrimmed {
+			_, _ = fmt.Fprintf(os.Stderr, "WARN: The current version (%s) is different than the latest released version (%s). It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.\n", utils.Version, latestVersion)
+
+			if !utils.ConfirmPrompt() {
+				return fmt.Errorf("user exited")
+			}
+		}
+	}
+
+	return nil
+}
+
+// Checks if the version check should be run
+func shouldRunVersionCheck(skipVersionCheckFlag bool, commandName string) bool {
+
+	// If either are true, then the version check should NOT run, hence negation
+	return !(skipVersionCheckFlag || canCommandSkipVersionCheck(commandName))
+}
+
+func canCommandSkipVersionCheck(commandName string) bool {
+	// Checks if the specific command is in the allowlist
+	return slice.ContainsString(exemptCommands, commandName, nil)
+}
+
+func trimVersionString(version string) string {
+	version = strings.TrimPrefix(version, "v")
+	version, _, _ = strings.Cut(version, "-")
+	return version
+}

--- a/pkg/version_check/version_check_test.go
+++ b/pkg/version_check/version_check_test.go
@@ -1,0 +1,69 @@
+package version_check
+
+import "testing"
+
+func TestTrimVersionString(t *testing.T) {
+	tests := []struct {
+		expected string
+		given    string
+	}{
+		{
+			expected: "1.1.1",
+			given:    "1.1.1",
+		},
+		{
+			expected: "1.2.3",
+			given:    "v1.2.3",
+		},
+		{
+			expected: "2.3.4",
+			given:    "2.3.4-build",
+		},
+		{
+			expected: "3.4.5",
+			given:    "v3.4.5-next",
+		},
+	}
+
+	for _, test := range tests {
+		result := trimVersionString(test.given)
+		if test.expected != result {
+			t.Errorf("Expected %s, given %s, got %s", test.expected, test.given, result)
+		}
+	}
+}
+
+func TestShouldRunVersionCheck(t *testing.T) {
+	tests := []struct {
+		commandName    string
+		checkFlagValue bool
+		expected       bool
+	}{
+		{
+			commandName:    "upgrade",
+			checkFlagValue: false,
+			expected:       false,
+		},
+		{
+			commandName:    "version",
+			checkFlagValue: false,
+			expected:       false,
+		},
+		{
+			commandName:    "myCommand",
+			checkFlagValue: false,
+			expected:       true,
+		},
+		{
+			commandName:    "myCommand",
+			checkFlagValue: true,
+			expected:       false,
+		},
+	}
+
+	for _, test := range tests {
+		if shouldRunVersionCheck(test.checkFlagValue, test.commandName) != test.expected {
+			t.Errorf("Skip Version Check Test failed with incorrect result. Values: %+v", test)
+		}
+	}
+}


### PR DESCRIPTION
Additionally, ignores `-next` version differences for a better developer experience. Will still throw errors if you're not working from the same version without `-next` builds, or if you use `go build .` instead of `make build`.