### PR TITLE
SREP-966: reimplement pull-secret email validation without backplane elevation

### DIFF
--- a/cmd/cluster/validatepullsecret.go
+++ b/cmd/cluster/validatepullsecret.go
@@ -3,33 +3,30 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"regexp"
-	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
-	backplaneapi "github.com/openshift/backplane-api/pkg/client"
 	bpapi "github.com/openshift/backplane-cli/pkg/backplaneapi"
 	bpconfig "github.com/openshift/backplane-cli/pkg/cli/config"
 	bputils "github.com/openshift/backplane-cli/pkg/utils"
 	"github.com/openshift/osdctl/cmd/servicelog"
+	"github.com/openshift/osdctl/pkg/backplane"
 	"github.com/openshift/osdctl/pkg/k8s"
 	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // validatePullSecretOptions defines the struct for running validate-pull-secret command
 type validatePullSecretOptions struct {
-	clusterID string
-	elevate   bool
-	reason    string
+	clusterID     string
+	managedScript bool
+	reason        string
 }
 
 var emailRegex = regexp.MustCompile(`[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`)
@@ -41,9 +38,10 @@ func newCmdValidatePullSecret() *cobra.Command {
 		Short: "Checks if the pull secret email matches the owner email",
 		Long: `Checks if the pull secret email matches the owner email.
 
-The command will first attempt to create a managedjob on the cluster to complete the task.
+The command will by default attempt to create a managedjob on the cluster to complete the task.
 However if this fails (e.g. pod fails to run on the cluster), the fallback option of elevating
-with backplane (requires reason and cluster-id) can be run.
+with backplane (requires reason for elevation) can be run. You can also directly use backplane
+elevation by setting --managed-script=false.
 `,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
@@ -53,7 +51,7 @@ with backplane (requires reason and cluster-id) can be run.
 	}
 
 	validatePullSecretCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "The internal ID of the cluster to check (only required if elevating, and ID is not found within context.)")
-	validatePullSecretCmd.Flags().BoolVar(&ops.elevate, "elevate", false, "Skip managed job approach and use backplane elevation directly")
+	validatePullSecretCmd.Flags().BoolVar(&ops.managedScript, "managed-script", true, "Use managed job approach to get pull secret (default true). Set to false to use backplane elevation directly")
 	validatePullSecretCmd.Flags().StringVar(&ops.reason, "reason", "", "The reason for this command to be run (usually an OHSS or PD ticket)")
 
 	return validatePullSecretCmd
