### PR TITLE
Adds helper info to `promotion` commit error message; prints commit message

### DIFF
--- a/cmd/promote/dynatrace/dt_utils.go
+++ b/cmd/promote/dynatrace/dt_utils.go
@@ -78,8 +78,10 @@ func servicePromotion(appInterface AppInterface, component, gitHash string) erro
 		fmt.Printf("Unable to find a git hash to promote. Exiting.\n")
 		os.Exit(6)
 	}
+
 	fmt.Printf("Service: %s will be promoted to %s\n", component, promotionGitHash)
 	fmt.Printf("commitLog: %v\n", commitLog)
+
 	branchName := fmt.Sprintf("promote-%s-%s", component, promotionGitHash)
 
 	err = appInterface.UpdateAppInterface(component, saasDir, currentGitHash, promotionGitHash, branchName)
@@ -88,11 +90,13 @@ func servicePromotion(appInterface AppInterface, component, gitHash string) erro
 	}
 
 	commitMessage := fmt.Sprintf("Promote %s to %s\n\nSee %s/compare/%s...%s for contents of the promotion.\n clog:%s", component, promotionGitHash, serviceRepo, currentGitHash, promotionGitHash, commitLog)
+
+	fmt.Printf("commitMessage: %s\n", commitMessage)
+
 	err = appInterface.CommitSaasFile(saasDir, commitMessage)
 	if err != nil {
-		return fmt.Errorf("failed to commit changes to app-interface: %w", err)
+		return fmt.Errorf("failed to commit changes to app-interface; manual commit may still succeed: %w", err)
 	}
-	fmt.Printf("commitMessage: %s\n", commitMessage)
 
 	fmt.Printf("The branch %s is ready to be pushed\n", branchName)
 	fmt.Println("")
@@ -310,11 +314,13 @@ func modulePromotion(dynatraceConfig DynatraceConfig, module string) error {
 		return err
 	}
 	commitMsg := fmt.Sprintf("Promote Module %s to GitHash %s", module, promotionGitHash)
-	fmt.Printf("commitLog: %v\n", commitMsg)
+
+	fmt.Printf("commitMessage: %v\n", commitMsg)
 
 	err = dynatraceConfig.commitFiles(commitMsg)
+
 	if err != nil {
-		return fmt.Errorf("failed to commit changes to app-interface: %w", err)
+		return fmt.Errorf("failed to commit changes to app-interface; manual commit may still succeed: %w", err)
 	}
 
 	fmt.Printf("The branch %s is ready to be pushed\n", branchName)

--- a/cmd/promote/saas/utils.go
+++ b/cmd/promote/saas/utils.go
@@ -99,6 +99,8 @@ func servicePromotion(appInterface git.AppInterface, serviceName, gitHash string
 	}
 	commitMessage += fmt.Sprintf("See %s/compare/%s...%s for contents of the promotion. clog:\n\n%s", serviceRepo, currentGitHash, promotionGitHash, commitLog)
 
+	fmt.Printf("commitMessage: %s\n", commitMessage)
+
 	// ovverriding appInterface.GitExecuter to iexec.Exec{}
 	appInterface.GitExecutor = iexec.Exec{}
 
@@ -107,10 +109,10 @@ func servicePromotion(appInterface git.AppInterface, serviceName, gitHash string
 	} else {
 		err = appInterface.CommitSaasFile(saasDir, commitMessage)
 	}
+
 	if err != nil {
-		return fmt.Errorf("failed to commit changes to app-interface: %w", err)
+		return fmt.Errorf("failed to commit changes to app-interface; manual commit may still succeed: %w", err)
 	}
-	fmt.Printf("commitMessage: %s\n", commitMessage)
 
 	fmt.Printf("The branch %s is ready to be pushed\n", branchName)
 	fmt.Println("")


### PR DESCRIPTION
Moves printing of the commit message above the attempt to commit, so that it is still printed even if an error occurs in the commit.  Adds a note that a failed commit may still succeed manually (for which the printed commit message is useful).

This is helpful in the case that, eg, you are using a toolbox, or ocm-contianer, and your GPG or SSH keys are not mounted.  The staged file can still be committed via a session with the required keys.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
