### PR TITLE
SREP-1191: add SDN-to-OVN migration check to osdctl cluster context

### DIFF
--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -925,17 +925,14 @@ func (data *contextData) printClusterHeader(w io.Writer) {
 	fmt.Fprintln(w, strings.Repeat("=", len(clusterHeader)))
 }
 
-func printMigrationStatus(data *contextData, w io.Writer) {
-	var name string = "Migration Status"
+func printSDNtoOVNMigrationStatus(data *contextData, w io.Writer) {
+	var name string = "SDN to OVN Migration Status"
 	fmt.Fprintln(w, "\n"+delimiter+name)
-
-	if data.SdnToOvnMigration == nil {
-		fmt.Fprintln(w, "No active SDN to OVN migrations")
-		return
-	}
 
 	if data.SdnToOvnMigration != nil && data.MigrationStateValue == cmv1.ClusterMigrationStateValueInProgress {
 		fmt.Fprintln(w, "SDN to OVN migration is in progress")
+		return
 	}
 
+	fmt.Fprintln(w, "No active SDN to OVN migrations")
 }

--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -281,8 +281,8 @@ func (o *contextOptions) printLongOutput(data *contextData, w io.Writer) {
 	// Print User Banned Details
 	printUserBannedStatus(data, w)
 
-	// Print Migration Status
-	printMigrationStatus(data, w)
+	// Print SDNtoOVN Migration Status
+	printSDNtoOVNMigrationStatus(data, w)
 }
 
 func (o *contextOptions) printShortOutput(data *contextData, w io.Writer) {
@@ -571,11 +571,11 @@ func (o *contextOptions) generateContextData() (*contextData, []error) {
 			return
 		}
 
-		migration, ok := migrationResponse.GetSdnToOvn()
+		sdntoovnmigration, ok := migrationResponse.GetSdnToOvn()
 		if !ok {
 			return
 		}
-		data.SdnToOvnMigration = migration
+		data.SdnToOvnMigration = sdntoovnmigration
 		if state, ok := migrationResponse.GetState(); ok {
 			data.MigrationStateValue = state.Value()
 		}
@@ -930,7 +930,7 @@ func printMigrationStatus(data *contextData, w io.Writer) {
 	fmt.Fprintln(w, "\n"+delimiter+name)
 
 	if data.SdnToOvnMigration == nil {
-		fmt.Fprintln(w, "No active migrations")
+		fmt.Fprintln(w, "No active SDN to OVN migrations")
 		return
 	}
 

--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -926,7 +926,7 @@ func (data *contextData) printClusterHeader(w io.Writer) {
 }
 
 func printSDNtoOVNMigrationStatus(data *contextData, w io.Writer) {
-	var name string = "SDN to OVN Migration Status"
+	name := "SDN to OVN Migration Status"
 	fmt.Fprintln(w, "\n"+delimiter+name)
 
 	if data.SdnToOvnMigration != nil && data.MigrationStateValue == cmv1.ClusterMigrationStateValueInProgress {

--- a/cmd/cluster/context_test.go
+++ b/cmd/cluster/context_test.go
@@ -11,6 +11,7 @@ import (
 	pd "github.com/PagerDuty/go-pagerduty"
 	"github.com/andygrunwald/go-jira"
 	"github.com/aws/aws-sdk-go-v2/service/cloudtrail/types"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	v2 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 	"github.com/openshift/osdctl/pkg/provider/pagerduty"
@@ -581,6 +582,44 @@ func TestPrintUserBannedStatus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			printUserBannedStatus(&tt.data, &buf)
+			actualOutput := buf.String()
+
+			expected := strings.TrimSpace(tt.expectedOutput)
+			actual := strings.TrimSpace(actualOutput)
+
+			if expected != actual {
+				t.Errorf("expected:\n%q\ngot:\n%q", expected, actual)
+			}
+		})
+	}
+}
+func TestPrintMigrationStatus(t *testing.T) {
+	tests := []struct {
+		name           string
+		data           contextData
+		expectedOutput string
+	}{
+		{
+			name: "no active migrations",
+			data: contextData{
+				SdnToOvnMigration: nil,
+			},
+			expectedOutput: "\n>> Migration Status\nNo active migrations",
+		},
+		{
+			name: "migration in progress",
+			data: contextData{
+				SdnToOvnMigration:   &v1.SdnToOvnClusterMigration{},
+				MigrationStateValue: cmv1.ClusterMigrationStateValueInProgress,
+			},
+			expectedOutput: "\n>> Migration Status\nSDN to OVN migration is in progress",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printMigrationStatus(&tt.data, &buf)
 			actualOutput := buf.String()
 
 			expected := strings.TrimSpace(tt.expectedOutput)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -254,6 +254,20 @@ func GetAccount(connection *sdk.Connection, key string) (account *amv1.Account, 
 	return
 }
 
+// GetMigration function gets the migration info for a cluster
+func GetMigration(connection *sdk.Connection, clusterID string) (*cmv1.ClusterMigration, error) {
+	migrationResponse, err := connection.ClustersMgmt().V1().Clusters().Cluster(clusterID).Migrations().List().Send()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve migrations for cluster %s: %v", clusterID, err)
+	}
+
+	if migrationResponse.Items().Len() > 0 {
+		return migrationResponse.Items().Get(0), nil
+	}
+
+	return nil, nil
+}
+
 func GetRegistryCredentials(connection *sdk.Connection, accountId string) ([]*amv1.RegistryCredential, error) {
 	searchString := fmt.Sprintf("account_id = '%s'", accountId)
 	registryCredentials, err := connection.AccountsMgmt().V1().RegistryCredentials().List().Search(searchString).Send()

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -167,4 +167,5 @@ func TestIsValidMatch(t *testing.T) {
 			t.Errorf("Test %d failed: isValidMatch() = %v; want %v", i, got, tt.shouldPass)
 		}
 	}
+
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -167,5 +167,4 @@ func TestIsValidMatch(t *testing.T) {
 			t.Errorf("Test %d failed: isValidMatch() = %v; want %v", i, got, tt.shouldPass)
 		}
 	}
-
 }


### PR DESCRIPTION
This PR increases visibility into the progress or health of an SDN-to-OVN migration by adding a `Migration Status` row to the output of `osdctl cluster context -C $CLUSTER_ID`. It uses the OCM API to get cluster specific migration status.