### PR TITLE
Add more supported instance types for down scale

### DIFF
--- a/cmd/cluster/resize/cmd.go
+++ b/cmd/cluster/resize/cmd.go
@@ -6,6 +6,7 @@ import (
 
 var supportedInstanceTypes = map[string][]string{
 	"controlplane": {
+		"m5.2xlarge",
 		"m5.4xlarge",
 		"m5.8xlarge",
 		"m5.12xlarge",
@@ -19,6 +20,8 @@ var supportedInstanceTypes = map[string][]string{
 		"n2-standard-32",
 	},
 	"infra": {
+		"r5.xlarge",
+		"r5.2xlarge",
 		"r5.4xlarge",
 		"r5.8xlarge",
 		"r5.12xlarge",

--- a/cmd/cluster/resize/infra_node_test.go
+++ b/cmd/cluster/resize/infra_node_test.go
@@ -114,7 +114,7 @@ func TestValidateInstanceSize(t *testing.T) {
 		{
 			instanceSize: "r5.2xlarge",
 			nodeType:     "infra",
-			expectErr:    true,
+			expectErr:    false,
 		},
 		{
 			instanceSize: "m5.4xlarge",
@@ -129,7 +129,7 @@ func TestValidateInstanceSize(t *testing.T) {
 		{
 			instanceSize: "m5.2xlarge",
 			nodeType:     "controlplane",
-			expectErr:    true,
+			expectErr:    false,
 		},
 		{
 			instanceSize: "r5.4xlarge",


### PR DESCRIPTION
This PR adds r5.xlarge and r5.2xlarge to the infra node supported type, and adds m5.2xlarge as the supported control plane instance type.

The use case is mainly for down size. Eg, when SRE up size the infra node to get some room to investigate a high resource usage issue, after SRE fixes the issue, SRE will need to scale it back to the original size.

As per the document https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/prepare_your_environment/rosa-sts-aws-prereqs#rosa-aws-policy-provisioned_rosa-sts-aws-prereqs , the minimum size for control plane is m5.2xlarge, minimum for infra is r5.xlarge.
