### PR TITLE
Use boilerplate v8 in CI

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: boilerplate
   namespace: openshift
-  tag: image-v7.2.0
+  tag: image-v8.0.0


### PR DESCRIPTION
Use the latest UBI9 and Go 1.24 boilerplate image for running CI