### PR TITLE
SREP-962: Add absolute timestamp support to fetching DT logs (--from and --to flags)

### DIFF
--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -462,18 +462,20 @@ func (o *contextOptions) generateContextData() (*contextData, []error) {
 				data.DyntraceEnvURL = "Failed to fetch Dynatrace URL"
 			}
 			return
-		} else {
-			query, err := dynatrace.GetQuery(hcpCluster)
-			if err != nil {
-				errors = append(errors, fmt.Errorf("failed to build query for Dynatrace %v", err))
-			}
-			queryTxt := query.Build()
-			data.DyntraceEnvURL = hcpCluster.DynatraceURL
-			data.DyntraceLogsURL, err = dynatrace.GetLinkToWebConsole(hcpCluster.DynatraceURL, 10, queryTxt)
-			if err != nil {
-				errors = append(errors, fmt.Errorf("failed to get url: %v", err))
-			}
 		}
+		query, err := dynatrace.GetQuery(hcpCluster, time.Time{}, time.Time{}, 1) // passing nil from/to values to use --since behaviour
+		if err != nil {
+			errors = append(errors, fmt.Errorf("failed to build query for Dynatrace %v", err))
+			data.DyntraceEnvURL = fmt.Sprintf("Failed to build Dynatrace query: %v", err)
+			return
+		}
+		queryTxt := query.Build()
+		data.DyntraceEnvURL = hcpCluster.DynatraceURL
+		data.DyntraceLogsURL, err = dynatrace.GetLinkToWebConsole(hcpCluster.DynatraceURL, "now()-10h", "now()", queryTxt)
+		if err != nil {
+			errors = append(errors, fmt.Errorf("failed to get url: %v", err))
+		}
+
 	}
 
 	GetPagerDutyAlerts := func() {

--- a/cmd/dynatrace/dtquery.go
+++ b/cmd/dynatrace/dtquery.go
@@ -3,7 +3,10 @@ package dynatrace
 import (
 	"fmt"
 	"strings"
+	"time"
 )
+
+const timeFormat = "2006-01-02T15:04:05Z"
 
 type DTQuery struct {
 	fragments  []string
@@ -14,6 +17,17 @@ func (q *DTQuery) InitLogs(hours int) *DTQuery {
 	q.fragments = []string{}
 
 	q.fragments = append(q.fragments, fmt.Sprintf("fetch logs, from:now()-%dh \n| filter matchesValue(event.type, \"LOG\") and ", hours))
+
+	return q
+}
+
+func (q *DTQuery) InitLogsWithTimeRange(from time.Time, to time.Time) *DTQuery {
+	q.fragments = []string{}
+
+	fromStr := from.Format(timeFormat)
+	toStr := to.Format(timeFormat)
+
+	q.fragments = append(q.fragments, fmt.Sprintf("fetch logs, from:\"%s\", to:\"%s\" \n| filter matchesValue(event.type, \"LOG\") and ", fromStr, toStr))
 
 	return q
 }

--- a/cmd/dynatrace/dtquery_test.go
+++ b/cmd/dynatrace/dtquery_test.go
@@ -2,6 +2,7 @@ package dynatrace
 
 import (
 	"testing"
+	"time"
 )
 
 func TestDTQuery_InitLogs(t *testing.T) {
@@ -188,6 +189,32 @@ func TestDTQuery_Deployments(t *testing.T) {
 			q := new(DTQuery).InitLogs(1).Deployments(tt.input)
 			if q.fragments[1] != tt.expected {
 				t.Errorf("expected: %s\ngot: %s", tt.expected, q.fragments[1])
+			}
+		})
+	}
+}
+
+func TestDTQuery_InitLogsWithTimeRange(t *testing.T) {
+	tests := []struct {
+		name     string
+		from     time.Time
+		to       time.Time
+		expected string
+	}{
+		{
+			name: "Standard time range",
+			from: time.Date(2025, 6, 12, 5, 0, 0, 0, time.UTC),
+			to:   time.Date(2025, 6, 17, 15, 0, 0, 0, time.UTC),
+			expected: `fetch logs, from:"2025-06-12T05:00:00Z", to:"2025-06-17T15:00:00Z" 
+| filter matchesValue(event.type, "LOG") and `,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := new(DTQuery).InitLogsWithTimeRange(tt.from, tt.to)
+			if q.fragments[0] != tt.expected {
+				t.Errorf("expected: %s\ngot: %s", tt.expected, q.fragments[0])
 			}
 		})
 	}

