### PR TITLE
servicelog post should support read query from file as clusters input

### DIFF
--- a/cmd/servicelog/post.go
+++ b/cmd/servicelog/post.go
@@ -110,8 +110,8 @@ func (o *PostCmdOptions) Init() error {
 }
 
 func (o *PostCmdOptions) Validate() error {
-	if o.ClusterId == "" && len(o.filterParams) == 0 && o.clustersFile == "" {
-		return fmt.Errorf("no cluster identifier has been found, please specify --cluster-id, -q, or -c")
+	if o.ClusterId == "" && len(o.filterParams) == 0 && o.clustersFile == "" && len(o.filterFiles) == 0 {
+		return fmt.Errorf("no cluster identifier has been found, please specify --cluster-id, -q, -c or -f")
 	}
 	return nil
 }

--- a/cmd/servicelog/post_test.go
+++ b/cmd/servicelog/post_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Test posting service logs", func() {
 			err := options.Validate()
 			Expect(err).Should(HaveOccurred())
 			// Updated error message to match the actual implementation
-			Expect(err.Error()).To(Equal("no cluster identifier has been found, please specify --cluster-id, -q, or -c"))
+			Expect(err.Error()).To(Equal("no cluster identifier has been found, please specify --cluster-id, -q, -c or -f"))
 		})
 
 		It("validates successfully with a cluster-id", func() {


### PR DESCRIPTION
Servicelog post should support read query from file as clusters input. But current osdctl version will report error when only given -f parameter. This commit fixed this issue and query from file is allowed.

The change has been tested locally

```
cat query.txt 
cloud_provider.id is 'aws' and managed='true' and product.id is 'rosa' and state is 'ready' and hypershift.enabled is 'false' and name like '%test%'

./dist/osdctl_darwin_arm64_v8.0/osdctl servicelog post -f query.txt -i -p "MESSAGE=Bulk servicelog test message" --dry-run
WARN: The current version (v0.0.0-next) is different than the latest released version (v0.47.1). It is recommended that you update to the latest released version to ensure that no known bugs or issues are hit.
Continue? (y/N): y
INFO[0007] The following clusters match the given parameters: 
Name                    ID                                 State               Version             Cloud Provider      Region
avalija-test-20250910   2l7jjs4micp3gq5dcgvfj28km5k4bdlt   ready               4.19.10             aws                 us-east-1
dkhan-test1             2l84j2o6qee4dg7t3820qb887gifjpn5   ready               4.19.10             aws                 us-east-1
tkong-test              2l8gjp8gila4p43nkteu156k7rp0br6k   ready               4.18.18             aws                 us-east-1

INFO[0007] The following template will be sent:         
{
  "severity":"Info",
  "service_name":"SREManualAction",
  "summary":"INTERNAL ONLY, DO NOT SHARE WITH CUSTOMER",
  "description":"Bulk servicelog test message",
  "internal_only":true,
  "event_stream_id":"",
  "doc_references":null
}
```