@@ -85,7 +83,7 @@ func (o *validatePullSecretOptions) run() error {
 	var emailCluster string
 	var clusterErr error
 
-	if !o.elevate {
+	if o.managedScript {
 		fmt.Println("Creating managedjob in-cluster to get pull-secret email")
 		emailCluster, clusterErr = o.getPullSecretWithManagedJob()
 		if clusterErr != nil {
@@ -94,7 +92,7 @@ func (o *validatePullSecretOptions) run() error {
 		}
 	}
 
-	if o.elevate || clusterErr != nil {
+	if !o.managedScript || clusterErr != nil {
 		if o.reason == "" {
 			var err error
 			o.reason, err = o.promptForReason()
@@ -135,117 +133,20 @@ func (o *validatePullSecretOptions) getPullSecretWithManagedJob() (email string,
 		return "", fmt.Errorf("failed to create backplane API client: %w", err)
 	}
 
-	return o.runManagedJobWithClient(bpclient)
-}
-
-func (o *validatePullSecretOptions) runManagedJobWithClient(client backplaneapi.ClientInterface) (email string, err error) {
+	client := backplane.NewClient(bpclient, o.clusterID)
 	canonicalName := "security/get-pull-secret-email"
-	parameters := map[string]string{} // No params needed for get-pullsecret
-	createJob := backplaneapi.CreateJobJSONRequestBody{
-		CanonicalName: &canonicalName,
-		Parameters:    &parameters,
-	}
+	parameters := map[string]string{}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second) // allow a timeout deadline for the job to return
-	defer cancel()
-
-	fmt.Printf("\nCreating managed job for script: %s on cluster: %s\n", canonicalName, o.clusterID)
-	resp, err := client.CreateJob(ctx, o.clusterID, createJob)
+	result, err := client.RunManagedJobWithClient(canonicalName, parameters, 60)
 	if err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
-			return "", fmt.Errorf("timeout deadline reached: was unable to create the job within the deadline")
-		}
-		return "", fmt.Errorf("failed to create managed job: %w", err)
+		return "", err
 	}
 
-	if resp.StatusCode != 200 {
-		defer resp.Body.Close()
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("managed job creation failed with status: %d, body: %s", resp.StatusCode, string(bodyBytes))
-	}
+	fmt.Printf("email from managedjob (cluster): %s\n", result.Output)
 
-	job, err := backplaneapi.ParseCreateJobResponse(resp)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse job creation response: %w", err)
-	}
-
-	if job.JSON200 == nil || job.JSON200.JobId == nil {
-		return "", fmt.Errorf("no job ID returned from create job")
-	}
-
-	jobID := *job.JSON200.JobId
-	fmt.Printf("Job %s created. Waiting for it to finish running. (Timeout in 60s)\n", jobID)
-
-	pollCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	err = wait.PollUntilContextTimeout(pollCtx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
-		runResp, err := client.GetRun(ctx, o.clusterID, jobID)
-		if err != nil {
-			return false, fmt.Errorf("failed to get job status: %w", err)
-		}
-
-		if runResp.StatusCode != 200 {
-			bodyBytes, _ := io.ReadAll(runResp.Body)
-			runResp.Body.Close()
-			return false, fmt.Errorf("failed to get job status: %d, body: %s", runResp.StatusCode, string(bodyBytes))
-		}
-
-		run, err := backplaneapi.ParseGetRunResponse(runResp)
-		if err != nil {
-			return false, fmt.Errorf("failed to parse job status response: %w", err)
-		}
-
-		if run.JSON200 == nil || run.JSON200.JobStatus == nil || run.JSON200.JobStatus.Status == nil {
-			return false, nil
-		}
-
-		status := *run.JSON200.JobStatus.Status
-		fmt.Printf("Job status: %s\n", status)
-
-		switch status {
-		case backplaneapi.JobStatusStatusSucceeded:
-			return true, nil
-		case backplaneapi.JobStatusStatusFailed:
-			return false, fmt.Errorf("job failed with status: %s", status)
-		case backplaneapi.JobStatusStatusKilled:
-			return false, fmt.Errorf("job was killed")
-		default:
-			return false, nil
-		}
-	})
-	if err != nil {
-		return "", fmt.Errorf("managed job did not complete successfully: %w", err)
-	}
-
-	v2 := "v2"
-	logsParams := &backplaneapi.GetJobLogsParams{
-		Version: &v2,
-	}
-	logsResp, err := client.GetJobLogs(context.Background(), o.clusterID, jobID, logsParams)
-	if err != nil {
-		return "", fmt.Errorf("failed to get job logs: %w", err)
-	}
-
-	if logsResp.StatusCode != 200 {
-		bodyBytes, _ := io.ReadAll(logsResp.Body)
-		logsResp.Body.Close()
-		return "", fmt.Errorf("failed to retrieve job logs: %d, body: %s", logsResp.StatusCode, string(bodyBytes))
-	}
-
-	logBytes, err := io.ReadAll(logsResp.Body)
-	logsResp.Body.Close()
-	if err != nil {
-		return "", fmt.Errorf("failed to read job logs: %w", err)
-	}
-
-	logOutput := string(logBytes)
-	fmt.Printf("email from managedjob (cluster): %s\n", logOutput)
-
-	email = emailRegex.FindString(logOutput)
-
+	email = emailRegex.FindString(result.Output)
 	if email == "" {
-		return "", fmt.Errorf("failed to extract email from job output: %s", logOutput)
+		return "", fmt.Errorf("failed to extract email from job output: %s", result.Output)
 	}
 
 	return email, nil

--- a/cmd/cluster/validatepullsecret.go
+++ b/cmd/cluster/validatepullsecret.go
@@ -3,15 +3,24 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
+	"regexp"
+	"time"
 
+	"github.com/AlecAivazis/survey/v2"
 	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+	backplaneapi "github.com/openshift/backplane-api/pkg/client"
+	bpapi "github.com/openshift/backplane-cli/pkg/backplaneapi"
+	bpconfig "github.com/openshift/backplane-cli/pkg/cli/config"
+	bputils "github.com/openshift/backplane-cli/pkg/utils"
 	"github.com/openshift/osdctl/cmd/servicelog"
 	"github.com/openshift/osdctl/pkg/k8s"
 	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -23,6 +32,8 @@ type validatePullSecretOptions struct {
 	reason    string
 }
 
+var emailRegex = regexp.MustCompile(`[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}`)
+
 func newCmdValidatePullSecret() *cobra.Command {
 	ops := newValidatePullSecretOptions()
 	validatePullSecretCmd := &cobra.Command{
@@ -30,7 +41,9 @@ func newCmdValidatePullSecret() *cobra.Command {
 		Short: "Checks if the pull secret email matches the owner email",
 		Long: `Checks if the pull secret email matches the owner email.
 
-This command will automatically login to the cluster to check the current pull-secret defined in 'openshift-config/pull-secret'
+The command will first attempt to create a managedjob on the cluster to complete the task.
+However if this fails (e.g. pod fails to run on the cluster), the fallback option of elevating
+with backplane (requires reason and cluster-id) can be run.
 `,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
@@ -39,14 +52,10 @@ This command will automatically login to the cluster to check the current pull-s
 		},
 	}
 
-	// Add cluster-id flag
-	validatePullSecretCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "The internal ID of the cluster to check (required)")
-	if err := validatePullSecretCmd.MarkFlagRequired("cluster-id"); err != nil {
-		fmt.Printf("Error marking cluster-id flag as required: %v\n", err)
-	}
+	validatePullSecretCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "The internal ID of the cluster to check (only required if elevating, and ID is not found within context.)")
+	validatePullSecretCmd.Flags().BoolVar(&ops.elevate, "elevate", false, "Skip managed job approach and use backplane elevation directly")
+	validatePullSecretCmd.Flags().StringVar(&ops.reason, "reason", "", "The reason for this command to be run (usually an OHSS or PD ticket)")
 
