### PR TITLE
Standardize --cluster-id flag to support -C shorthand across all commands

### DIFF
--- a/cmd/alerts/list_alerts.go
+++ b/cmd/alerts/list_alerts.go
@@ -30,7 +30,7 @@ func NewCmdListAlerts() *cobra.Command {
 			ListAlerts(alertCmd)
 		},
 	}
-	newCmd.Flags().StringVar(&alertCmd.clusterID, "cluster-id", "", "Provide the internal ID of the cluster")
+	newCmd.Flags().StringVarP(&alertCmd.clusterID, "cluster-id", "C", "", "Provide the internal ID of the cluster")
 	_ = newCmd.MarkFlagRequired("cluster-id")
 
 	newCmd.Flags().StringVarP(&alertCmd.alertLevel, "level", "l", "all", "Alert level [warning, critical, firing, pending, all]")

--- a/cmd/alerts/silence/add_silence.go
+++ b/cmd/alerts/silence/add_silence.go
@@ -37,7 +37,7 @@ func NewCmdAddSilence() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&addSilenceCmd.clusterID, "cluster-id", "", "Provide the internal ID of the cluster")
+	cmd.Flags().StringVarP(&addSilenceCmd.clusterID, "cluster-id", "C", "", "Provide the internal ID of the cluster")
 	cmd.Flags().StringSliceVar(&addSilenceCmd.alertID, "alertname", []string{}, "alertname (comma-separated)")
 	cmd.Flags().StringVarP(&addSilenceCmd.comment, "comment", "c", "Adding silence using the osdctl alert command", "add comment about silence")
 	cmd.Flags().StringVarP(&addSilenceCmd.duration, "duration", "d", "15d", "Adding duration for silence as 15 days") //default duration set to 15 days

--- a/cmd/alerts/silence/clear_silence.go
+++ b/cmd/alerts/silence/clear_silence.go
@@ -33,7 +33,7 @@ func NewCmdClearSilence() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&silenceCmd.clusterID, "cluster-id", "", "Provide the internal ID of the cluster")
+	cmd.Flags().StringVarP(&silenceCmd.clusterID, "cluster-id", "C", "", "Provide the internal ID of the cluster")
 	cmd.Flags().StringSliceVar(&silenceCmd.silenceIDs, "silence-id", []string{}, "silence id (comma-separated)")
 	cmd.Flags().BoolVarP(&silenceCmd.all, "all", "a", false, "clear all silences")
 	cmd.Flags().StringVar(&silenceCmd.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)")

--- a/cmd/alerts/silence/list_silence.go
+++ b/cmd/alerts/silence/list_silence.go
@@ -27,7 +27,7 @@ func NewCmdListSilence() *cobra.Command {
 			ListSilence(listSilenceCmd)
 		},
 	}
-	cmd.Flags().StringVar(&listSilenceCmd.clusterID, "cluster-id", "", "Provide the internal ID of the cluster")
+	cmd.Flags().StringVarP(&listSilenceCmd.clusterID, "cluster-id", "C", "", "Provide the internal ID of the cluster")
 	cmd.Flags().StringVar(&listSilenceCmd.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)")
 	_ = cmd.MarkFlagRequired("cluster-id")
 	_ = cmd.MarkFlagRequired("reason")

--- a/cmd/cluster/access/access.go
+++ b/cmd/cluster/access/access.go
@@ -65,7 +65,7 @@ func NewCmdAccess(streams genericclioptions.IOStreams, client *k8s.LazyClient) *
 	}
 	accessCmd.AddCommand(newCmdCleanup(client, streams))
 	accessCmd.Flags().StringVar(&ops.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)")
-	accessCmd.Flags().StringVar(&ops.clusterID, "cluster-id", "", "Provide the internal ID of the cluster")
+	accessCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "Provide the internal ID of the cluster")
 	_ = accessCmd.MarkFlagRequired("reason")
 	_ = accessCmd.MarkFlagRequired("cluster-id")
 

--- a/cmd/cluster/access/cleanup.go
+++ b/cmd/cluster/access/cleanup.go
@@ -33,7 +33,7 @@ func newCmdCleanup(client *k8s.LazyClient, streams genericclioptions.IOStreams) 
 			cmdutil.CheckErr(ops.Run(cmd))
 		},
 	}
-	cleanupCmd.Flags().StringVar(&ops.clusterID, "cluster-id", "", "[Mandatory] Provide the Internal ID of the cluster")
+	cleanupCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "[Mandatory] Provide the Internal ID of the cluster")
 	cleanupCmd.Flags().StringVar(&ops.reason, "reason", "", "[Mandatory for PrivateLink clusters] The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)")
 
 	_ = cleanupCmd.MarkFlagRequired("cluster-id")

--- a/cmd/cluster/checkbanneduser.go
+++ b/cmd/cluster/checkbanneduser.go
@@ -22,7 +22,7 @@ func newCmdCheckBannedUser() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&clusterID, "cluster-id", "c", "", "Provide internal ID of the cluster")
+	cmd.Flags().StringVarP(&clusterID, "cluster-id", "C", "", "Provide internal ID of the cluster")
 	_ = cmd.MarkFlagRequired("cluster-id")
 
 	return cmd

--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -139,7 +139,7 @@ func newCmdContext() *cobra.Command {
 		},
 	}
 
-	contextCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "c", "", "Provide internal ID of the cluster")
+	contextCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "Provide internal ID of the cluster")
 	_ = contextCmd.MarkFlagRequired("cluster-id")
 
 	contextCmd.Flags().StringVarP(&ops.output, "output", "o", "long", "Valid formats are ['long', 'short', 'json']. Output is set to 'long' by default")

