### PR TITLE
SREP-1831 - Fix watch command label

### DIFF
--- a/cmd/cluster/resize/controlplane_node.go
+++ b/cmd/cluster/resize/controlplane_node.go
@@ -541,7 +541,7 @@ func promptGenerateResizeSL(clusterID string, newMachineType string) error {
 
 	fmt.Println("Service log sent successfully. Use the following command to track progress of the resize:")
 	fmt.Println()
-	fmt.Println(`watch -d 'oc get machines -n openshift-machine-api -l machine.openshift.io/cluster-api-machine-role=master && oc get nodes -l node-role.kubernetes.io/control-plane'`)
+	fmt.Println(`watch -d 'oc get machines -n openshift-machine-api -l machine.openshift.io/cluster-api-machine-role=master && oc get nodes -l node-role.kubernetes.io/master'`)
 
 	return nil
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/SREP-1831

---

Modifies the label used by the suggested `watch` command to print all (current and new) control-plane instances when watching control-plane scale-up/down processes.