### PR TITLE
Fix formatting of commit message for dynatrace promotions

### DIFF
--- a/cmd/promote/dynatrace/dt_utils.go
+++ b/cmd/promote/dynatrace/dt_utils.go
@@ -309,10 +309,10 @@ func modulePromotion(dynatraceConfig DynatraceConfig, module string) error {
 	if err != nil {
 		return err
 	}
-	commitLog := "Promote Module " + module + " to GitHash %s" + promotionGitHash
-	fmt.Printf("commitLog: %v\n", commitLog)
+	commitMsg := fmt.Sprintf("Promote Module %s to GitHash %s", module, promotionGitHash)
+	fmt.Printf("commitLog: %v\n", commitMsg)
 
-	err = dynatraceConfig.commitFiles(commitLog)
+	err = dynatraceConfig.commitFiles(commitMsg)
 	if err != nil {
 		return fmt.Errorf("failed to commit changes to app-interface: %w", err)
 	}

--- a/cmd/promote/dynatrace/dynatrace.go
+++ b/cmd/promote/dynatrace/dynatrace.go
@@ -19,7 +19,7 @@ type promoteDynatraceOptions struct {
 	dynatraceConfigCheckoutDir string
 }
 
-// NewCmdPromote implements the promote command to promote services/operators
+// NewCmdDynatrace implements the promote command to promote services/operators
 func NewCmdDynatrace() *cobra.Command {
 	ops := &promoteDynatraceOptions{}
 	promoteDynatraceCmd := &cobra.Command{
@@ -52,7 +52,7 @@ func NewCmdDynatrace() *cobra.Command {
 						cmd.Help()
 						os.Exit(1)
 					}
-					listDynatraceModuleNames(dynatraceConfig)
+					_ = listDynatraceModuleNames(dynatraceConfig)
 					os.Exit(0)
 				} else {
 					if ops.module == "" {


### PR DESCRIPTION
Fix the commit message (example right now https://gitlab.cee.redhat.com/service/dynatrace-config/-/merge_requests/886) to not have an extra string formatter.