### PR TITLE
OSD-26415: Add update-pull-secret cmd. Updates, fixes to transfer-owner cmd. 

### DIFF
--- a/cmd/cluster/cmd.go
+++ b/cmd/cluster/cmd.go
@@ -31,6 +31,7 @@ func NewCmdCluster(streams genericclioptions.IOStreams, client *k8s.LazyClient, 
 	clusterCmd.AddCommand(newCmdResync())
 	clusterCmd.AddCommand(newCmdContext())
 	clusterCmd.AddCommand(newCmdTransferOwner(streams, globalOpts))
+	clusterCmd.AddCommand(newCmdUpdatePullSecret(streams, globalOpts))
 	clusterCmd.AddCommand(access.NewCmdAccess(streams, client))
 	clusterCmd.AddCommand(newCmdCpd())
 	clusterCmd.AddCommand(newCmdCheckBannedUser())

--- a/cmd/cluster/updatepullsecret.go
+++ b/cmd/cluster/updatepullsecret.go
@@ -1,0 +1,42 @@
+package cluster
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/openshift/osdctl/internal/utils/globalflags"
+)
+
+const updatePullSecCmdExample = `
+  # Update Pull Secret's OCM access token data
+  osdctl cluster update-pull-secret --cluster-id 1kfmyclusteristhebesteverp8m --reason "Update PullSecret per pd or jira-id"
+`
+
+func newCmdUpdatePullSecret(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *cobra.Command {
+	ops := newTransferOwnerOptions(streams, globalOpts)
+	updatePullSecretCmd := &cobra.Command{
+		Use:               "update-pull-secret",
+		Short:             "Update cluster pullsecret with current OCM accessToken data(to be done by Region Lead)",
+		Args:              cobra.NoArgs,
+		Example:           updatePullSecCmdExample,
+		DisableAutoGenTag: true,
+		PreRun:            func(cmd *cobra.Command, args []string) { cmdutil.CheckErr(ops.preRun()) },
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(ops.run())
+		},
+	}
+	// can we get cluster-id from some context maybe?
+	updatePullSecretCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "The Internal Cluster ID/External Cluster ID/ Cluster Name")
+	updatePullSecretCmd.Flags().BoolVarP(&ops.dryrun, "dry-run", "d", false, "Dry-run - show all changes but do not apply them")
+	updatePullSecretCmd.Flags().StringVar(&ops.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket)")
+
+	_ = updatePullSecretCmd.MarkFlagRequired("cluster-id")
+	_ = updatePullSecretCmd.MarkFlagRequired("reason")
+	// This arg is used as part of this wrapper command to instruct the transfer op to exit after
+	// updating the pull secret, and before doing the ownership transfer...
+	updatePullSecretCmd.Flags().BoolVar(&ops.doPullSecretOnly, "pull-secret-only", true, "Update cluster pull secret from current OCM AccessToken data without ownership transfer")
+	_ = updatePullSecretCmd.Flags().MarkHidden("pull-secret-only")
+
+	return updatePullSecretCmd
+}

--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -116,6 +116,10 @@ func (o *PostCmdOptions) Validate() error {
 	return nil
 }
 
+func (o *PostCmdOptions) SetDryRun(dryRun bool) {
+	o.isDryRun = dryRun
+}
+
 // CheckServiceLogsLastHour returns true if there were servicelogs sent in the past hour, otherwise false
 func CheckServiceLogsLastHour(clusterId string) bool {
 	timeStampToCompare := time.Now().Add(-time.Hour)

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@
     - `post --cluster-id <cluster-identifier>` - Send limited support reason to a given cluster
     - `status --cluster-id <cluster-identifier>` - Shows the support status of a specified cluster
   - `transfer-owner` - Transfer cluster ownership to a new user (to be done by Region Lead)
+  - `update-pull-secret` - Update cluster pullsecret with current OCM accessToken data(to be done by Region Lead)
   - `validate-pull-secret --cluster-id <cluster-identifier>` - Checks if the pull secret email matches the owner email
   - `validate-pull-secret-ext [CLUSTER_ID]` - Extended checks to confirm pull-secret data is synced with current OCM data
 - `cost` - Cost Management related utilities
@@ -1983,6 +1984,33 @@ osdctl cluster transfer-owner [flags]
       --old-owner string                 The old owner's username to transfer the cluster from
   -o, --output string                    Valid formats are ['', 'json', 'yaml', 'env']
       --reason string                    The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)
+      --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                    The address and port of the Kubernetes API server
+      --skip-aws-proxy-check aws_proxy   Don't use the configured aws_proxy value
+  -S, --skip-version-check               skip checking to see if this is the most recent release
+```
+
+### osdctl cluster update-pull-secret
+
+Update cluster pullsecret with current OCM accessToken data(to be done by Region Lead)
+
+```
+osdctl cluster update-pull-secret [flags]
+```
+
+#### Flags
+
+```
+      --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --cluster string                   The name of the kubeconfig cluster to use
+  -C, --cluster-id string                The Internal Cluster ID/External Cluster ID/ Cluster Name
+      --context string                   The name of the kubeconfig context to use
+  -d, --dry-run                          Dry-run - show all changes but do not apply them
+  -h, --help                             help for update-pull-secret
+      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
+  -o, --output string                    Valid formats are ['', 'json', 'yaml', 'env']
+      --reason string                    The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket)
       --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                    The address and port of the Kubernetes API server
       --skip-aws-proxy-check aws_proxy   Don't use the configured aws_proxy value

