### PR TITLE
Adds provision shard lookup for MC List

### DIFF
--- a/cmd/mc/list.go
+++ b/cmd/mc/list.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	ocmsdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -18,12 +21,14 @@ type list struct {
 }
 
 type managementClusterOutput struct {
-	Name      string `json:"name" yaml:"name"`
-	ID        string `json:"id" yaml:"id"`
-	Sector    string `json:"sector" yaml:"sector"`
-	Region    string `json:"region" yaml:"region"`
-	AccountID string `json:"account_id" yaml:"account_id"`
-	Status    string `json:"status" yaml:"status"`
+	Name             string `json:"name" yaml:"name"`
+	ID               string `json:"id" yaml:"id"`
+	Sector           string `json:"sector" yaml:"sector"`
+	Region           string `json:"region" yaml:"region"`
+	AccountID        string `json:"account_id" yaml:"account_id"`
+	Status           string `json:"status" yaml:"status"`
+	Hive             string `json:"hive" yaml:"hive"`
+	ProvisionShardID string `json:"provision_shard_id" yaml:"provision_shard_id"`
 }
 
 func newCmdList() *cobra.Command {
@@ -63,15 +68,22 @@ func (l *list) Run() error {
 	}
 
 	var output []managementClusterOutput
+	provisionShards, err := getProvisionShards(ocm)
+	if err != nil {
+		log.Printf("Warning: %s", err)
+	}
+
 	for _, mc := range managementClusters.Items().Slice() {
-		cluster, err := ocm.ClustersMgmt().V1().Clusters().Cluster(mc.ClusterManagementReference().ClusterId()).Get().Send()
+		clusterClient := ocm.ClustersMgmt().V1().Clusters().Cluster(mc.ClusterManagementReference().ClusterId())
+		clusterResp, err := clusterClient.Get().Send()
 		if err != nil {
 			log.Printf("failed to find clusters_mgmt cluster for %s: %v", mc.Name(), err)
 			continue
 		}
+		cluster := clusterResp.Body()
 
 		awsAccountID := "NON-STS"
-		supportRole := cluster.Body().AWS().STS().SupportRoleARN()
+		supportRole := cluster.AWS().STS().SupportRoleARN()
 		if supportRole != "" {
 			supportRoleARN, err := arn.Parse(supportRole)
 			if err != nil {
@@ -80,14 +92,35 @@ func (l *list) Run() error {
 			awsAccountID = supportRoleARN.AccountID
 		}
 
-		output = append(output, managementClusterOutput{
+		hiveShardResp, err := clusterClient.ProvisionShard().Get().Send()
+		if err != nil {
+			log.Printf("Could not get provision shard info")
+		}
+		hiveLink := hiveShardResp.Body().HiveConfig().Server()
+		hiveName, _ := getClusterNameFromServerURL(hiveLink)
+
+		serviceClusterName := mc.Parent().Name()
+
+		mcData := managementClusterOutput{
 			Name:      mc.Name(),
 			ID:        mc.ClusterManagementReference().ClusterId(),
 			Sector:    mc.Sector(),
 			Region:    mc.Region(),
 			AccountID: awsAccountID,
 			Status:    mc.Status(),
-		})
+			Hive:      hiveName,
+		}
+
+		if provisionShards != nil {
+			ps, ok := provisionShards[serviceClusterName]
+			if ok {
+				mcData.ProvisionShardID = ps.ID()
+			} else {
+				mcData.ProvisionShardID = "N/A"
+			}
+		}
+
+		output = append(output, mcData)
 	}
 
 	switch l.outputFormat {
@@ -113,6 +146,8 @@ func (l *list) Run() error {
 			fmt.Fprintf(w, " Region:\t%s\n", item.Region)
 			fmt.Fprintf(w, " Account ID:\t%s\n", item.AccountID)
 			fmt.Fprintf(w, " Status:\t%s\n", item.Status)
+			fmt.Fprintf(w, " Hive:\t%s\n", item.Hive)
+			fmt.Fprintf(w, " Provision Shard ID:\t%s\n", item.ProvisionShardID)
 			if i < len(output)-1 {
 				_, err := fmt.Fprintln(w, "")
 				if err != nil {
@@ -125,19 +160,21 @@ func (l *list) Run() error {
 			}
 		}
 	case "table":
-		w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
-		_, err := fmt.Fprintln(w, "NAME\tID\tSECTOR\tREGION\tACCOUNT_ID\tSTATUS")
+		w := tabwriter.NewWriter(os.Stdout, 1, 1, 2, ' ', 0)
+		_, err := fmt.Fprintln(w, "NAME\tID\tSECTOR\tREGION\tACCOUNT_ID\tSTATUS\tHIVE\tPROVISION_SHARD_ID")
 		if err != nil {
 			return fmt.Errorf("failed to format table output: %v", err)
 		}
 		for _, item := range output {
-			_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			_, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 				item.Name,
 				item.ID,
 				item.Sector,
 				item.Region,
 				item.AccountID,
 				item.Status,
+				item.Hive,
+				item.ProvisionShardID,
 			)
 			if err != nil {
 				return fmt.Errorf("failed to format table output: %v", err)
@@ -152,4 +189,36 @@ func (l *list) Run() error {
 	}
 
 	return nil
+}
+
+func getProvisionShards(ocmClient *ocmsdk.Connection) (map[string]*cmv1.ProvisionShard, error) {
+	provisionShardResponse, err := ocmClient.ClustersMgmt().V1().ProvisionShards().List().Send()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get provision shards: %w", err)
+	}
+
+	return processServiceClusters(provisionShardResponse.Items().Slice()), nil
+}
+
+func processServiceClusters(shards []*cmv1.ProvisionShard) map[string]*cmv1.ProvisionShard {
+	provisionShards := map[string]*cmv1.ProvisionShard{}
+
+	for _, ps := range shards {
+		if ps.HypershiftConfig() != nil {
+			if strings.Contains(ps.HypershiftConfig().Server(), "hs-sc-") {
+				name, _ := getClusterNameFromServerURL(ps.HypershiftConfig().Server())
+				provisionShards[name] = ps
+			}
+		}
+	}
+
+	return provisionShards
+}
+
+func getClusterNameFromServerURL(server string) (string, error) {
+	nameSlice := strings.Split(server, ".")
+	if len(nameSlice) < 2 {
+		return "", fmt.Errorf("invalid Server URL")
+	}
+	return nameSlice[1], nil
 }

--- a/cmd/mc/list_test.go
+++ b/cmd/mc/list_test.go
@@ -1,0 +1,135 @@
+package mc
+
+import (
+	"testing"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetClusterNameFromServerURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		serverURL    string
+		expectedName string
+		expectError  bool
+	}{
+		{
+			name:         "valid server URL with cluster name",
+			serverURL:    "https://api.hs-sc-cluster1.example.com",
+			expectedName: "hs-sc-cluster1",
+			expectError:  false,
+		},
+		{
+			name:         "valid server URL with different cluster name",
+			serverURL:    "https://api.test-cluster.domain.com",
+			expectedName: "test-cluster",
+			expectError:  false,
+		},
+		{
+			name:         "server URL with port",
+			serverURL:    "https://api.cluster-name.example.com:8080",
+			expectedName: "cluster-name",
+			expectError:  false,
+		},
+		{
+			name:         "invalid server URL - no dots",
+			serverURL:    "https://invalidurl",
+			expectedName: "",
+			expectError:  true,
+		},
+		{
+			name:         "invalid server URL - only one part",
+			serverURL:    "api",
+			expectedName: "",
+			expectError:  true,
+		},
+		{
+			name:         "empty server URL",
+			serverURL:    "",
+			expectedName: "",
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := getClusterNameFromServerURL(tt.serverURL)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Equal(t, "", result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedName, result)
+			}
+		})
+	}
+}
+
+func TestProcessServiceClusters(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputShards   []*cmv1.ProvisionShard
+		expectedCount int
+	}{
+		{
+			name:          "handles empty input",
+			inputShards:   []*cmv1.ProvisionShard{},
+			expectedCount: 0,
+		},
+		{
+			name: "handles shards without hypershift config",
+			inputShards: []*cmv1.ProvisionShard{
+				createProvisionShardWithoutHypershift("shard1"),
+			},
+			expectedCount: 0,
+		},
+		{
+			name: "handles shards with hypershift config",
+			inputShards: []*cmv1.ProvisionShard{
+				createProvisionShardWithHypershift("shard1", "https://api.hs-sc-aaabbb.mydomain.com"),
+				createProvisionShardWithHypershift("shard2", "https://api.hs-mc-aaabbb.mydomain.com"),
+			},
+			expectedCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := processServiceClusters(tt.inputShards)
+			assert.Equal(t, tt.expectedCount, len(result))
+		})
+	}
+}
+
+// Test the behavior when processServiceClusters encounters invalid data
+func TestProcessServiceClustersEdgeCases(t *testing.T) {
+	// Test with nil slice
+	result := processServiceClusters(nil)
+	assert.Equal(t, 0, len(result))
+	assert.NotNil(t, result) // Should return empty map, not nil
+
+	// Test with slice containing nil elements (this would normally not happen but good to test)
+	shards := []*cmv1.ProvisionShard{nil}
+	result = processServiceClusters(shards)
+	assert.Equal(t, 0, len(result))
+}
+
+// Helper functions to create test ProvisionShard objects
+func createProvisionShardWithoutHypershift(id string) *cmv1.ProvisionShard {
+	shard, _ := cmv1.NewProvisionShard().
+		ID(id).
+		Build()
+
+	return shard
+}
+
+func createProvisionShardWithHypershift(id string, serverURL string) *cmv1.ProvisionShard {
+	hsConfig := cmv1.NewServerConfig().Server(serverURL)
+	shard, _ := cmv1.NewProvisionShard().
+		ID(id).
+		HypershiftConfig(hsConfig).
+		Build()
+	return shard
+}


### PR DESCRIPTION
This adds the hive that owns a management cluster and the provision shard for a management cluster to the output.


Use cases:

1. I want to find all of the MCs that are managed by a specific hive so I can find which hives are affected by Managed Cluster Config during progressive delivery. This can be used to spot-check for proper deployment of things or for troubleshooting issues, etc.

2. I want to pin a cluster to a specific provision shard. Instead of having to do the lookup manually, now this output is in this command.

Unit tests written with the assistance of AI.