--- a/cmd/cluster/detachstuckvolume.go
+++ b/cmd/cluster/detachstuckvolume.go
@@ -43,7 +43,7 @@ func newCmdDetachStuckVolume() *cobra.Command {
 		},
 	}
 
-	detachstuckvolumeCmd.Flags().StringVar(&ops.clusterID, "cluster-id", "", "Provide internal ID of the cluster")
+	detachstuckvolumeCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "Provide internal ID of the cluster")
 	detachstuckvolumeCmd.Flags().StringVar(&ops.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket)")
 	_ = detachstuckvolumeCmd.MarkFlagRequired("cluster-id")
 	_ = detachstuckvolumeCmd.MarkFlagRequired("reason")

--- a/cmd/cluster/etcd_health.go
+++ b/cmd/cluster/etcd_health.go
@@ -68,7 +68,7 @@ func newCmdEtcdHealthCheck() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.clusterID, "cluster-id", "", "Provide the internal Cluster ID or name to perform health check on")
+	cmd.Flags().StringVarP(&opts.clusterID, "cluster-id", "C", "", "Provide the internal Cluster ID or name to perform health check on")
 	cmd.Flags().StringVar(&opts.reason, "reason", "", "Specify a reason for privilege escalation")
 
 	err := cmd.MarkFlagRequired("cluster-id")

--- a/cmd/cluster/etcd_replace.go
+++ b/cmd/cluster/etcd_replace.go
@@ -50,7 +50,7 @@ func newCmdEtcdMemberReplacement() *cobra.Command {
 			cmdutil.CheckErr(opts.EtcdReplaceMember())
 		},
 	}
-	replaceCmd.Flags().StringVar(&opts.clusterID, "cluster-id", "", "Provide internal Cluster ID")
+	replaceCmd.Flags().StringVarP(&opts.clusterID, "cluster-id", "C", "", "Provide internal Cluster ID")
 	replaceCmd.Flags().StringVar(&opts.nodeId, "node", "", "Node ID (required)")
 	replaceCmd.Flags().StringVar(&opts.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket)")
 	_ = replaceCmd.MarkFlagRequired("cluster-id")

--- a/cmd/cluster/hypershift_info.go
+++ b/cmd/cluster/hypershift_info.go
@@ -47,7 +47,7 @@ It attempts to render the relationships as graphviz if that output format is cho
 			cmdutil.CheckErr(ops.run())
 		},
 	}
-	infoCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "c", "", "Provide internal ID of the cluster")
+	infoCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "Provide internal ID of the cluster")
 	infoCmd.Flags().StringVarP(&ops.awsProfile, "profile", "p", "", "AWS Profile")
 	infoCmd.Flags().StringVarP(&ops.awsRegion, "region", "r", "", "AWS Region")
 	infoCmd.Flags().StringVarP(&ops.privatelinkAccountId, "privatelinkaccount", "l", "", "Privatelink account ID")

--- a/cmd/cluster/loggingcheck.go
+++ b/cmd/cluster/loggingcheck.go
@@ -37,7 +37,7 @@ func newCmdLoggingCheck(streams genericclioptions.IOStreams, globalOpts *globalf
 		},
 	}
 	loggingCheckCmd.Flags().BoolVarP(&ops.verbose, "verbose", "", false, "Verbose output")
-	loggingCheckCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "c", "", "The internal ID of the cluster to check (required)")
+	loggingCheckCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "The internal ID of the cluster to check (required)")
 	cmdutil.CheckErr(loggingCheckCmd.MarkFlagRequired("cluster-id"))
 
 	return loggingCheckCmd

--- a/cmd/cluster/org_id.go
+++ b/cmd/cluster/org_id.go
@@ -31,7 +31,7 @@ func newCmdOrgId() *cobra.Command {
 		},
 	}
 
-	orgIdCmd.Flags().StringVarP(&o.clusterID, "cluster-id", "c", "", "The internal ID of the cluster to check (required)")
+	orgIdCmd.Flags().StringVarP(&o.clusterID, "cluster-id", "C", "", "The internal ID of the cluster to check (required)")
 
 	return orgIdCmd
 }

--- a/cmd/cluster/resize/controlplane_node.go
+++ b/cmd/cluster/resize/controlplane_node.go
@@ -73,7 +73,7 @@ func newCmdResizeControlPlane() *cobra.Command {
 			return ops.run(context.Background())
 		},
 	}
-	resizeControlPlaneNodeCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "c", "", "The internal ID of the cluster to perform actions on")
+	resizeControlPlaneNodeCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "The internal ID of the cluster to perform actions on")
 	resizeControlPlaneNodeCmd.Flags().StringVar(&ops.newMachineType, "machine-type", "", "The target AWS machine type to resize to (e.g. m5.2xlarge)")
 	resizeControlPlaneNodeCmd.Flags().StringVar(&ops.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket)")
 	_ = resizeControlPlaneNodeCmd.MarkFlagRequired("cluster-id")