--- a/docs/README.md
+++ b/docs/README.md
@@ -2308,6 +2308,7 @@ osdctl dynatrace logs --cluster-id <cluster-identifier> [flags]
       --contains string                  Include logs which contain a phrase
       --context string                   The name of the kubeconfig context to use
       --dry-run                          Only builds the query without fetching any logs from the tenant
+      --from time                        Datetime from which to filter logs, in the format "YYYY-MM-DD HH:MM" (default 0001-01-01T00:00:00Z)
   -h, --help                             help for logs
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
@@ -2322,6 +2323,7 @@ osdctl dynatrace logs --cluster-id <cluster-identifier> [flags]
       --sort string                      Sort the results by timestamp in either ascending or descending order. Accepted values are 'asc' and 'desc'. Defaults to 'asc' (default "asc")
       --status strings                   Status(Info/Warn/Error) (comma-separated)
       --tail int                         Last 'n' logs to fetch (defaults to 100) (default 1000)
+      --to time                          Datetime until which to filter logs to, in the format "YYYY-MM-DD HH:MM" (default 0001-01-01T00:00:00Z)
 ```
 
 ### osdctl dynatrace url

--- a/docs/osdctl_dynatrace_logs.md
+++ b/docs/osdctl_dynatrace_logs.md
@@ -37,6 +37,9 @@ osdctl dynatrace logs --cluster-id <cluster-identifier> [flags]
   # Only return logs newer than 2 hours old (an integer in hours)
   $ osdctl dt logs alertmanager-main-0 -n openshift-monitoring --since 2
 
+  # Get logs for a specific time range using --from and --to flags
+  $ osdctl dt logs alertmanager-main-0 -n openshift-monitoring --from "2025-06-15 04:00" --to "2025-06-17 13:00"
+
   # Restrict return of logs to those that contain a specific phrase
   $ osdctl dt logs alertmanager-main-0 -n openshift-monitoring --contains <phrase>
 
@@ -50,6 +53,7 @@ osdctl dynatrace logs --cluster-id <cluster-identifier> [flags]
       --container strings   Container name(s) (comma-separated)
       --contains string     Include logs which contain a phrase
       --dry-run             Only builds the query without fetching any logs from the tenant
+      --from time           Datetime from which to filter logs, in the format "YYYY-MM-DD HH:MM" (default 0001-01-01T00:00:00Z)
   -h, --help                help for logs
   -n, --namespace strings   Namespace(s) (comma-separated)
       --node strings        Node name(s) (comma-separated)
@@ -57,6 +61,7 @@ osdctl dynatrace logs --cluster-id <cluster-identifier> [flags]
       --sort string         Sort the results by timestamp in either ascending or descending order. Accepted values are 'asc' and 'desc'. Defaults to 'asc' (default "asc")
       --status strings      Status(Info/Warn/Error) (comma-separated)
       --tail int            Last 'n' logs to fetch (defaults to 100) (default 1000)
+      --to time             Datetime until which to filter logs to, in the format "YYYY-MM-DD HH:MM" (default 0001-01-01T00:00:00Z)
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/afero v1.12.0
 	github.com/spf13/cobra v1.9.1
-	github.com/spf13/pflag v1.0.6
+	github.com/spf13/pflag v1.0.7
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	github.com/zclconf/go-cty v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -603,8 +603,9 @@ github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cA
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
+github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.20.1 h1:ZMi+z/lvLyPSCoNtFCpqjy0S4kPbirhpTMwl8BkW9X4=
 github.com/spf13/viper v1.20.1/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqjJvu4=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=


### PR DESCRIPTION
This PR adds support for specification of absolute (datetime) timestamps for the `osdctl logs` command through the newly added `--from` and `--to` flags. 

They are to be used in conjunction with one-another, of course cannot be used with `--since`, and the timestamps are also validated to ensure `from` is not after `to`. The PR also bumps the "spf13/pflag" dependency (to add `time.Time` flag support).