--- a/docs/osdctl_cluster.md
+++ b/docs/osdctl_cluster.md
@@ -45,6 +45,7 @@ Provides information for a specified cluster
 * [osdctl cluster ssh](osdctl_cluster_ssh.md)	 - utilities for accessing cluster via ssh
 * [osdctl cluster support](osdctl_cluster_support.md)	 - Cluster Support
 * [osdctl cluster transfer-owner](osdctl_cluster_transfer-owner.md)	 - Transfer cluster ownership to a new user (to be done by Region Lead)
+* [osdctl cluster update-pull-secret](osdctl_cluster_update-pull-secret.md)	 - Update cluster pullsecret with current OCM accessToken data(to be done by Region Lead)
 * [osdctl cluster validate-pull-secret](osdctl_cluster_validate-pull-secret.md)	 - Checks if the pull secret email matches the owner email
 * [osdctl cluster validate-pull-secret-ext](osdctl_cluster_validate-pull-secret-ext.md)	 - Extended checks to confirm pull-secret data is synced with current OCM data
 

--- a/docs/osdctl_cluster_update-pull-secret.md
+++ b/docs/osdctl_cluster_update-pull-secret.md
@@ -1,17 +1,17 @@
-## osdctl cluster transfer-owner
+## osdctl cluster update-pull-secret
 
-Transfer cluster ownership to a new user (to be done by Region Lead)
+Update cluster pullsecret with current OCM accessToken data(to be done by Region Lead)
 
 ```
-osdctl cluster transfer-owner [flags]
+osdctl cluster update-pull-secret [flags]
 ```
 
 ### Examples
 
 ```
 
-  # Transfer ownership
-  osdctl cluster transfer-owner --new-owner "$NEW_ACCOUNT" --old-owner "$OLD_ACCOUNT" --cluster-id 1kfmyclusteristhebesteverp8m --reason "transfer ownership per jira-id"
+  # Update Pull Secret's OCM access token data
+  osdctl cluster update-pull-secret --cluster-id 1kfmyclusteristhebesteverp8m --reason "Update PullSecret per pd or jira-id"
 
 ```
 
@@ -20,10 +20,8 @@ osdctl cluster transfer-owner [flags]
 ```
   -C, --cluster-id string   The Internal Cluster ID/External Cluster ID/ Cluster Name
   -d, --dry-run             Dry-run - show all changes but do not apply them
-  -h, --help                help for transfer-owner
-      --new-owner string    The new owner's username to transfer the cluster to
-      --old-owner string    The old owner's username to transfer the cluster from
-      --reason string       The reason for this command, which requires elevation, to be run (usualy an OHSS or PD ticket)
+  -h, --help                help for update-pull-secret
+      --reason string       The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This PR attempts to allow a user to update a cluster's pull secret w/o transferring ownership for both classic and HCP clusters. (closes PR#705)

- This adds a new command 'osdctl cluster update-pull-secret'. This cmd is a wrapper re-using the transfer-owner's pullsecret update functions and general flow, leveraging the hidden'--pull-secret-only' (bool) flag.
- When 'updating the pull secret only' is used the utility will now exit after the pull secret is updated with the account's OCM accessToken values. 
- The pull secret only op prompts user to choose to send an internal service log before the operation begins, and prompts to send a customer service log after the operation completes. 
- This adds additional programmatic checks/comparisons of the resulting on cluster pull-secret auths for the end user to review. ( transfer-owner and update-pull-secret)
- The new programmatic checks/comparisons may negate the need for printing to the terminal for visual comparison. Previously this util printed the secret data to the terminal, this PR changes this to instead warn + prompt the user to choose whether or not to print the raw data for the optional visual inspection. ( transfer-owner and update-pull-secret)
- Updates to existing 'Dry-run' when transferring-owner: Do not update pull-secret, roll pods, and pass 'dryrun' flag to service logs . ( transfer-owner and update-pull-secret)
- Additional information and formatting of errors. ( transfer-owner and update-pull-secret)

Example usage:
```
osdctl cluster update-pull-secret -h
Update cluster pullsecret with current OCM accessToken data(to be done by Region Lead)

Usage:
  osdctl cluster update-pull-secret [flags]

Examples:

  # Update Pull Secret's OCM access token data
  osdctl cluster update-pull-secret --cluster-id 1kfmyclusteristhebesteverp8m --reason "Update PullSecret per pd or jira-id"


Flags:
  -C, --cluster-id string   The Internal Cluster ID/External Cluster ID/ Cluster Name
  -d, --dry-run             Dry-run - show all changes but do not apply them
  -h, --help                help for update-pull-secret
      --reason string       The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket
```