--- a/cmd/cluster/ssh/key.go
+++ b/cmd/cluster/ssh/key.go
@@ -79,7 +79,7 @@ Despite the logs from backplane, the ssh key is the only output channelled throu
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.clusterID, "cluster-id", "", "Cluster identifier (internal ID, UUID, name, etc) to retrieve the SSH key for. If not specified, the current cluster will be used.")
+	cmd.Flags().StringVarP(&opts.clusterID, "cluster-id", "C", "", "Cluster identifier (internal ID, UUID, name, etc) to retrieve the SSH key for. If not specified, the current cluster will be used.")
 	cmd.Flags().BoolVarP(&opts.skipConfirmation, "yes", "y", false, "Skip any confirmation prompts and print the key automatically. Useful for redirects and scripting.")
 	cmd.Flags().StringVar(&opts.elevationReason, "reason", "", "Provide a reason for accessing the clusters SSH key, used for backplane. Eg: 'OHSS-XXXX', or '#ITN-2024-XXXXX")
 

--- a/cmd/cluster/support/delete.go
+++ b/cmd/cluster/support/delete.go
@@ -45,7 +45,7 @@ func newCmddelete(streams genericclioptions.IOStreams, globalOpts *globalflags.G
 	}
 
 	// Defined required flags
-	deleteCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "c", "", "Internal cluster ID (required)")
+	deleteCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "Internal cluster ID (required)")
 	deleteCmd.Flags().BoolVar(&ops.removeAll, "all", false, "Remove all limited support reasons")
 	deleteCmd.Flags().StringVarP(&ops.limitedSupportReasonID, "limited-support-reason-id", "i", "", "Limited support reason ID")
 	deleteCmd.Flags().BoolVarP(&ops.isDryRun, "dry-run", "d", false, "Dry-run - print the limited support reason about to be sent but don't send it.")

--- a/cmd/cluster/support/post.go
+++ b/cmd/cluster/support/post.go
@@ -84,7 +84,7 @@ The cluster has a second failing ingress controller, which is not supported and 
 	}
 
 	// Define required flags
-	postCmd.Flags().StringVarP(&p.ClusterID, "cluster-id", "c", "", "Internal Cluster ID (required)")
+	postCmd.Flags().StringVarP(&p.ClusterID, "cluster-id", "C", "", "Internal Cluster ID (required)")
 	postCmd.Flags().StringVarP(&p.Template, "template", "t", "", "Message template file or URL")
 	postCmd.Flags().StringArrayVarP(&p.TemplateParams, "param", "p", p.TemplateParams, "Specify a key-value pair (eg. -p FOO=BAR) to set/override a parameter value in the template.")
 	postCmd.Flags().Var(&p.Misconfiguration, MisconfigurationFlag, "The type of misconfiguration responsible for the cluster being placed into limited support. Valid values are `cloud` or `cluster`.")

--- a/cmd/cluster/support/status.go
+++ b/cmd/cluster/support/status.go
@@ -34,7 +34,7 @@ func newCmdstatus(streams genericclioptions.IOStreams, globalOpts *globalflags.G
 		},
 	}
 
-	statusCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "c", "", "Cluster ID for which to get support status")
+	statusCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "Cluster ID for which to get support status")
 	statusCmd.Flags().BoolVarP(&ops.verbose, "verbose", "", false, "Verbose output")
 
 	_ = statusCmd.MarkFlagRequired("cluster-id")

--- a/cmd/cluster/validatepullsecret.go
+++ b/cmd/cluster/validatepullsecret.go
@@ -40,7 +40,7 @@ This command will automatically login to the cluster to check the current pull-s
 	}
 
 	// Add cluster-id flag
-	validatePullSecretCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "c", "", "The internal ID of the cluster to check (required)")
+	validatePullSecretCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "The internal ID of the cluster to check (required)")
 	if err := validatePullSecretCmd.MarkFlagRequired("cluster-id"); err != nil {
 		fmt.Printf("Error marking cluster-id flag as required: %v\n", err)
 	}

--- a/cmd/dynatrace/dashCmd.go
+++ b/cmd/dynatrace/dashCmd.go
@@ -46,7 +46,7 @@ func newCmdDashboard() *cobra.Command {
 	}
 
 	urlCmd.Flags().StringVar(&dashboardName, "dash", "Central ROSA HCP Dashboard", "Name of the dashboard you wish to find")
-	urlCmd.Flags().StringVar(&clusterId, "cluster-id", "", "Provide the id of the cluster")
+	urlCmd.Flags().StringVarP(&clusterId, "cluster-id", "C", "", "Provide the id of the cluster")
 	_ = urlCmd.MarkFlagRequired("cluster-id")
 
 	return urlCmd

--- a/cmd/dynatrace/hcpGatherLogsCmd.go
+++ b/cmd/dynatrace/hcpGatherLogsCmd.go
@@ -55,7 +55,7 @@ func NewCmdHCPMustGather() *cobra.Command {
 	hcpMgCmd.Flags().IntVar(&g.Tail, "tail", 0, "Last 'n' logs and events to fetch. By default it will pull everything")
 	hcpMgCmd.Flags().StringVar(&g.SortOrder, "sort", "asc", "Sort the results by timestamp in either ascending or descending order. Accepted values are 'asc' and 'desc'")
 	hcpMgCmd.Flags().StringVar(&g.DestDir, "dest-dir", "", "Destination directory for the logs dump, defaults to the local directory.")
-	hcpMgCmd.Flags().StringVar(&g.ClusterID, "cluster-id", "", "Internal ID of the HCP cluster to gather logs from (required)")
+	hcpMgCmd.Flags().StringVarP(&g.ClusterID, "cluster-id", "C", "", "Internal ID of the HCP cluster to gather logs from (required)")
 
 	_ = hcpMgCmd.MarkFlagRequired("cluster-id")
 

--- a/cmd/dynatrace/logsCmd.go
+++ b/cmd/dynatrace/logsCmd.go
@@ -91,7 +91,7 @@ func NewCmdLogs() *cobra.Command {
 		},
 	}
 
