### PR TITLE
SREP-1010: Added "osdctl dt" check for vault cli

### DIFF
--- a/cmd/dynatrace/vault.go
+++ b/cmd/dynatrace/vault.go
@@ -19,6 +19,15 @@ func setupVaultToken(vaultAddr string) error {
 		return fmt.Errorf("error setting environment variable: %v", err)
 	}
 
+	versionCheckCmd := exec.Command("vault", "version")
+
+	versionCheckCmd.Stdout = os.Stdout
+	versionCheckCmd.Stderr = os.Stderr
+
+	if err = versionCheckCmd.Run(); err != nil {
+		return fmt.Errorf("missing vault cli: %v", err)
+	}
+
 	tokenCheckCmd := exec.Command("vault", "token", "lookup")
 	tokenCheckCmd.Stdout = nil
 	tokenCheckCmd.Stderr = nil


### PR DESCRIPTION
This PR introduces a check to verify the availability of the Vault CLI before performing Vault operations. If the CLI is missing, an appropriate error message is returned to inform the user that Vault CLI is not installed. If the Vault CLI is available, it will display the current version of the Vault CLI being used, which will assist in debugging Vault-related issues.