### PR TITLE
OSD-30374: update long description based on SOP

### DIFF
--- a/cmd/jira/cmd.go
+++ b/cmd/jira/cmd.go
@@ -22,7 +22,7 @@ func init() {
 	createHandoverAnnouncmentCmd.Flags().String("products", "", "Comma-separated list of products (e.g. 'Product A,Product B')")
 	createHandoverAnnouncmentCmd.Flags().String("customer", "", "Customer name")
 	createHandoverAnnouncmentCmd.Flags().String("cluster", "", "Cluster ID")
-	createHandoverAnnouncmentCmd.Flags().String("version", "", "Affects version")
+	createHandoverAnnouncmentCmd.Flags().String("version", "", "Affected Openshift Version (e.g 4.16 or 4.15.32)")
 
 	flags := []string{"summary", "description", "products", "customer", "cluster", "version"}
 	for _, flag := range flags {

--- a/cmd/jira/handover.go
+++ b/cmd/jira/handover.go
@@ -14,9 +14,34 @@ import (
 
 const handoverAnnoucementsProjectID = 12351820
 
+const longDescription = `
+Create a new Handover announcement for SREPHOA Project. To fill the fields, use the following instructions:
+
+1. Cluster ID
+	- If a specific cluster is affected, enter the ID (internal or external).
+	- If not applicable: enter None, N/A, or All for fleet-wide impact.
+
+2. Customer Name 	
+	- Use the exact name from the output of the command you ran. Do not modify or abbreviate. Copy-paste exactly.
+	- If not applicable: enter None or N/A
+	Note : To find the Customer Name you can get it from ocm describe cluster | grep -i organization or run the following command ocm get $(ocm get $(ocm get cluster $CLUSTER_ID  | jq -r .subscription.href) | jq -r '.creator.href') |  jq -r '.organization.name'
+
+3. Version
+Use the Openshift version number in the format:
+	- 4.16 if it affects entire Y-stream versions
+	- 4.16.5 if it affects a specific version
+
+4. Product Type
+Select the appropriate product type:
+	- Choose Multiple if it affects the fleet
+	- Otherwise, select the specific product involved
+
+5. Description - Add a brief description of the announcement.`
+
 var createHandoverAnnouncmentCmd = &cobra.Command{
 	Use:   "create-handover-announcement",
 	Short: "Create a new Handover announcement for SREPHOA Project",
+	Long:  longDescription,
 	Run: func(cmd *cobra.Command, args []string) {
 		CreateHandoverAnnouncment()
 	},

--- a/docs/README.md
+++ b/docs/README.md
@@ -2722,7 +2722,29 @@ osdctl jira [flags]
 
 ### osdctl jira create-handover-announcement
 
-Create a new Handover announcement for SREPHOA Project
+
+Create a new Handover announcement for SREPHOA Project. To fill the fields, use the following instructions:
+
+1. Cluster ID
+	- If a specific cluster is affected, enter the ID (internal or external).
+	- If not applicable: enter None, N/A, or All for fleet-wide impact.
+
+2. Customer Name 	
+	- Use the exact name from the output of the command you ran. Do not modify or abbreviate. Copy-paste exactly.
+	- If not applicable: enter None or N/A
+	Note : To find the Customer Name you can get it from ocm describe cluster | grep -i organization or run the following command ocm get $(ocm get $(ocm get cluster $CLUSTER_ID  | jq -r .subscription.href) | jq -r '.creator.href') |  jq -r '.organization.name'
+
+3. Version
+Use the Openshift version number in the format:
+	- 4.16 if it affects entire Y-stream versions
+	- 4.16.5 if it affects a specific version
+
+4. Product Type
+Select the appropriate product type:
+	- Choose Multiple if it affects the fleet
+	- Otherwise, select the specific product involved
+
+5. Description - Add a brief description of the announcement.
 
 ```
 osdctl jira create-handover-announcement [flags]
@@ -2746,7 +2768,7 @@ osdctl jira create-handover-announcement [flags]
       --skip-aws-proxy-check aws_proxy   Don't use the configured aws_proxy value
   -S, --skip-version-check               skip checking to see if this is the most recent release
       --summary string                   Enter Summary/Title for the Announcment
-      --version string                   Affects version
+      --version string                   Affected Openshift Version (e.g 4.16 or 4.15.32)
 ```
 
 ### osdctl jira quick-task

--- a/docs/osdctl_jira_create-handover-announcement.md
+++ b/docs/osdctl_jira_create-handover-announcement.md
@@ -2,6 +2,32 @@
 
 Create a new Handover announcement for SREPHOA Project
 
+### Synopsis
+
+
+Create a new Handover announcement for SREPHOA Project. To fill the fields, use the following instructions:
+
+1. Cluster ID
+	- If a specific cluster is affected, enter the ID (internal or external).
+	- If not applicable: enter None, N/A, or All for fleet-wide impact.
+
+2. Customer Name 	
+	- Use the exact name from the output of the command you ran. Do not modify or abbreviate. Copy-paste exactly.
+	- If not applicable: enter None or N/A
+	Note : To find the Customer Name you can get it from ocm describe cluster | grep -i organization or run the following command ocm get $(ocm get $(ocm get cluster $CLUSTER_ID  | jq -r .subscription.href) | jq -r '.creator.href') |  jq -r '.organization.name'
+
+3. Version
+Use the Openshift version number in the format:
+	- 4.16 if it affects entire Y-stream versions
+	- 4.16.5 if it affects a specific version
+
+4. Product Type
+Select the appropriate product type:
+	- Choose Multiple if it affects the fleet
+	- Otherwise, select the specific product involved
+
+5. Description - Add a brief description of the announcement.
+
 ```
 osdctl jira create-handover-announcement [flags]
 ```
@@ -15,7 +41,7 @@ osdctl jira create-handover-announcement [flags]
   -h, --help                 help for create-handover-announcement
       --products string      Comma-separated list of products (e.g. 'Product A,Product B')
       --summary string       Enter Summary/Title for the Announcment
-      --version string       Affects version
+      --version string       Affected Openshift Version (e.g 4.16 or 4.15.32)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Updates long description based on SOP
The help command would now look like
```
╰─❯ go run . -S jira create-handover-announcement -h

Create a new Handover announcement for SREPHOA Project. To fill the fields, use the following instructions:

1. Cluster ID
	- If a specific cluster is affected, enter the ID (internal or external).
	- If not applicable: enter None, N/A, or All for fleet-wide impact.

2. Customer Name
	- Use the exact name from the output of the command you ran. Do not modify or abbreviate. Copy-paste exactly.
	- If not applicable: enter None or N/A
	Note : To find the Customer Name you can get it from ocm decribe cluster | grep -i organization or run the following command ocm get $(ocm get $(ocm get cluster $CLUSTER_ID  | jq -r .subscription.href) | jq -r '.creator.href') |  jq -r '.organization.name'

3. Version
Use the Openshift version number in the format:
	- 4.16 if it affects entire Y-stream versions
	- 4.16.5 if it affects a specific version

4. Product Type
Select the appropriate product type:
	- Choose Multiple if it affects the fleet
	- Otherwise, select the specific product involved

5. Description - Add a brief description of the announcement.

Usage:
  osdctl jira create-handover-announcement [flags]

Flags:
      --cluster string       Cluster ID
      --customer string      Customer name
      --description string   Enter Description for the Announcment
  -h, --help                 help for create-handover-announcement
      --products string      Comma-separated list of products (e.g. 'Product A,Product B')
      --summary string       Enter Summary/Title for the Announcment
      --version string       Affected Openshift Version (e.g 4.16 or 4.15.32)

```