-	validatePullSecretCmd.Flags().StringVar(&ops.reason, "reason", "", "The reason for this command to be run (usually an OHSS or PD ticket), mandatory when using elevate")
-	_ = validatePullSecretCmd.MarkFlagRequired("reason")
 	return validatePullSecretCmd
 }
 
@@ -55,6 +64,15 @@ func newValidatePullSecretOptions() *validatePullSecretOptions {
 }
 
 func (o *validatePullSecretOptions) run() error {
+	if o.clusterID == "" {
+		bpCluster, err := bputils.DefaultClusterUtils.GetBackplaneCluster()
+		if err != nil {
+			return fmt.Errorf("no cluster-id provided and failed to get cluster from current context: %w. Please provide --cluster-id or ensure you're logged into a cluster", err)
+		}
+		o.clusterID = bpCluster.ClusterID
+		fmt.Printf("Using cluster from current context: %s\n", o.clusterID)
+	}
+
 	// get the pull secret in OCM
 	emailOCM, err, done := o.getPullSecretFromOCM()
 	if err != nil {
@@ -64,13 +82,33 @@ func (o *validatePullSecretOptions) run() error {
 		return nil
 	}
 
-	// get the pull secret in cluster
-	emailCluster, err, done := getPullSecretElevated(o.clusterID, o.reason)
-	if err != nil {
-		return err
+	var emailCluster string
+	var clusterErr error
+
+	if !o.elevate {
+		fmt.Println("Creating managedjob in-cluster to get pull-secret email")
+		emailCluster, clusterErr = o.getPullSecretWithManagedJob()
+		if clusterErr != nil {
+			fmt.Printf("Managed job failed: %v\n", clusterErr)
+			fmt.Println("Falling back to elevated access...")
+		}
 	}
-	if done {
-		return nil
+
+	if o.elevate || clusterErr != nil {
+		if o.reason == "" {
+			var err error
+			o.reason, err = o.promptForReason()
+			if err != nil {
+				return fmt.Errorf("failed to get reason for elevation: %w", err)
+			}
+		}
+		emailCluster, clusterErr, done = getPullSecretElevated(o.clusterID, o.reason)
+		if clusterErr != nil {
+			return clusterErr
+		}
+		if done {
+			return nil
+		}
 	}
 
 	if emailOCM != emailCluster {
@@ -84,6 +122,146 @@ func (o *validatePullSecretOptions) run() error {
 
 	fmt.Println("Email addresses match.")
 	return nil
+}
+
+func (o *validatePullSecretOptions) getPullSecretWithManagedJob() (email string, err error) {
+	bp, err := bpconfig.GetBackplaneConfiguration()
+	if err != nil {
+		return "", fmt.Errorf("failed to load backplane configuration: %w", err)
+	}
+
+	bpclient, err := bpapi.DefaultClientUtils.MakeRawBackplaneAPIClient(bp.URL)
+	if err != nil {
+		return "", fmt.Errorf("failed to create backplane API client: %w", err)
+	}
+
+	return o.runManagedJobWithClient(bpclient)
+}
+
+func (o *validatePullSecretOptions) runManagedJobWithClient(client backplaneapi.ClientInterface) (email string, err error) {
+	canonicalName := "security/get-pull-secret-email"
+	parameters := map[string]string{} // No params needed for get-pullsecret
+	createJob := backplaneapi.CreateJobJSONRequestBody{
+		CanonicalName: &canonicalName,
+		Parameters:    &parameters,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second) // allow a timeout deadline for the job to return
+	defer cancel()
+
+	fmt.Printf("\nCreating managed job for script: %s on cluster: %s\n", canonicalName, o.clusterID)
+	resp, err := client.CreateJob(ctx, o.clusterID, createJob)
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("timeout deadline reached: was unable to create the job within the deadline")
+		}
+		return "", fmt.Errorf("failed to create managed job: %w", err)
+	}
+
+	if resp.StatusCode != 200 {
+		defer resp.Body.Close()
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("managed job creation failed with status: %d, body: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	job, err := backplaneapi.ParseCreateJobResponse(resp)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse job creation response: %w", err)
+	}
+
+	if job.JSON200 == nil || job.JSON200.JobId == nil {
+		return "", fmt.Errorf("no job ID returned from create job")
+	}
+
+	jobID := *job.JSON200.JobId
+	fmt.Printf("Job %s created. Waiting for it to finish running. (Timeout in 60s)\n", jobID)
+
+	pollCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	err = wait.PollUntilContextTimeout(pollCtx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		runResp, err := client.GetRun(ctx, o.clusterID, jobID)
+		if err != nil {
+			return false, fmt.Errorf("failed to get job status: %w", err)
+		}
+
+		if runResp.StatusCode != 200 {
+			bodyBytes, _ := io.ReadAll(runResp.Body)
+			runResp.Body.Close()
+			return false, fmt.Errorf("failed to get job status: %d, body: %s", runResp.StatusCode, string(bodyBytes))
+		}
+
+		run, err := backplaneapi.ParseGetRunResponse(runResp)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse job status response: %w", err)
+		}
+
+		if run.JSON200 == nil || run.JSON200.JobStatus == nil || run.JSON200.JobStatus.Status == nil {
+			return false, nil
+		}
+
+		status := *run.JSON200.JobStatus.Status
+		fmt.Printf("Job status: %s\n", status)
+
+		switch status {
+		case backplaneapi.JobStatusStatusSucceeded:
+			return true, nil
+		case backplaneapi.JobStatusStatusFailed:
+			return false, fmt.Errorf("job failed with status: %s", status)
+		case backplaneapi.JobStatusStatusKilled:
+			return false, fmt.Errorf("job was killed")
+		default:
+			return false, nil
+		}
+	})
+	if err != nil {
+		return "", fmt.Errorf("managed job did not complete successfully: %w", err)
+	}
+
+	v2 := "v2"
+	logsParams := &backplaneapi.GetJobLogsParams{
+		Version: &v2,
+	}
+	logsResp, err := client.GetJobLogs(context.Background(), o.clusterID, jobID, logsParams)
+	if err != nil {
+		return "", fmt.Errorf("failed to get job logs: %w", err)
+	}
+
+	if logsResp.StatusCode != 200 {
+		bodyBytes, _ := io.ReadAll(logsResp.Body)
+		logsResp.Body.Close()
+		return "", fmt.Errorf("failed to retrieve job logs: %d, body: %s", logsResp.StatusCode, string(bodyBytes))
+	}
+
+	logBytes, err := io.ReadAll(logsResp.Body)
+	logsResp.Body.Close()
+	if err != nil {
+		return "", fmt.Errorf("failed to read job logs: %w", err)
+	}
+
+	logOutput := string(logBytes)
+	fmt.Printf("email from managedjob (cluster): %s\n", logOutput)
+
+	email = emailRegex.FindString(logOutput)
+
+	if email == "" {
+		return "", fmt.Errorf("failed to extract email from job output: %s", logOutput)
+	}
+
+	return email, nil
+}
+
+func (o *validatePullSecretOptions) promptForReason() (string, error) {
+	prompt := &survey.Input{
+		Message: "Enter reason for elevation (usually an OHSS or PD ticket):",
+	}
+	var reason string
+	err := survey.AskOne(prompt, &reason, survey.WithValidator(survey.Required))
+	if err != nil {
+		return "", err
+	}
+
+	return reason, nil
 }
 
 // getPullSecretElevated gets the pull-secret in the cluster with backplane elevation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1995,9 +1995,10 @@ osdctl cluster transfer-owner [flags]
 
 Checks if the pull secret email matches the owner email.
 
-The command will first attempt to create a managedjob on the cluster to complete the task.
+The command will by default attempt to create a managedjob on the cluster to complete the task.
 However if this fails (e.g. pod fails to run on the cluster), the fallback option of elevating
-with backplane (requires reason and cluster-id) can be run.
+with backplane (requires reason for elevation) can be run. You can also directly use backplane
+elevation by setting --managed-script=false.
 
 
 ```
@@ -2011,10 +2012,10 @@ osdctl cluster validate-pull-secret --cluster-id <cluster-identifier> [flags]
       --cluster string                   The name of the kubeconfig cluster to use
   -C, --cluster-id string                The internal ID of the cluster to check (only required if elevating, and ID is not found within context.)
       --context string                   The name of the kubeconfig context to use
-      --elevate                          Skip managed job approach and use backplane elevation directly
   -h, --help                             help for validate-pull-secret
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
+      --managed-script                   Use managed job approach to get pull secret (default true). Set to false to use backplane elevation directly (default true)
   -o, --output string                    Valid formats are ['', 'json', 'yaml', 'env']
       --reason string                    The reason for this command to be run (usually an OHSS or PD ticket)
       --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")

--- a/docs/README.md
+++ b/docs/README.md
@@ -1995,7 +1995,9 @@ osdctl cluster transfer-owner [flags]
 
 Checks if the pull secret email matches the owner email.
 
-This command will automatically login to the cluster to check the current pull-secret defined in 'openshift-config/pull-secret'
+The command will first attempt to create a managedjob on the cluster to complete the task.
+However if this fails (e.g. pod fails to run on the cluster), the fallback option of elevating
+with backplane (requires reason and cluster-id) can be run.
 
 
 ```
@@ -2007,13 +2009,14 @@ osdctl cluster validate-pull-secret --cluster-id <cluster-identifier> [flags]
 ```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
-  -C, --cluster-id string                The internal ID of the cluster to check (required)
+  -C, --cluster-id string                The internal ID of the cluster to check (only required if elevating, and ID is not found within context.)
       --context string                   The name of the kubeconfig context to use
+      --elevate                          Skip managed job approach and use backplane elevation directly
   -h, --help                             help for validate-pull-secret
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
   -o, --output string                    Valid formats are ['', 'json', 'yaml', 'env']
-      --reason string                    The reason for this command to be run (usually an OHSS or PD ticket), mandatory when using elevate
+      --reason string                    The reason for this command to be run (usually an OHSS or PD ticket)
       --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                    The address and port of the Kubernetes API server
       --skip-aws-proxy-check aws_proxy   Don't use the configured aws_proxy value

--- a/docs/osdctl_cluster_validate-pull-secret.md
+++ b/docs/osdctl_cluster_validate-pull-secret.md
@@ -6,7 +6,9 @@ Checks if the pull secret email matches the owner email
 
 Checks if the pull secret email matches the owner email.
 
-This command will automatically login to the cluster to check the current pull-secret defined in 'openshift-config/pull-secret'
+The command will first attempt to create a managedjob on the cluster to complete the task.
+However if this fails (e.g. pod fails to run on the cluster), the fallback option of elevating
+with backplane (requires reason and cluster-id) can be run.
 
 
 ```
@@ -16,9 +18,10 @@ osdctl cluster validate-pull-secret --cluster-id <cluster-identifier> [flags]
 ### Options
 
 ```
-  -C, --cluster-id string   The internal ID of the cluster to check (required)
+  -C, --cluster-id string   The internal ID of the cluster to check (only required if elevating, and ID is not found within context.)
+      --elevate             Skip managed job approach and use backplane elevation directly
   -h, --help                help for validate-pull-secret
-      --reason string       The reason for this command to be run (usually an OHSS or PD ticket), mandatory when using elevate
+      --reason string       The reason for this command to be run (usually an OHSS or PD ticket)
 ```
 
 ### Options inherited from parent commands

--- a/docs/osdctl_cluster_validate-pull-secret.md
+++ b/docs/osdctl_cluster_validate-pull-secret.md
@@ -6,9 +6,10 @@ Checks if the pull secret email matches the owner email
 
 Checks if the pull secret email matches the owner email.
 
-The command will first attempt to create a managedjob on the cluster to complete the task.
+The command will by default attempt to create a managedjob on the cluster to complete the task.
 However if this fails (e.g. pod fails to run on the cluster), the fallback option of elevating
-with backplane (requires reason and cluster-id) can be run.
+with backplane (requires reason for elevation) can be run. You can also directly use backplane
+elevation by setting --managed-script=false.
 
 
 ```
@@ -19,8 +20,8 @@ osdctl cluster validate-pull-secret --cluster-id <cluster-identifier> [flags]
 
 ```
   -C, --cluster-id string   The internal ID of the cluster to check (only required if elevating, and ID is not found within context.)
-      --elevate             Skip managed job approach and use backplane elevation directly
   -h, --help                help for validate-pull-secret
+      --managed-script      Use managed job approach to get pull secret (default true). Set to false to use backplane elevation directly (default true)
       --reason string       The reason for this command to be run (usually an OHSS or PD ticket)
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.6
 
 require (
 	cloud.google.com/go/compute v1.37.0
+	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Dynatrace/dynatrace-operator v0.14.2
 	github.com/PagerDuty/go-pagerduty v1.8.0
 	github.com/andygrunwald/go-jira v1.16.0
@@ -40,6 +41,7 @@ require (
 	github.com/openshift-online/ocm-sdk-go v0.1.473
 	github.com/openshift/api v0.0.0-20250207102212-9e59a77ed2e0
 	github.com/openshift/aws-account-operator/api v0.0.0-20250205151445-6455c35fc4ae
+	github.com/openshift/backplane-api v0.0.0-20250514095514-2aa57551ec70
 	github.com/openshift/backplane-cli v0.4.0
 	github.com/openshift/cloud-credential-operator v0.0.0-20250120201329-db5f2531a5b4
 	github.com/openshift/gcp-project-operator v0.0.0-20241024143818-ec4eabd35aba
@@ -83,7 +85,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.7.0 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/99designs/keyring v1.2.2 // indirect
-	github.com/AlecAivazis/survey/v2 v2.3.7 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53 // indirect
@@ -217,7 +218,6 @@ require (
 	github.com/oasdiff/yaml3 v0.0.0-20241214160948-977117996672 // indirect
 	github.com/openshift-online/ocm-api-model/clientapi v0.0.426 // indirect
 	github.com/openshift-online/ocm-api-model/model v0.0.426 // indirect
-	github.com/openshift/backplane-api v0.0.0-20250514095514-2aa57551ec70 // indirect
 	github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect

--- a/pkg/backplane/client.go
+++ b/pkg/backplane/client.go
@@ -1,0 +1,148 @@
+package backplane
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	backplaneapi "github.com/openshift/backplane-api/pkg/client"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type Client struct {
+	backplaneClient backplaneapi.ClientInterface
+	clusterID       string
+}
+
+// NewClient creates a new backplane client
+func NewClient(backplaneClient backplaneapi.ClientInterface, clusterID string) *Client {
+	return &Client{
+		backplaneClient: backplaneClient,
+		clusterID:       clusterID,
+	}
+}
+
+type ManagedJobResult struct {
+	Output string
+	JobID  string
+}
+
+// RunManagedJobWithClient executes a managedscript (with a specified timeout) on the cluster and returns the result
+func (c *Client) RunManagedJobWithClient(canonicalName string, parameters map[string]string, timeoutSeconds int) (*ManagedJobResult, error) {
+	createJob := backplaneapi.CreateJobJSONRequestBody{
+		CanonicalName: &canonicalName,
+		Parameters:    &parameters,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutSeconds)*time.Second)
+	defer cancel()
+
+	fmt.Printf("\nCreating managed job for script: %s on cluster: %s\n", canonicalName, c.clusterID)
+	resp, err := c.backplaneClient.CreateJob(ctx, c.clusterID, createJob)
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("timeout deadline reached: was unable to create the job within the deadline")
+		}
+		return nil, fmt.Errorf("failed to create managed job: %w", err)
+	}
+
+	if resp.StatusCode != 200 {
+		defer resp.Body.Close()
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("managed job creation failed with status: %d, body: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	job, err := backplaneapi.ParseCreateJobResponse(resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse job creation response: %w", err)
+	}
+
+	if job.JSON200 == nil || job.JSON200.JobId == nil {
+		return nil, fmt.Errorf("no job ID returned from create job")
+	}
+
+	jobID := *job.JSON200.JobId
+	fmt.Printf("Job %s created. Waiting for it to finish running. (Timeout in %v seconds)\n", jobID, timeoutSeconds)
+
+	err = c.waitForJobCompletion(jobID)
+	if err != nil {
+		return nil, fmt.Errorf("managed job did not complete successfully: %w", err)
+	}
+
+	output, err := c.getJobLogs(jobID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get job logs: %w", err)
+	}
+
+	return &ManagedJobResult{
+		Output: output,
+		JobID:  jobID,
+	}, nil
+}
+
+func (c *Client) waitForJobCompletion(jobID string) error {
+	pollCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	return wait.PollUntilContextTimeout(pollCtx, 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		runResp, err := c.backplaneClient.GetRun(ctx, c.clusterID, jobID)
+		if err != nil {
+			return false, fmt.Errorf("failed to get job status: %w", err)
+		}
+
+		if runResp.StatusCode != 200 {
+			bodyBytes, _ := io.ReadAll(runResp.Body)
+			runResp.Body.Close()
+			return false, fmt.Errorf("failed to get job status: %d, body: %s", runResp.StatusCode, string(bodyBytes))
+		}
+
+		run, err := backplaneapi.ParseGetRunResponse(runResp)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse job status response: %w", err)
+		}
+
+		if run.JSON200 == nil || run.JSON200.JobStatus == nil || run.JSON200.JobStatus.Status == nil {
+			return false, nil
+		}
+
+		status := *run.JSON200.JobStatus.Status
+		fmt.Printf("Job status: %s\n", status)
+
+		switch status {
+		case backplaneapi.JobStatusStatusSucceeded:
+			return true, nil
+		case backplaneapi.JobStatusStatusFailed:
+			return false, fmt.Errorf("job failed with status: %s", status)
+		case backplaneapi.JobStatusStatusKilled:
+			return false, fmt.Errorf("job was killed")
+		default:
+			return false, nil
+		}
+	})
+}
+
+func (c *Client) getJobLogs(jobID string) (string, error) {
+	v2 := "v2"
+	logsParams := &backplaneapi.GetJobLogsParams{
+		Version: &v2,
+	}
+	logsResp, err := c.backplaneClient.GetJobLogs(context.Background(), c.clusterID, jobID, logsParams)
+	if err != nil {
+		return "", fmt.Errorf("failed to get job logs: %w", err)
+	}
+
+	if logsResp.StatusCode != 200 {
+		bodyBytes, _ := io.ReadAll(logsResp.Body)
+		logsResp.Body.Close()
+		return "", fmt.Errorf("failed to retrieve job logs: %d, body: %s", logsResp.StatusCode, string(bodyBytes))
+	}
+
+	logBytes, err := io.ReadAll(logsResp.Body)
+	logsResp.Body.Close()
+	if err != nil {
+		return "", fmt.Errorf("failed to read job logs: %w", err)
+	}
+
+	return string(logBytes), nil
+}

