### PR TITLE
Fix last month time period calculation to handle year boundaries

### DIFF
--- a/cmd/cost/get.go
+++ b/cmd/cost/get.go
@@ -340,7 +340,8 @@ func getTimePeriod(timePtr *string) (string, string) {
 
 	switch *timePtr {
 	case "LM": //Last Month
-		start = fmt.Sprintf("%d-%02d-%02d", t.Year(), t.Month()-1, 01)
+		prevMonth := t.AddDate(0, -1, 0)
+		start = fmt.Sprintf("%d-%02d-%02d", prevMonth.Year(), prevMonth.Month(), 01)
 		end = fmt.Sprintf("%d-%02d-%02d", t.Year(), t.Month(), 01)
 	case "MTD":
 		start = fmt.Sprintf("%d-%02d-%02d", t.Year(), t.Month(), 01)


### PR DESCRIPTION
The LM (Last Month) case in getTimePeriod was using t.Month()-1 which doesn't handle year boundaries correctly. Changed to use AddDate(0, -1, 0) to properly calculate the previous month, fixing the failing test TestGetTimePeriod/Last_Month_(LM).

🤖 Generated with [Claude Code](https://claude.ai/code)