### PR TITLE
SREP-949: osdctl should be extended to allow quickly and easily pushing a hotfix version to the fleet for a given codebase

### DIFF
--- a/cmd/promote/git/app_interface.go
+++ b/cmd/promote/git/app_interface.go
@@ -323,3 +323,21 @@ func (a *AppInterface) CommitSaasFile(saasFile, commitMessage string) error {
 
 	return nil
 }
+
+func (a *AppInterface) CommitSaasAndAppYmlFile(saasFile, serviceName, commitMessage string) error {
+	if err := a.GitExecutor.Run(a.GitDirectory, "git", "add", saasFile); err != nil {
+		return fmt.Errorf("failed to add file %s: %v", saasFile, err)
+	}
+
+	componentName := strings.TrimPrefix(serviceName, "saas-")
+	appYmlPath := filepath.Join(a.GitDirectory, "data", "services", componentName, "app.yml")
+	if err := a.GitExecutor.Run(a.GitDirectory, "git", "add", appYmlPath); err != nil {
+		return fmt.Errorf("failed to add file %s: %v", appYmlPath, err)
+	}
+
+	if err := a.GitExecutor.Run(a.GitDirectory, "git", "commit", "-m", commitMessage); err != nil {
+		return fmt.Errorf("failed to commit changes: %v", err)
+	}
+
+	return nil
+}

--- a/cmd/promote/saas/saas.go
+++ b/cmd/promote/saas/saas.go
@@ -16,6 +16,7 @@ type saasOptions struct {
 	serviceName             string
 	gitHash                 string
 	namespaceRef            string
+	hotfix                  bool
 }
 
 // newCmdSaas implementes the saas command to interact with promoting SaaS services/operators
@@ -52,7 +53,13 @@ func NewCmdSaas() *cobra.Command {
 				return cmd.Help()
 			}
 
-			err := servicePromotion(appInterface, ops.serviceName, ops.gitHash, ops.namespaceRef, ops.osd, ops.hcp)
+			if ops.hotfix && ops.gitHash == "" {
+				fmt.Printf("Error: --hotfix requires --gitHash to be specified\n\n")
+
+				return cmd.Help()
+			}
+
+			err := servicePromotion(appInterface, ops.serviceName, ops.gitHash, ops.namespaceRef, ops.osd, ops.hcp, ops.hotfix)
 			if err != nil {
 				fmt.Printf("Error while promoting service: %v\n", err)
 			}
@@ -68,6 +75,7 @@ func NewCmdSaas() *cobra.Command {
 	saasCmd.Flags().BoolVarP(&ops.osd, "osd", "", false, "OSD service/operator getting promoted")
 	saasCmd.Flags().BoolVarP(&ops.hcp, "hcp", "", false, "HCP service/operator getting promoted")
 	saasCmd.Flags().StringVarP(&ops.appInterfaceCheckoutDir, "appInterfaceDir", "", "", "location of app-interface checkout. Falls back to current working directory")
+	saasCmd.Flags().BoolVarP(&ops.hotfix, "hotfix", "", false, "Add gitHash to hotfixVersions in app.yml to bypass progressive delivery (requires --gitHash)")
 
 	return saasCmd
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -3464,6 +3464,7 @@ osdctl promote saas [flags]
   -g, --gitHash string                   Git hash of the SaaS service/operator commit getting promoted
       --hcp                              HCP service/operator getting promoted
   -h, --help                             help for saas
+      --hotfix                           Add gitHash to hotfixVersions in app.yml to bypass progressive delivery (requires --gitHash)
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
   -l, --list                             List all SaaS services/operators

--- a/docs/osdctl_promote_saas.md
+++ b/docs/osdctl_promote_saas.md
@@ -26,6 +26,7 @@ osdctl promote saas [flags]
   -g, --gitHash string           Git hash of the SaaS service/operator commit getting promoted
       --hcp                      HCP service/operator getting promoted
   -h, --help                     help for saas
+      --hotfix                   Add gitHash to hotfixVersions in app.yml to bypass progressive delivery (requires --gitHash)
   -l, --list                     List all SaaS services/operators
   -n, --namespaceRef string      SaaS target namespace reference name
       --osd                      OSD service/operator getting promoted


### PR DESCRIPTION
This PR introduces an optional --hotfix flag for the osdctl promote saas command to support emergency deployments that bypass progressive delivery.

  Key changes:
  - Added --hotfix flag that must be used with --gitHash pointing to a valid and tested commit SHA
  -  When enabled, the flag creates or overwrites the hotfixVersions array in the corresponding app.yml file under codeComponents with the specified commit SHA

  How it works:
  1. The --hotfix flag requires --gitHash to be specified (validation enforced)
  2. During promotion, the tool locates the service's app.yml file at data/services/{component}/app.yml
  3. Updates the matching codeComponent entry by setting/overwriting hotfixVersions: [\<gitHash>]
  4. Commits both the saas promotion and app.yml changes in a single commit

  This follows the hotfix process outlined in the https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/the-app-sre-hotfix-path.md and allows critical fixes to be deployed across the fleet immediately without waiting for progressive rollout gates.

🤖 Generated with [Claude Code](https://claude.ai/code)