--- a/pkg/backplane/client_test.go
+++ b/pkg/backplane/client_test.go
@@ -1,0 +1,182 @@
+package backplane
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	backplaneapi "github.com/openshift/backplane-api/pkg/client"
+)
+
+// Mock client: embed the generated interface, override only what we use
+type mockBackplaneClient struct {
+	backplaneapi.ClientInterface
+
+	createJobResponse *http.Response
+	createJobError    error
+	getRunResponse    *http.Response
+	getRunError       error
+	getLogsResponse   *http.Response
+	getLogsError      error
+}
+
+func (m *mockBackplaneClient) CreateJob(
+	ctx context.Context,
+	clusterId string,
+	body backplaneapi.CreateJobJSONRequestBody,
+	reqEditors ...backplaneapi.RequestEditorFn,
+) (*http.Response, error) {
+	return m.createJobResponse, m.createJobError
+}
+
+func (m *mockBackplaneClient) GetRun(
+	ctx context.Context,
+	clusterId string,
+	jobId string,
+	reqEditors ...backplaneapi.RequestEditorFn,
+) (*http.Response, error) {
+	return m.getRunResponse, m.getRunError
+}
+
+func (m *mockBackplaneClient) GetJobLogs(
+	ctx context.Context,
+	clusterId string,
+	jobId string,
+	params *backplaneapi.GetJobLogsParams,
+	reqEditors ...backplaneapi.RequestEditorFn,
+) (*http.Response, error) {
+	return m.getLogsResponse, m.getLogsError
+}
+
+func TestNewClient(t *testing.T) {
+	tests := []struct {
+		name      string
+		clusterID string
+	}{
+		{
+			name:      "Valid cluster ID",
+			clusterID: "test-cluster-123",
+		},
+		{
+			name:      "Empty cluster ID",
+			clusterID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockBackplaneClient{}
+			client := NewClient(mockClient, tt.clusterID)
+
+			if client.clusterID != tt.clusterID {
+				t.Errorf("NewClient() clusterID = %v, expected %v", client.clusterID, tt.clusterID)
+			}
+		})
+	}
+}
+
+func TestGetJobLogs(t *testing.T) {
+	tests := []struct {
+		name          string
+		jobID         string
+		mockResponse  *http.Response
+		mockError     error
+		expectedLogs  string
+		expectedError bool
+		errorContains string
+	}{
+		{
+			name:         "Success",
+			jobID:        "job-123",
+			mockResponse: &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader("test log output"))},
+			expectedLogs: "test log output",
+		},
+		{
+			name:          "Client error",
+			jobID:         "job-456",
+			mockError:     errors.New("network error"),
+			expectedError: true,
+			errorContains: "failed to get job logs",
+		},
+		{
+			name:          "Non-200 status code",
+			jobID:         "job-789",
+			mockResponse:  &http.Response{StatusCode: 404, Body: io.NopCloser(strings.NewReader("not found"))},
+			expectedError: true,
+			errorContains: "failed to retrieve job logs: 404",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockBackplaneClient{
+				getLogsResponse: tt.mockResponse,
+				getLogsError:    tt.mockError,
+			}
+
+			client := NewClient(mockClient, "test-cluster")
+			logs, err := client.getJobLogs(tt.jobID)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("getJobLogs() expected error but got none")
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("getJobLogs() error = %v, expected to contain %v", err, tt.errorContains)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("getJobLogs() unexpected error = %v", err)
+				}
+				if logs != tt.expectedLogs {
+					t.Errorf("getJobLogs() logs = %v, expected %v", logs, tt.expectedLogs)
+				}
+			}
+		})
+	}
+}
+
+func TestRunManagedJobWithClient_CreateJobErrors(t *testing.T) {
+	tests := []struct {
+		name          string
+		mockResponse  *http.Response
+		mockError     error
+		errorContains string
+	}{
+		{
+			name:          "Network error",
+			mockError:     errors.New("connection failed"),
+			errorContains: "failed to create managed job",
+		},
+		{
+			name:          "Non-200 status code",
+			mockResponse:  &http.Response{StatusCode: 400, Body: io.NopCloser(strings.NewReader("bad request"))},
+			errorContains: "managed job creation failed with status: 400",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockBackplaneClient{
+				createJobResponse: tt.mockResponse,
+				createJobError:    tt.mockError,
+			}
+
+			client := NewClient(mockClient, "test-cluster")
+			result, err := client.RunManagedJobWithClient("test-script", map[string]string{}, 60)
+
+			if result != nil {
+				t.Errorf("RunManagedJobWithClient() result = %v, expected nil", result)
+			}
+			if err == nil {
+				t.Errorf("RunManagedJobWithClient() expected error but got none")
+			}
+			if !strings.Contains(err.Error(), tt.errorContains) {
+				t.Errorf("RunManagedJobWithClient() error = %v, expected to contain %v", err, tt.errorContains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR reimplements `osdctl cluster validate-pull-secret` to improve usability by eliminating the default requirement for backplane elevation.

  Key Changes

  Security Enhancement:
  - Primary method now uses backplane-api to execute the [get-pull-secret-email](https://github.com/openshift/managed-scripts/tree/main/scripts/security/get-pull-secret-email) managedscript
  - Removes default elevation requirement, improving security posture
  - Elevation only occurs as fallback when managedscript execution fails

  Improved User Experience:
  - `--cluster-id` is now optional when logged into a cluster (works with both methods)
  - `--reason` is now optional:
    - Not used if managedscript succeeds (no elevation needed)
    - User will be prompted if elevation fallback is required and a reason was not given
  - New `--elevate` flag forces traditional elevation method when desired

  Execution Flow:
  1. Attempts managedscript execution via backplane-api (no elevation)
  2. Falls back to elevation method if managedscript fails
  3. User prompted for elevation reason only when needed
  4. `--elevate` flag bypasses managedscript and uses elevation directly

🤖 Generated with [Claude Code](https://claude.ai/code)