### PR TITLE
Hosted cluster dump and a dynatrace logs export

### DIFF
--- a/cmd/dynatrace/hcpGatherLogsCmd.go
+++ b/cmd/dynatrace/hcpGatherLogsCmd.go
@@ -44,7 +44,7 @@ func NewCmdHCPMustGather() *cobra.Command {
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
 
-			err := g.GatherLogs(g.ClusterID)
+			err := g.GatherLogs(g.ClusterID, "")
 			if err != nil {
 				cmdutil.CheckErr(err)
 			}
@@ -62,7 +62,7 @@ func NewCmdHCPMustGather() *cobra.Command {
 	return hcpMgCmd
 }
 
-func (g *GatherLogsOpts) GatherLogs(clusterID string) (error error) {
+func (g *GatherLogsOpts) GatherLogs(clusterID string, elevationReasons ...string) (error error) {
 	accessToken, err := getStorageAccessToken()
 	if err != nil {
 		return fmt.Errorf("failed to acquire access token %v", err)
@@ -73,7 +73,7 @@ func (g *GatherLogsOpts) GatherLogs(clusterID string) (error error) {
 		return err
 	}
 
-	_, _, clientset, err := common.GetKubeConfigAndClient(hcpCluster.managementClusterID, "", "")
+	_, _, clientset, err := common.GetKubeConfigAndClient(hcpCluster.managementClusterID, elevationReasons...)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve Kubernetes configuration and client for cluster with ID %s: %w", hcpCluster.managementClusterID, err)
 	}

--- a/cmd/hcp/mustgather/mustGather.go
+++ b/cmd/hcp/mustgather/mustGather.go
@@ -181,13 +181,13 @@ func (mg *mustGather) Run() error {
 				// 2. ACM must-gather which includes running the hypershift binary for a dump
 				clusterHyperShift, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(mg.clusterId).Hypershift().Get().Send()
 				if err != nil {
-					fmt.Printf("failed to get OCM cluster hypershift info for %s: %v\n", mg.clusterId, err)
+					fmt.Printf("collected HCP dynatrace logs but failed to get OCM cluster hypershift info for %s: %v\n", mg.clusterId, err)
 					return
 				}
 
 				hcpNamespace, ok := clusterHyperShift.Body().GetHCPNamespace()
 				if !ok {
-					fmt.Println("failed to get HCP namespace")
+					fmt.Println("collected HCP dynatrace logs but failed to get HCP namespace")
 					return
 				}
 
@@ -198,8 +198,9 @@ func (mg *mustGather) Run() error {
 				acmHyperShiftImage := "quay.io/rokejungrh/must-gather:v2.13.0-33-linux"
 				gatherScript := fmt.Sprintf("/usr/bin/gather hosted-cluster-namespace=%s hosted-cluster-name=%s", hcNamespace, hcName)
 				if err := createMustGather(mcRestCfg, mcK8sCli, []string{"--dest-dir=" + destDir, "--image=" + acmHyperShiftImage, gatherScript}); err != nil {
-					fmt.Printf("failed to gather %s: %v\n", gatherTarget, err)
+					fmt.Printf("collected HCP dynatrace logs but failed to gather %s: %v\n", gatherTarget, err.Error())
 				}
+
 			default:
 				fmt.Printf("unknown gather type: %s\n", gatherTarget)
 			}


### PR DESCRIPTION
This work is a part of enabling MCS team do to must-gather via `osdctl`, where the goal is to collect logs only for Hosted cluster.  

Testing and validation:
Testing has been completed at local by using below steps.
- Created binary using `make build`
- Executed command to start gathering hcp logs `/osdctl/dist/osdctl_linux_arm64_v8.0/osdctl hcp must-gather --cluster-id <HCP-CLUSTER-ID> --reason <REASON>`
- Logs has been collected and verified.

Sample output from above command
`
.
.
All must-gather tasks completed. Creating tarball.
Data collection completed successfully in: /tmp/cluster_dump_<HCP-CLUSTER-ID>_20250806150915
Compressed archive has been created at: /tmp/cluster_dump_<HCP-CLUSTER-ID>_20250806150915/cluster_dump_<HCP-CLUSTER-ID>_20250806150915.tar.gz`

Reference Tickets:
https://issues.redhat.com/browse/SREP-1084
https://issues.redhat.com/browse/SREP-1328