### PR TITLE
Update DTP Labels to be derived from generic labels

### DIFF
--- a/pkg/utils/ocm.go
+++ b/pkg/utils/ocm.go
@@ -28,7 +28,7 @@ const (
 	integrationGovURL          = "https://api-admin.int.openshiftusgov.com"
 	stagingGovURL              = "https://api-admin.stage.openshiftusgov.com"
 	HypershiftClusterTypeLabel = "ext-hypershift.openshift.io/cluster-type"
-	DynatraceTenantKeyLabel    = "sre-capabilities.dtp.v2.tenant"
+	DynatraceTenantKeyLabel    = "dynatrace.regional-tenant"
 )
 
 var urlAliases = map[string]string{


### PR DESCRIPTION
As a part of https://issues.redhat.com/browse/APPSRE-11102, the DTP Tokens now provision both Regional and Global Tenant secrets. 
This also updates the DTP to v3 version which would break the osdctl code. Thus to avoid that we would now be using a generic label which is not affected by DTP version