-	logsCmd.Flags().StringVar(&clusterID, "cluster-id", "", "Name or Internal ID of the cluster (defaults to current cluster context)")
+	logsCmd.Flags().StringVarP(&clusterID, "cluster-id", "C", "", "Name or Internal ID of the cluster (defaults to current cluster context)")
 	logsCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Only builds the query without fetching any logs from the tenant")
 	logsCmd.Flags().IntVar(&tail, "tail", 1000, "Last 'n' logs to fetch (defaults to 100)")
 	logsCmd.Flags().IntVar(&since, "since", 1, "Number of hours (integer) since which to search (defaults to 1 hour)")

--- a/cmd/dynatrace/urlCmd.go
+++ b/cmd/dynatrace/urlCmd.go
@@ -24,7 +24,7 @@ func newCmdURL() *cobra.Command {
 		},
 	}
 
-	urlCmd.Flags().StringVar(&clusterID, "cluster-id", "", "ID of the cluster")
+	urlCmd.Flags().StringVarP(&clusterID, "cluster-id", "C", "", "ID of the cluster")
 	_ = urlCmd.MarkFlagRequired("cluster-id")
 
 	return urlCmd

--- a/cmd/env/env.go
+++ b/cmd/env/env.go
@@ -106,7 +106,7 @@ func NewCmdEnv() *cobra.Command {
 	envCmd.Flags().BoolVarP(&options.ResetEnv, "reset", "r", false, "Reset environment")
 	envCmd.Flags().BoolVarP(&options.ExportKubeConfig, "export-kubeconfig", "k", false, "Output export kubeconfig statement, to use environment outside of the env directory")
 
-	envCmd.Flags().StringVarP(&options.ClusterId, "cluster-id", "c", "", "Cluster ID")
+	envCmd.Flags().StringVarP(&options.ClusterId, "cluster-id", "C", "", "Cluster ID")
 	envCmd.Flags().StringVarP(&options.LoginScript, "login-script", "l", "", "OCM login script to execute in a loop in ocb every 30 seconds")
 
 	envCmd.Flags().StringVarP(&options.LoginScript, "username", "u", "", "Username for individual cluster login")

--- a/cmd/hcp/mustgather/mustGather.go
+++ b/cmd/hcp/mustgather/mustGather.go
@@ -51,7 +51,7 @@ func NewCmdMustGather() *cobra.Command {
 	}
 
 	defaultAcmImage := "quay.io/stolostron/must-gather:2.11.4-SNAPSHOT-2024-12-02-15-19-44"
-	mustGatherCommand.Flags().StringVar(&mg.clusterId, "cluster-id", "", "Internal ID of the cluster to gather data from")
+	mustGatherCommand.Flags().StringVarP(&mg.clusterId, "cluster-id", "C", "", "Internal ID of the cluster to gather data from")
 	mustGatherCommand.Flags().StringVar(&mg.reason, "reason", "", "The reason for this command, which requires elevation (e.g., OHSS ticket or PD incident).")
 	mustGatherCommand.Flags().StringVar(&mg.gatherTargets, "gather", "hcp", "Comma-separated list of gather targets (available: sc, sc_acm, mc, hcp).")
 	mustGatherCommand.Flags().StringVar(&mg.acmMustGatherImage, "acm_image", defaultAcmImage, "Overrides the acm must-gather image being used for acm mc, sc as well as hcp must-gathers.")

--- a/docs/README.md
+++ b/docs/README.md
@@ -926,7 +926,7 @@ osdctl alert list --cluster-id <cluster-id> --level [warning, critical, firing, 
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-      --cluster-id string                Provide the internal ID of the cluster
+  -C, --cluster-id string                Provide the internal ID of the cluster
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for list
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -979,7 +979,7 @@ osdctl alert silence add --cluster-id <cluster-identifier> [--all --duration --c
   -a, --all                              Adding silences for all alert
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-      --cluster-id string                Provide the internal ID of the cluster
+  -C, --cluster-id string                Provide the internal ID of the cluster
   -c, --comment string                   add comment about silence (default "Adding silence using the osdctl alert command")
       --context string                   The name of the kubeconfig context to use
   -d, --duration string                  Adding duration for silence as 15 days (default "15d")
@@ -1008,7 +1008,7 @@ osdctl alert silence expire [--cluster-id <cluster-identifier>] [--all | --silen
   -a, --all                              clear all silences
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-      --cluster-id string                Provide the internal ID of the cluster
+  -C, --cluster-id string                Provide the internal ID of the cluster
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for expire
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -1035,7 +1035,7 @@ osdctl alert silence list --cluster-id <cluster-identifier> [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-      --cluster-id string                Provide the internal ID of the cluster
+  -C, --cluster-id string                Provide the internal ID of the cluster
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for list
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -1194,7 +1194,7 @@ osdctl cluster break-glass --cluster-id <cluster-identifier> [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-      --cluster-id string                Provide the internal ID of the cluster
+  -C, --cluster-id string                Provide the internal ID of the cluster
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for break-glass
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -1223,7 +1223,7 @@ osdctl cluster break-glass cleanup --cluster-id <cluster-identifier> [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-      --cluster-id string                [Mandatory] Provide the Internal ID of the cluster
+  -C, --cluster-id string                [Mandatory] Provide the Internal ID of the cluster
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for cleanup
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -1249,7 +1249,7 @@ osdctl cluster check-banned-user --cluster-id <cluster-identifier> [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-  -c, --cluster-id string                Provide internal ID of the cluster
+  -C, --cluster-id string                Provide internal ID of the cluster
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for check-banned-user
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -1274,7 +1274,7 @@ osdctl cluster context --cluster-id <cluster-identifier> [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-  -c, --cluster-id string                Provide internal ID of the cluster
+  -C, --cluster-id string                Provide internal ID of the cluster
       --context string                   The name of the kubeconfig context to use
   -d, --days int                         Command will display X days of Error SLs sent to the cluster. Days is set to 30 by default (default 30)
       --full                             Run full suite of checks.
@@ -1345,7 +1345,7 @@ osdctl cluster detach-stuck-volume --cluster-id <cluster-identifier> [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-      --cluster-id string                Provide internal ID of the cluster
+  -C, --cluster-id string                Provide internal ID of the cluster
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for detach-stuck-volume
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -1371,7 +1371,7 @@ osdctl cluster etcd-health-check --cluster-id <cluster-id> --reason <reason for 
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-      --cluster-id string                Provide the internal Cluster ID or name to perform health check on
+  -C, --cluster-id string                Provide the internal Cluster ID or name to perform health check on
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for etcd-health-check
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -1397,7 +1397,7 @@ osdctl cluster etcd-member-replace --cluster-id <cluster-identifier> [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-      --cluster-id string                Provide internal Cluster ID
+  -C, --cluster-id string                Provide internal Cluster ID
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for etcd-member-replace
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -1476,7 +1476,7 @@ osdctl cluster hypershift-info [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-  -c, --cluster-id string                Provide internal ID of the cluster
+  -C, --cluster-id string                Provide internal ID of the cluster
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for hypershift-info
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -1505,7 +1505,7 @@ osdctl cluster logging-check --cluster-id <cluster-identifier> [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-  -c, --cluster-id string                The internal ID of the cluster to check (required)
+  -C, --cluster-id string                The internal ID of the cluster to check (required)
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for logging-check
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -1531,7 +1531,7 @@ osdctl cluster orgId --cluster-id <cluster-identifier [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-  -c, --cluster-id string                The internal ID of the cluster to check (required)
+  -C, --cluster-id string                The internal ID of the cluster to check (required)
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for orgId
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -1609,7 +1609,7 @@ osdctl cluster resize control-plane [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-  -c, --cluster-id string                The internal ID of the cluster to perform actions on
+  -C, --cluster-id string                The internal ID of the cluster to perform actions on
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for control-plane
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -1823,7 +1823,7 @@ osdctl cluster ssh key --reason $reason [--cluster-id $CLUSTER_ID] [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-      --cluster-id string                Cluster identifier (internal ID, UUID, name, etc) to retrieve the SSH key for. If not specified, the current cluster will be used.
+  -C, --cluster-id string                Cluster identifier (internal ID, UUID, name, etc) to retrieve the SSH key for. If not specified, the current cluster will be used.
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for key
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -1875,7 +1875,7 @@ osdctl cluster support delete --cluster-id <cluster-identifier> [flags]
       --all                                Remove all limited support reasons
       --as string                          Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                     The name of the kubeconfig cluster to use
-  -c, --cluster-id string                  Internal cluster ID (required)
+  -C, --cluster-id string                  Internal cluster ID (required)
       --context string                     The name of the kubeconfig context to use
   -d, --dry-run                            Dry-run - print the limited support reason about to be sent but don't send it.
   -h, --help                               help for delete
@@ -1904,7 +1904,7 @@ osdctl cluster support post --cluster-id <cluster-identifier> [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-  -c, --cluster-id string                Internal Cluster ID (required)
+  -C, --cluster-id string                Internal Cluster ID (required)
       --context string                   The name of the kubeconfig context to use
       --evidence string                  (optional) The reasoning that led to the decision to place the cluster in limited support. Can also be a link to a Jira case. Used for internal service log only.
   -h, --help                             help for post
@@ -1935,7 +1935,7 @@ osdctl cluster support status --cluster-id <cluster-identifier> [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-  -c, --cluster-id string                Cluster ID for which to get support status
+  -C, --cluster-id string                Cluster ID for which to get support status
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for status
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -1993,7 +1993,7 @@ osdctl cluster validate-pull-secret --cluster-id <cluster-identifier> [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-  -c, --cluster-id string                The internal ID of the cluster to check (required)
+  -C, --cluster-id string                The internal ID of the cluster to check (required)
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for validate-pull-secret
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -2238,7 +2238,7 @@ osdctl dynatrace dashboard --cluster-id CLUSTER_ID [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-      --cluster-id string                Provide the id of the cluster
+  -C, --cluster-id string                Provide the id of the cluster
       --context string                   The name of the kubeconfig context to use
       --dash string                      Name of the dashboard you wish to find (default "Central ROSA HCP Dashboard")
   -h, --help                             help for dashboard
@@ -2268,7 +2268,7 @@ osdctl dynatrace gather-logs --cluster-id <cluster-identifier> [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-      --cluster-id string                Internal ID of the HCP cluster to gather logs from (required)
+  -C, --cluster-id string                Internal ID of the HCP cluster to gather logs from (required)
       --context string                   The name of the kubeconfig context to use
       --dest-dir string                  Destination directory for the logs dump, defaults to the local directory.
   -h, --help                             help for gather-logs
@@ -2302,7 +2302,7 @@ osdctl dynatrace logs --cluster-id <cluster-identifier> [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-      --cluster-id string                Name or Internal ID of the cluster (defaults to current cluster context)
+  -C, --cluster-id string                Name or Internal ID of the cluster (defaults to current cluster context)
       --console                          Print the url to the dynatrace web console instead of outputting the logs
       --container strings                Container name(s) (comma-separated)
       --contains string                  Include logs which contain a phrase
@@ -2339,7 +2339,7 @@ osdctl dynatrace url --cluster-id <cluster-identifier> [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-      --cluster-id string                ID of the cluster
+  -C, --cluster-id string                ID of the cluster
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for url
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -2387,7 +2387,7 @@ osdctl env [flags] [env-alias]
   -a, --api string                       OpenShift API URL for individual cluster login
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-  -c, --cluster-id string                Cluster ID
+  -C, --cluster-id string                Cluster ID
       --context string                   The name of the kubeconfig context to use
   -d, --delete                           Delete environment
   -k, --export-kubeconfig                Output export kubeconfig statement, to use environment outside of the env directory
@@ -2442,7 +2442,7 @@ osdctl hcp must-gather --cluster-id <cluster-identifier> [flags]
       --acm_image string                 Overrides the acm must-gather image being used for acm mc, sc as well as hcp must-gathers. (default "quay.io/stolostron/must-gather:2.11.4-SNAPSHOT-2024-12-02-15-19-44")
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-      --cluster-id string                Internal ID of the cluster to gather data from
+  -C, --cluster-id string                Internal ID of the cluster to gather data from
       --context string                   The name of the kubeconfig context to use
       --gather string                    Comma-separated list of gather targets (available: sc, sc_acm, mc, hcp). (default "hcp")
   -h, --help                             help for must-gather

--- a/docs/osdctl_alert_list.md
+++ b/docs/osdctl_alert_list.md
@@ -13,7 +13,7 @@ osdctl alert list --cluster-id <cluster-id> --level [warning, critical, firing, 
 ### Options
 
 ```
-      --cluster-id string   Provide the internal ID of the cluster
+  -C, --cluster-id string   Provide the internal ID of the cluster
   -h, --help                help for list
   -l, --level string        Alert level [warning, critical, firing, pending, all] (default "all")
       --reason string       The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)

--- a/docs/osdctl_alert_silence_add.md
+++ b/docs/osdctl_alert_silence_add.md
@@ -15,7 +15,7 @@ osdctl alert silence add --cluster-id <cluster-identifier> [--all --duration --c
 ```
       --alertname strings   alertname (comma-separated)
   -a, --all                 Adding silences for all alert
-      --cluster-id string   Provide the internal ID of the cluster
+  -C, --cluster-id string   Provide the internal ID of the cluster
   -c, --comment string      add comment about silence (default "Adding silence using the osdctl alert command")
   -d, --duration string     Adding duration for silence as 15 days (default "15d")
   -h, --help                help for add

--- a/docs/osdctl_alert_silence_expire.md
+++ b/docs/osdctl_alert_silence_expire.md
@@ -14,7 +14,7 @@ osdctl alert silence expire [--cluster-id <cluster-identifier>] [--all | --silen
 
 ```
   -a, --all                  clear all silences
-      --cluster-id string    Provide the internal ID of the cluster
+  -C, --cluster-id string    Provide the internal ID of the cluster
   -h, --help                 help for expire
       --reason string        The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)
       --silence-id strings   silence id (comma-separated)

--- a/docs/osdctl_alert_silence_list.md
+++ b/docs/osdctl_alert_silence_list.md
@@ -13,7 +13,7 @@ osdctl alert silence list --cluster-id <cluster-identifier> [flags]
 ### Options
 
 ```
-      --cluster-id string   Provide the internal ID of the cluster
+  -C, --cluster-id string   Provide the internal ID of the cluster
   -h, --help                help for list
       --reason string       The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)
 ```

--- a/docs/osdctl_cluster_break-glass.md
+++ b/docs/osdctl_cluster_break-glass.md
@@ -13,7 +13,7 @@ osdctl cluster break-glass --cluster-id <cluster-identifier> [flags]
 ### Options
 
 ```
-      --cluster-id string   Provide the internal ID of the cluster
+  -C, --cluster-id string   Provide the internal ID of the cluster
   -h, --help                help for break-glass
       --reason string       The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)
 ```

--- a/docs/osdctl_cluster_break-glass_cleanup.md
+++ b/docs/osdctl_cluster_break-glass_cleanup.md
@@ -16,7 +16,7 @@ osdctl cluster break-glass cleanup --cluster-id <cluster-identifier> [flags]
 ### Options
 
 ```
-      --cluster-id string   [Mandatory] Provide the Internal ID of the cluster
+  -C, --cluster-id string   [Mandatory] Provide the Internal ID of the cluster
   -h, --help                help for cleanup
       --reason string       [Mandatory for PrivateLink clusters] The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)
 ```

--- a/docs/osdctl_cluster_check-banned-user.md
+++ b/docs/osdctl_cluster_check-banned-user.md
@@ -9,7 +9,7 @@ osdctl cluster check-banned-user --cluster-id <cluster-identifier> [flags]
 ### Options
 
 ```
-  -c, --cluster-id string   Provide internal ID of the cluster
+  -C, --cluster-id string   Provide internal ID of the cluster
   -h, --help                help for check-banned-user
 ```
 

--- a/docs/osdctl_cluster_context.md
+++ b/docs/osdctl_cluster_context.md
@@ -9,7 +9,7 @@ osdctl cluster context --cluster-id <cluster-identifier> [flags]
 ### Options
 
 ```
-  -c, --cluster-id string           Provide internal ID of the cluster
+  -C, --cluster-id string           Provide internal ID of the cluster
   -d, --days int                    Command will display X days of Error SLs sent to the cluster. Days is set to 30 by default (default 30)
       --full                        Run full suite of checks.
   -h, --help                        help for context

--- a/docs/osdctl_cluster_detach-stuck-volume.md
+++ b/docs/osdctl_cluster_detach-stuck-volume.md
@@ -9,7 +9,7 @@ osdctl cluster detach-stuck-volume --cluster-id <cluster-identifier> [flags]
 ### Options
 
 ```
-      --cluster-id string   Provide internal ID of the cluster
+  -C, --cluster-id string   Provide internal ID of the cluster
   -h, --help                help for detach-stuck-volume
       --reason string       The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket)
 ```

--- a/docs/osdctl_cluster_etcd-health-check.md
+++ b/docs/osdctl_cluster_etcd-health-check.md
@@ -13,7 +13,7 @@ osdctl cluster etcd-health-check --cluster-id <cluster-id> --reason <reason for 
 ### Options
 
 ```
-      --cluster-id string   Provide the internal Cluster ID or name to perform health check on
+  -C, --cluster-id string   Provide the internal Cluster ID or name to perform health check on
   -h, --help                help for etcd-health-check
       --reason string       Specify a reason for privilege escalation
 ```

--- a/docs/osdctl_cluster_etcd-member-replace.md
+++ b/docs/osdctl_cluster_etcd-member-replace.md
@@ -13,7 +13,7 @@ osdctl cluster etcd-member-replace --cluster-id <cluster-identifier> [flags]
 ### Options
 
 ```
-      --cluster-id string   Provide internal Cluster ID
+  -C, --cluster-id string   Provide internal Cluster ID
   -h, --help                help for etcd-member-replace
       --node string         Node ID (required)
       --reason string       The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket)

--- a/docs/osdctl_cluster_hypershift-info.md
+++ b/docs/osdctl_cluster_hypershift-info.md
@@ -14,7 +14,7 @@ osdctl cluster hypershift-info [flags]
 ### Options
 
 ```
-  -c, --cluster-id string           Provide internal ID of the cluster
+  -C, --cluster-id string           Provide internal ID of the cluster
   -h, --help                        help for hypershift-info
   -o, --output string               output format ['table', 'graphviz'] (default "graphviz")
   -l, --privatelinkaccount string   Privatelink account ID

--- a/docs/osdctl_cluster_logging-check.md
+++ b/docs/osdctl_cluster_logging-check.md
@@ -9,7 +9,7 @@ osdctl cluster logging-check --cluster-id <cluster-identifier> [flags]
 ### Options
 
 ```
-  -c, --cluster-id string   The internal ID of the cluster to check (required)
+  -C, --cluster-id string   The internal ID of the cluster to check (required)
   -h, --help                help for logging-check
       --verbose             Verbose output
 ```

--- a/docs/osdctl_cluster_orgId.md
+++ b/docs/osdctl_cluster_orgId.md
@@ -9,7 +9,7 @@ osdctl cluster orgId --cluster-id <cluster-identifier [flags]
 ### Options
 
 ```
-  -c, --cluster-id string   The internal ID of the cluster to check (required)
+  -C, --cluster-id string   The internal ID of the cluster to check (required)
   -h, --help                help for orgId
 ```
 

--- a/docs/osdctl_cluster_resize_control-plane.md
+++ b/docs/osdctl_cluster_resize_control-plane.md
@@ -25,7 +25,7 @@ osdctl cluster resize control-plane [flags]
 ### Options
 
 ```
-  -c, --cluster-id string     The internal ID of the cluster to perform actions on
+  -C, --cluster-id string     The internal ID of the cluster to perform actions on
   -h, --help                  help for control-plane
       --machine-type string   The target AWS machine type to resize to (e.g. m5.2xlarge)
       --reason string         The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket)

--- a/docs/osdctl_cluster_ssh_key.md
+++ b/docs/osdctl_cluster_ssh_key.md
@@ -44,7 +44,7 @@ Despite the logs from backplane, the ssh key is the only output channelled throu
 ### Options
 
 ```
-      --cluster-id string   Cluster identifier (internal ID, UUID, name, etc) to retrieve the SSH key for. If not specified, the current cluster will be used.
+  -C, --cluster-id string   Cluster identifier (internal ID, UUID, name, etc) to retrieve the SSH key for. If not specified, the current cluster will be used.
   -h, --help                help for key
       --reason string       Provide a reason for accessing the clusters SSH key, used for backplane. Eg: 'OHSS-XXXX', or '#ITN-2024-XXXXX
   -y, --yes                 Skip any confirmation prompts and print the key automatically. Useful for redirects and scripting.

--- a/docs/osdctl_cluster_support_delete.md
+++ b/docs/osdctl_cluster_support_delete.md
@@ -10,7 +10,7 @@ osdctl cluster support delete --cluster-id <cluster-identifier> [flags]
 
 ```
       --all                                Remove all limited support reasons
-  -c, --cluster-id string                  Internal cluster ID (required)
+  -C, --cluster-id string                  Internal cluster ID (required)
   -d, --dry-run                            Dry-run - print the limited support reason about to be sent but don't send it.
   -h, --help                               help for delete
   -i, --limited-support-reason-id string   Limited support reason ID

--- a/docs/osdctl_cluster_support_post.md
+++ b/docs/osdctl_cluster_support_post.md
@@ -27,7 +27,7 @@ The cluster has a second failing ingress controller, which is not supported and 
 ### Options
 
 ```
-  -c, --cluster-id string        Internal Cluster ID (required)
+  -C, --cluster-id string        Internal Cluster ID (required)
       --evidence string          (optional) The reasoning that led to the decision to place the cluster in limited support. Can also be a link to a Jira case. Used for internal service log only.
   -h, --help                     help for post
       --misconfiguration cloud   The type of misconfiguration responsible for the cluster being placed into limited support. Valid values are cloud or `cluster`.

--- a/docs/osdctl_cluster_support_status.md
+++ b/docs/osdctl_cluster_support_status.md
@@ -9,7 +9,7 @@ osdctl cluster support status --cluster-id <cluster-identifier> [flags]
 ### Options
 
 ```
-  -c, --cluster-id string   Cluster ID for which to get support status
+  -C, --cluster-id string   Cluster ID for which to get support status
   -h, --help                help for status
       --verbose             Verbose output
 ```

--- a/docs/osdctl_cluster_validate-pull-secret.md
+++ b/docs/osdctl_cluster_validate-pull-secret.md
@@ -16,7 +16,7 @@ osdctl cluster validate-pull-secret --cluster-id <cluster-identifier> [flags]
 ### Options
 
 ```
-  -c, --cluster-id string   The internal ID of the cluster to check (required)
+  -C, --cluster-id string   The internal ID of the cluster to check (required)
   -h, --help                help for validate-pull-secret
       --reason string       The reason for this command to be run (usually an OHSS or PD ticket), mandatory when using elevate
 ```

--- a/docs/osdctl_dynatrace_dashboard.md
+++ b/docs/osdctl_dynatrace_dashboard.md
@@ -9,7 +9,7 @@ osdctl dynatrace dashboard --cluster-id CLUSTER_ID [flags]
 ### Options
 
 ```
-      --cluster-id string   Provide the id of the cluster
+  -C, --cluster-id string   Provide the id of the cluster
       --dash string         Name of the dashboard you wish to find (default "Central ROSA HCP Dashboard")
   -h, --help                help for dashboard
 ```

--- a/docs/osdctl_dynatrace_gather-logs.md
+++ b/docs/osdctl_dynatrace_gather-logs.md
@@ -25,7 +25,7 @@ osdctl dynatrace gather-logs --cluster-id <cluster-identifier> [flags]
 ### Options
 
 ```
-      --cluster-id string   Internal ID of the HCP cluster to gather logs from (required)
+  -C, --cluster-id string   Internal ID of the HCP cluster to gather logs from (required)
       --dest-dir string     Destination directory for the logs dump, defaults to the local directory.
   -h, --help                help for gather-logs
       --since int           Number of hours (integer) since which to pull logs and events (default 10)

--- a/docs/osdctl_dynatrace_logs.md
+++ b/docs/osdctl_dynatrace_logs.md
@@ -48,7 +48,7 @@ osdctl dynatrace logs --cluster-id <cluster-identifier> [flags]
 ### Options
 
 ```
-      --cluster-id string   Name or Internal ID of the cluster (defaults to current cluster context)
+  -C, --cluster-id string   Name or Internal ID of the cluster (defaults to current cluster context)
       --console             Print the url to the dynatrace web console instead of outputting the logs
       --container strings   Container name(s) (comma-separated)
       --contains string     Include logs which contain a phrase

--- a/docs/osdctl_dynatrace_url.md
+++ b/docs/osdctl_dynatrace_url.md
@@ -9,7 +9,7 @@ osdctl dynatrace url --cluster-id <cluster-identifier> [flags]
 ### Options
 
 ```
-      --cluster-id string   ID of the cluster
+  -C, --cluster-id string   ID of the cluster
   -h, --help                help for url
 ```
 

--- a/docs/osdctl_env.md
+++ b/docs/osdctl_env.md
@@ -36,7 +36,7 @@ osdctl env [flags] [env-alias]
 
 ```
   -a, --api string            OpenShift API URL for individual cluster login
-  -c, --cluster-id string     Cluster ID
+  -C, --cluster-id string     Cluster ID
   -d, --delete                Delete environment
   -k, --export-kubeconfig     Output export kubeconfig statement, to use environment outside of the env directory
   -h, --help                  help for env

--- a/docs/osdctl_hcp_must-gather.md
+++ b/docs/osdctl_hcp_must-gather.md
@@ -20,7 +20,7 @@ osdctl hcp must-gather --cluster-id CLUSTER_ID --gather sc,mc,sc_acm --reason OH
 
 ```
       --acm_image string    Overrides the acm must-gather image being used for acm mc, sc as well as hcp must-gathers. (default "quay.io/stolostron/must-gather:2.11.4-SNAPSHOT-2024-12-02-15-19-44")
-      --cluster-id string   Internal ID of the cluster to gather data from
+  -C, --cluster-id string   Internal ID of the cluster to gather data from
       --gather string       Comma-separated list of gather targets (available: sc, sc_acm, mc, hcp). (default "hcp")
   -h, --help                help for must-gather
       --reason string       The reason for this command, which requires elevation (e.g., OHSS ticket or PD incident).


### PR DESCRIPTION
Updated all commands under cmd/ to consistently support the -C shorthand for the --cluster-id flag:

- Added -C shorthand to commands using StringVar (no shorthand previously)
- Standardized existing commands using -c (lowercase) to -C (uppercase)
- Updated documentation to reflect the changes

This ensures a consistent user experience across all osdctl commands that accept cluster ID parameters.

🤖 Generated with [Claude Code](https://claude.ai/code)