### PR TITLE
[OHSS-49752] Handles transitioning Stable channel EOL for ROSA HCP for even chanels 

### DIFF
--- a/cmd/hcp/cmd.go
+++ b/cmd/hcp/cmd.go
@@ -6,6 +6,7 @@ import (
 	getcpautoscalingstatus "github.com/openshift/osdctl/cmd/hcp/get-cp-autoscaling-status"
 	"github.com/openshift/osdctl/cmd/hcp/mustgather"
 	"github.com/openshift/osdctl/cmd/hcp/status"
+	"github.com/openshift/osdctl/cmd/hcp/transitiontoeus"
 	"github.com/spf13/cobra"
 )
 
@@ -20,6 +21,7 @@ func NewCmdHCP() *cobra.Command {
 	hcp.AddCommand(mustgather.NewCmdMustGather())
 	hcp.AddCommand(forceupgrade.NewCmdForceUpgrade())
 	hcp.AddCommand(status.NewCmdStatus())
+	hcp.AddCommand(transitiontoeus.NewCmdTransitionToEUS())
 
 	return hcp
 }

--- a/cmd/hcp/transitiontoeus/cmd.go
+++ b/cmd/hcp/transitiontoeus/cmd.go
@@ -1,0 +1,10 @@
+package transitiontoeus
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCmdTransitionToEUS creates and returns the transition-to-eus command
+func NewCmdTransitionToEUS() *cobra.Command {
+	return newCmdTransitionToEUS()
+}

--- a/cmd/hcp/transitiontoeus/transitiontoeus.go
+++ b/cmd/hcp/transitiontoeus/transitiontoeus.go
@@ -347,12 +347,12 @@ func (o *transitionOptions) preValidateClusters(clusters []*v1.Cluster) ([]*v1.C
 
 // recurringPolicyBackup stores complete information needed to restore a recurring upgrade policy
 type recurringPolicyBackup struct {
-	id          string
-	schedule    string
+	id           string
+	schedule     string
 	scheduleType v1.ScheduleType
-	upgradeType v1.UpgradeType
-	enableMinor bool
-	version     string // May be empty for automatic policies
+	upgradeType  v1.UpgradeType
+	enableMinor  bool
+	version      string // May be empty for automatic policies
 }
 
 // policyDetails stores information about a cluster's upgrade policies

--- a/cmd/hcp/transitiontoeus/transitiontoeus.go
+++ b/cmd/hcp/transitiontoeus/transitiontoeus.go
@@ -483,15 +483,30 @@ func (o *transitionOptions) getUpgradePolicyDetails(ocmClient *sdk.Connection, c
 		return &policyDetails{hasRecurringPolicy: false}, nil
 	}
 
-	// Get the first policy (there should only be one)
-	policy := policies[0]
+	// Filter for recurring (automatic) policies only - ignore one-off manual upgrade policies
+	// One-off manual policies (ScheduleTypeManual) are customer-scheduled upgrades that should not be touched
+	var recurringPolicy *v1.ControlPlaneUpgradePolicy
+	for _, policy := range policies {
+		if policy.ScheduleType() == v1.ScheduleTypeAutomatic {
+			if recurringPolicy != nil {
+				return nil, fmt.Errorf("found multiple automatic recurring policies (IDs: %s, %s) - this is unexpected, please review cluster state manually", recurringPolicy.ID(), policy.ID())
+			}
+			recurringPolicy = policy
+		}
+		// Skip manual one-off policies - these are customer-scheduled and should not be deleted
+	}
+
+	// No recurring policies found - cluster uses individual updates or only has one-off manual upgrades
+	if recurringPolicy == nil {
+		return &policyDetails{hasRecurringPolicy: false}, nil
+	}
 
 	return &policyDetails{
 		hasRecurringPolicy: true,
-		policyID:           policy.ID(),
-		schedule:           policy.Schedule(),
-		scheduleType:       string(policy.ScheduleType()),
-		enableMinor:        policy.EnableMinorVersionUpgrades(),
+		policyID:           recurringPolicy.ID(),
+		schedule:           recurringPolicy.Schedule(),
+		scheduleType:       string(recurringPolicy.ScheduleType()),
+		enableMinor:        recurringPolicy.EnableMinorVersionUpgrades(),
 	}, nil
 }
 

--- a/cmd/hcp/transitiontoeus/transitiontoeus.go
+++ b/cmd/hcp/transitiontoeus/transitiontoeus.go
@@ -31,8 +31,8 @@ type transitionOptions struct {
 
 // Service log template mappings
 var serviceLogTemplates = map[string]string{
-	"success":   "https://raw.githubusercontent.com/diakovnec/managed-notifications/refs/heads/ohss-49572-notification/hcp/eus_transition_success.json",
-	"attempted": "https://raw.githubusercontent.com/diakovnec/managed-notifications/refs/heads/ohss-49572-notification/hcp/eus_transition_attempted.json",
+	"success":   "https://raw.githubusercontent.com/openshift/managed-notifications/master/hcp/eus_transition_success.json",
+	"attempted": "https://raw.githubusercontent.com/openshift/managed-notifications/master/hcp/eus_transition_attempted.json",
 }
 
 // Regular expression for valid cluster IDs - alphanumeric characters and hyphens only

--- a/cmd/hcp/transitiontoeus/transitiontoeus.go
+++ b/cmd/hcp/transitiontoeus/transitiontoeus.go
@@ -1,0 +1,707 @@
+package transitiontoeus
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/openshift-online/ocm-cli/pkg/arguments"
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/osdctl/internal/io"
+	"github.com/openshift/osdctl/internal/servicelog"
+	"github.com/openshift/osdctl/internal/utils"
+	ocmutils "github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+// transitionOptions contains all options for the transition-to-eus command
+type transitionOptions struct {
+	clusterID    string
+	clustersFile string
+	dryRun       bool
+
+	// Parsed cluster IDs (populated during validation)
+	clusterIDs []string
+}
+
+// Service log template mappings
+var serviceLogTemplates = map[string]string{
+	"success":   "https://raw.githubusercontent.com/diakovnec/managed-notifications/refs/heads/ohss-49572-notification/hcp/eus_transition_success.json",
+	"attempted": "https://raw.githubusercontent.com/diakovnec/managed-notifications/refs/heads/ohss-49572-notification/hcp/eus_transition_attempted.json",
+}
+
+// Regular expression for valid cluster IDs - alphanumeric characters and hyphens only
+var validClusterIDRegex = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
+
+func newCmdTransitionToEUS() *cobra.Command {
+	opts := &transitionOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "transition-to-eus",
+		Short: "Transition ROSA HCP clusters from stable to EUS channel (Even Y-Stream EOL handling)",
+		Long: `Transition ROSA HCP clusters from stable to EUS channel during End-of-Life handling.
+
+⚠️ IMPORTANT GUARDRAILS ⚠️
+This command is specifically designed for EVEN Y-STREAM end-of-life transitions (4.14, 4.16, 4.18, etc.).
+
+The command validates:
+- Cluster must be HCP (not Classic)
+- Cluster must be on an even y-stream (4.14, 4.16, 4.18, etc.)
+- Cluster must be on 'stable' channel (not already on 'eus')
+- Cluster must be in 'ready' state
+
+WORKFLOW:
+For clusters with recurring update policies:
+1. Saves the existing recurring update policy settings
+2. Deletes the recurring update policy
+3. Transitions the channel from 'stable' to 'eus'
+4. Verifies the channel change
+5. Restores the recurring update policy with original settings
+6. Prompts to send service log notification
+
+For clusters with individual updates:
+1. Transitions the channel from 'stable' to 'eus'
+2. Verifies the channel change
+3. Prompts to send service log notification
+
+SERVICE LOG BEHAVIOR:
+- After each successful transition, you will be prompted to optionally send a service log notification
+- On failures where recurring policy was modified and restored: You will be prompted to send an 'attempted' notification to the customer
+
+This approach extends the support lifecycle for clusters on even y-streams without forcing upgrades.`,
+		Example: `  # Transition single cluster (will prompt to send service log after success)
+  osdctl hcp transition-to-eus -C cluster123
+
+  # Multiple clusters from file
+  osdctl hcp transition-to-eus --clusters-file clusters.json
+
+  # Dry-run to preview changes
+  osdctl hcp transition-to-eus --clusters-file clusters.json --dry-run
+`,
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Run()
+		},
+	}
+
+	// Cluster targeting flags
+	cmd.Flags().StringVarP(&opts.clusterID, "cluster-id", "C", "", "ID of the target HCP cluster")
+	cmd.Flags().StringVarP(&opts.clustersFile, "clusters-file", "c", "", "JSON file containing cluster IDs (format: {\"clusters\":[\"$CLUSTERID1\", \"$CLUSTERID2\"]})")
+
+	// Configuration flags
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Simulate the transition without making any changes")
+
+	return cmd
+}
+
+func (o *transitionOptions) validate() error {
+	// Exactly one cluster targeting method must be provided
+	if o.clusterID == "" && o.clustersFile == "" {
+		return fmt.Errorf("no cluster identifier has been found, please specify either --cluster-id or --clusters-file")
+	}
+
+	if o.clusterID != "" && o.clustersFile != "" {
+		return fmt.Errorf("cannot specify both --cluster-id and --clusters-file, choose one")
+	}
+
+	// Validate cluster ID format when using single cluster ID
+	if o.clusterID != "" {
+		if !validClusterIDRegex.MatchString(o.clusterID) {
+			return fmt.Errorf("cluster ID '%s' contains invalid characters - only alphanumeric characters and hyphens are allowed", o.clusterID)
+		}
+	}
+
+	// Parse and validate cluster targets
+	if o.clustersFile != "" {
+		clusterIDs, err := io.ParseAndValidateClustersFile(o.clustersFile)
+		if err != nil {
+			return err
+		}
+		// Require at least one cluster
+		if len(clusterIDs) == 0 {
+			return fmt.Errorf("clusters file contains no cluster IDs - the 'clusters' array is empty")
+		}
+		o.clusterIDs = clusterIDs
+	} else {
+		o.clusterIDs = []string{o.clusterID}
+	}
+
+	return nil
+}
+
+func (o *transitionOptions) Run() error {
+	if err := o.validate(); err != nil {
+		return err
+	}
+
+	ocmClient, err := ocmutils.CreateConnection()
+	if err != nil {
+		return fmt.Errorf("failed to create OCM connection: %w", err)
+	}
+	defer ocmClient.Close()
+
+	clusters, err := o.getClusters(ocmClient)
+	if err != nil {
+		return fmt.Errorf("failed to get target clusters: %w", err)
+	}
+
+	if len(clusters) == 0 {
+		fmt.Println("No clusters found matching the given cluster-id or cluster list.")
+		return nil
+	}
+
+	// Pre-validate clusters and filter out those that don't need transition
+	eligibleClusters, skippedClusters := o.preValidateClusters(clusters)
+
+	// Show skipped clusters (already on EUS, validation failures, etc.)
+	if len(skippedClusters) > 0 {
+		fmt.Printf("\nℹ️  Skipping %d cluster(s) that don't require transition:\n", len(skippedClusters))
+		for _, skip := range skippedClusters {
+			fmt.Printf("  • %s (%s): %s\n", skip.cluster.ExternalID(), skip.cluster.Name(), skip.reason)
+		}
+		fmt.Println()
+	}
+
+	// If no eligible clusters, exit early
+	if len(eligibleClusters) == 0 {
+		fmt.Println("✓ No clusters require transition. All clusters are already on EUS or don't meet criteria.")
+		return nil
+	}
+
+	// Display cluster list and service log preview before processing
+	if err := o.printPreProcessingSummary(eligibleClusters); err != nil {
+		return fmt.Errorf("failed to display pre-processing summary: %w", err)
+	}
+
+	// Ask for confirmation before proceeding (unless in dry-run mode)
+	if !o.dryRun {
+		if !ocmutils.ConfirmPrompt() {
+			fmt.Println("EUS transition operation cancelled.")
+			return nil
+		}
+		fmt.Println()
+	}
+
+	// Process only eligible clusters
+	clusters = eligibleClusters
+
+	var successful, failed []string
+
+	for i, cluster := range clusters {
+		fmt.Printf("\n[%d/%d] Processing cluster: %s (%s)\n", i+1, len(clusters), cluster.ID(), cluster.Name())
+
+		result := o.processCluster(ocmClient, cluster)
+
+		if result.err != nil {
+			failed = append(failed, fmt.Sprintf("%s: %s", cluster.ExternalID(), result.err.Error()))
+			fmt.Printf("  ⚠️  Failed to transition: %v\n", result.err)
+
+			// Prompt to send "attempted" service log if we modified recurring policy and restored it
+			// This means we actually changed the customer's cluster configuration but transition failed
+			if result.policyWasModified && result.policyWasRestored {
+				if !o.dryRun {
+					fmt.Println()
+					fmt.Printf("  ℹ️  Note: The recurring upgrade policy was modified during this attempt but has been restored.\n")
+
+					// Show service log preview and prompt
+					if err := promptAndSendServiceLog(ocmClient, cluster, "attempted"); err != nil {
+						fmt.Printf("  ⚠️  Failed to send service log: %v\n", err)
+					}
+				} else {
+					fmt.Printf("  📧 DRY-RUN: Would prompt to send 'attempted' service log (policy was modified and restored)\n")
+				}
+			}
+		} else {
+			successful = append(successful, cluster.ExternalID())
+
+			// Prompt user to send service log after successful transition
+			if !o.dryRun {
+				fmt.Println()
+				fmt.Printf("  ✅ Transition completed successfully!\n")
+
+				// Show service log preview and prompt
+				if err := promptAndSendServiceLog(ocmClient, cluster, "success"); err != nil {
+					fmt.Printf("  ⚠️  Failed to send service log: %v\n", err)
+				}
+			} else {
+				fmt.Printf("  📧 DRY-RUN: Would prompt to send service log notification\n")
+			}
+		}
+	}
+
+	o.printSummary(successful, failed)
+	return nil
+}
+
+func (o *transitionOptions) getClusters(ocmClient *sdk.Connection) ([]*v1.Cluster, error) {
+	clusterIDs := o.clusterIDs
+
+	var queries []string
+	for _, id := range clusterIDs {
+		if id == "" {
+			return nil, fmt.Errorf("encountered empty cluster ID, this should not happen")
+		}
+		queries = append(queries, ocmutils.GenerateQuery(id))
+	}
+
+	// Ensure we have at least one valid query
+	if len(queries) == 0 {
+		return nil, fmt.Errorf("no valid cluster IDs found to create OCM search query")
+	}
+
+	clusters, err := ocmutils.ApplyFilters(ocmClient, []string{strings.Join(queries, " or ")})
+	if err != nil {
+		return nil, fmt.Errorf("failed to find clusters: %w", err)
+	}
+
+	if len(clusterIDs) != len(clusters) {
+		fmt.Println("")
+		fmt.Printf("⚠️ Warning: found %d clusters but expected %d. This can happen when clusters are no longer available in OCM, e.g. due to a deletion.\n", len(clusterIDs), len(clusters))
+		fmt.Println("")
+	}
+
+	return clusters, nil
+}
+
+// skippedCluster represents a cluster that was skipped with a reason
+type skippedCluster struct {
+	cluster *v1.Cluster
+	reason  string
+}
+
+// preValidateClusters validates all clusters upfront and returns eligible vs skipped clusters
+func (o *transitionOptions) preValidateClusters(clusters []*v1.Cluster) ([]*v1.Cluster, []skippedCluster) {
+	var eligible []*v1.Cluster
+	var skipped []skippedCluster
+
+	for _, cluster := range clusters {
+		// Validation 1: Must be HCP cluster
+		if !cluster.Hypershift().Enabled() {
+			skipped = append(skipped, skippedCluster{
+				cluster: cluster,
+				reason:  "not an HCP cluster (Classic clusters are not supported)",
+			})
+			continue
+		}
+
+		// Validation 2: Must be on even y-stream
+		version, err := semver.NewVersion(cluster.OpenshiftVersion())
+		if err != nil {
+			skipped = append(skipped, skippedCluster{
+				cluster: cluster,
+				reason:  fmt.Sprintf("invalid version format '%s'", cluster.OpenshiftVersion()),
+			})
+			continue
+		}
+
+		if version.Minor()%2 != 0 {
+			skipped = append(skipped, skippedCluster{
+				cluster: cluster,
+				reason:  fmt.Sprintf("odd y-stream %d.%d (only even y-streams 4.14, 4.16, 4.18, etc. are supported)", version.Major(), version.Minor()),
+			})
+			continue
+		}
+
+		// Validation 3: Must be in ready state
+		if cluster.State() != v1.ClusterStateReady {
+			skipped = append(skipped, skippedCluster{
+				cluster: cluster,
+				reason:  fmt.Sprintf("cluster state is '%s' (must be 'ready')", cluster.State()),
+			})
+			continue
+		}
+
+		// Validation 4: Must be on stable channel (not already on eus)
+		currentChannel := cluster.Version().ChannelGroup()
+		if currentChannel == "eus" {
+			skipped = append(skipped, skippedCluster{
+				cluster: cluster,
+				reason:  "already on 'eus' channel (no transition needed)",
+			})
+			continue
+		}
+
+		if currentChannel != "stable" {
+			skipped = append(skipped, skippedCluster{
+				cluster: cluster,
+				reason:  fmt.Sprintf("on '%s' channel (expected 'stable' channel for EUS transition)", currentChannel),
+			})
+			continue
+		}
+
+		// All validations passed - cluster is eligible
+		eligible = append(eligible, cluster)
+	}
+
+	return eligible, skipped
+}
+
+// policyDetails stores information about a cluster's upgrade policy
+type policyDetails struct {
+	hasRecurringPolicy bool
+	policyID           string
+	schedule           string
+	scheduleType       string
+	enableMinor        bool
+}
+
+// clusterProcessResult contains the result of processing a cluster
+type clusterProcessResult struct {
+	err                  error
+	policyWasModified    bool // true if we deleted recurring policy (even if later restored)
+	policyWasRestored    bool // true if we successfully restored the policy after modification
+}
+
+func (o *transitionOptions) processCluster(ocmClient *sdk.Connection, cluster *v1.Cluster) *clusterProcessResult {
+	result := &clusterProcessResult{}
+
+	// Get cluster version info (already validated in preValidateClusters)
+	version, err := semver.NewVersion(cluster.OpenshiftVersion())
+	if err != nil {
+		result.err = fmt.Errorf("failed to parse cluster version '%s': %w", cluster.OpenshiftVersion(), err)
+		return result
+	}
+
+	fmt.Printf("  ✓ Cluster is HCP on even y-stream %d.%d\n", version.Major(), version.Minor())
+
+	currentChannel := cluster.Version().ChannelGroup()
+	fmt.Printf("  ✓ Cluster is on 'stable' channel and ready to transition\n")
+
+	// Step 1: Check for recurring upgrade policies
+	policy, err := o.getUpgradePolicyDetails(ocmClient, cluster)
+	if err != nil {
+		result.err = fmt.Errorf("failed to check upgrade policies: %w", err)
+		return result
+	}
+
+	// Step 2: Delete recurring policy if it exists
+	if policy.hasRecurringPolicy {
+		fmt.Printf("  📋 Found recurring update policy (schedule: %s)\n", policy.schedule)
+
+		if o.dryRun {
+			fmt.Printf("  🔍 DRY-RUN: Would delete upgrade policy\n")
+		} else {
+			fmt.Printf("  🗑️  Deleting upgrade policy to allow channel transition\n")
+			if err := o.deleteUpgradePolicy(ocmClient, cluster, policy.policyID); err != nil {
+				result.err = fmt.Errorf("failed to delete upgrade policy: %w", err)
+				return result
+			}
+			// Mark that we've modified the policy
+			result.policyWasModified = true
+		}
+	} else {
+		fmt.Printf("  ℹ️  Cluster uses individual updates (no policy to delete)\n")
+	}
+
+	// Step 3: Transition channel to EUS
+	if o.dryRun {
+		fmt.Printf("  🔍 DRY-RUN: Would transition channel from '%s' to 'eus'\n", currentChannel)
+	} else {
+		fmt.Printf("  🔄 Transitioning channel from '%s' to 'eus'\n", currentChannel)
+		if err := o.transitionChannelToEUS(ocmClient, cluster); err != nil {
+			// Channel transition failed - try to restore policy if we deleted it
+			if result.policyWasModified {
+				fmt.Printf("  🔁 Channel transition failed - attempting to restore upgrade policy\n")
+				if restoreErr := o.restoreUpgradePolicy(ocmClient, cluster, policy); restoreErr != nil {
+					result.err = fmt.Errorf("failed to transition channel: %w (CRITICAL: also failed to restore policy: %v)", err, restoreErr)
+				} else {
+					result.policyWasRestored = true
+					result.err = fmt.Errorf("failed to transition channel: %w (upgrade policy was restored)", err)
+					fmt.Printf("  ✓ Upgrade policy restored after failure\n")
+				}
+			} else {
+				result.err = fmt.Errorf("failed to transition channel: %w", err)
+			}
+			return result
+		}
+
+		// Step 4: Verify channel change
+		time.Sleep(2 * time.Second) // Give OCM time to process
+		updatedCluster, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).Get().Send()
+		if err != nil {
+			// Verification failed - try to restore policy if we deleted it
+			if result.policyWasModified {
+				fmt.Printf("  🔁 Channel verification failed - attempting to restore upgrade policy\n")
+				if restoreErr := o.restoreUpgradePolicy(ocmClient, cluster, policy); restoreErr != nil {
+					result.err = fmt.Errorf("failed to verify channel change: %w (CRITICAL: also failed to restore policy: %v)", err, restoreErr)
+				} else {
+					result.policyWasRestored = true
+					result.err = fmt.Errorf("failed to verify channel change: %w (upgrade policy was restored)", err)
+					fmt.Printf("  ✓ Upgrade policy restored after failure\n")
+				}
+			} else {
+				result.err = fmt.Errorf("failed to verify channel change: %w", err)
+			}
+			return result
+		}
+
+		newChannel := updatedCluster.Body().Version().ChannelGroup()
+		if newChannel != "eus" {
+			// Verification failed - try to restore policy if we deleted it
+			if result.policyWasModified {
+				fmt.Printf("  🔁 Channel verification failed - attempting to restore upgrade policy\n")
+				if restoreErr := o.restoreUpgradePolicy(ocmClient, cluster, policy); restoreErr != nil {
+					result.err = fmt.Errorf("channel verification failed - expected 'eus' but got '%s' (CRITICAL: also failed to restore policy: %v)", newChannel, restoreErr)
+				} else {
+					result.policyWasRestored = true
+					result.err = fmt.Errorf("channel verification failed - expected 'eus' but got '%s' (upgrade policy was restored)", newChannel)
+					fmt.Printf("  ✓ Upgrade policy restored after failure\n")
+				}
+			} else {
+				result.err = fmt.Errorf("channel verification failed - expected 'eus' but got '%s'", newChannel)
+			}
+			return result
+		}
+
+		fmt.Printf("  ✓ Channel successfully transitioned to 'eus'\n")
+	}
+
+	// Step 5: Restore recurring policy if it existed
+	if policy.hasRecurringPolicy {
+		if o.dryRun {
+			fmt.Printf("  🔍 DRY-RUN: Would restore upgrade policy\n")
+		} else {
+			fmt.Printf("  🔁 Restoring upgrade policy\n")
+			if err := o.restoreUpgradePolicy(ocmClient, cluster, policy); err != nil {
+				result.err = fmt.Errorf("failed to restore upgrade policy: %w", err)
+				return result
+			}
+			result.policyWasRestored = true
+			fmt.Printf("  ✓ Upgrade policy restored\n")
+		}
+	}
+
+	if !o.dryRun {
+		fmt.Printf("  ✅ Successfully transitioned cluster to EUS channel\n")
+	} else {
+		fmt.Printf("  🔍 DRY-RUN: Transition would be successful\n")
+	}
+
+	return result
+}
+
+func (o *transitionOptions) getUpgradePolicyDetails(ocmClient *sdk.Connection, cluster *v1.Cluster) (*policyDetails, error) {
+	policiesResponse, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).
+		ControlPlane().UpgradePolicies().List().Send()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list upgrade policies: %w", err)
+	}
+
+	policies := policiesResponse.Items().Slice()
+	if len(policies) == 0 {
+		return &policyDetails{hasRecurringPolicy: false}, nil
+	}
+
+	// Get the first policy (there should only be one)
+	policy := policies[0]
+
+	return &policyDetails{
+		hasRecurringPolicy: true,
+		policyID:           policy.ID(),
+		schedule:           policy.Schedule(),
+		scheduleType:       string(policy.ScheduleType()),
+		enableMinor:        policy.EnableMinorVersionUpgrades(),
+	}, nil
+}
+
+func (o *transitionOptions) deleteUpgradePolicy(ocmClient *sdk.Connection, cluster *v1.Cluster, policyID string) error {
+	_, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).
+		ControlPlane().UpgradePolicies().ControlPlaneUpgradePolicy(policyID).Delete().Send()
+	return err
+}
+
+func (o *transitionOptions) transitionChannelToEUS(ocmClient *sdk.Connection, cluster *v1.Cluster) error {
+	versionBuilder := v1.NewVersion().ChannelGroup("eus")
+
+	clusterUpdate, err := v1.NewCluster().Version(versionBuilder).Build()
+	if err != nil {
+		return fmt.Errorf("failed to build cluster update: %w", err)
+	}
+
+	_, err = ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).Update().Body(clusterUpdate).Send()
+	return err
+}
+
+func (o *transitionOptions) restoreUpgradePolicy(ocmClient *sdk.Connection, cluster *v1.Cluster, policy *policyDetails) error {
+	scheduleType := v1.ScheduleTypeAutomatic
+	if policy.scheduleType == "manual" {
+		scheduleType = v1.ScheduleTypeManual
+	}
+
+	newPolicy, err := v1.NewControlPlaneUpgradePolicy().
+		Schedule(policy.schedule).
+		ScheduleType(scheduleType).
+		UpgradeType(v1.UpgradeTypeControlPlane).
+		EnableMinorVersionUpgrades(policy.enableMinor).
+		Build()
+	if err != nil {
+		return fmt.Errorf("failed to build upgrade policy: %w", err)
+	}
+
+	_, err = ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).
+		ControlPlane().UpgradePolicies().Add().Body(newPolicy).Send()
+	return err
+}
+
+// loadServiceLogTemplate loads a service log template from either a predefined template name or file path
+func loadServiceLogTemplate(templateOrFile string) ([]byte, bool, error) {
+	var templateBytes []byte
+	var err error
+	var usingDefaultTemplate bool
+
+	// Check if it's a template name
+	if templateURL, exists := serviceLogTemplates[templateOrFile]; exists {
+		// Use predefined template URL
+		templateBytes, err = utils.CurlThis(templateURL)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to fetch template from %s: %w", templateURL, err)
+		}
+		usingDefaultTemplate = true
+	} else {
+		// Treat as file path
+		templateBytes, err = os.ReadFile(templateOrFile)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to read template file %s: %w", templateOrFile, err)
+		}
+		usingDefaultTemplate = false
+	}
+
+	return templateBytes, usingDefaultTemplate, nil
+}
+
+// promptAndSendServiceLog shows the service log preview and prompts user to send it
+func promptAndSendServiceLog(ocmClient *sdk.Connection, cluster *v1.Cluster, templateName string) error {
+	// Load and prepare the message
+	templateBytes, usingDefaultTemplate, err := loadServiceLogTemplate(templateName)
+	if err != nil {
+		return err
+	}
+
+	var message servicelog.Message
+	if err := json.Unmarshal(templateBytes, &message); err != nil {
+		return fmt.Errorf("failed to parse service log template: %w", err)
+	}
+
+	// Set cluster-specific fields
+	message.ClusterUUID = cluster.ExternalID()
+	message.ClusterID = cluster.ID()
+
+	// Validate that all required parameters were replaced
+	if leftoverParams, found := message.FindLeftovers(); found {
+		if usingDefaultTemplate {
+			return fmt.Errorf("default template contains unresolved parameters: %v. This should not happen", leftoverParams)
+		} else {
+			return fmt.Errorf("custom template contains unresolved parameters: %v. Please ensure all parameters are defined in your template", leftoverParams)
+		}
+	}
+
+	// Display service log preview
+	fmt.Println()
+	fmt.Printf("  📧 SERVICE LOG PREVIEW:\n")
+	fmt.Printf("  Summary:  %s\n", message.Summary)
+	fmt.Printf("  Severity: %s\n", message.Severity)
+	fmt.Println()
+	fmt.Printf("  Message to Customer:\n")
+	fmt.Printf("  %s\n", message.Description)
+	fmt.Println()
+
+	// Prompt user
+	if templateName == "success" {
+		fmt.Printf("  📧 Do you want to send this service log notification to the customer? (yes/no): ")
+	} else {
+		fmt.Printf("  📧 Do you want to send this 'attempted' service log to notify the customer? (yes/no): ")
+	}
+
+	if ocmutils.ConfirmPrompt() {
+		fmt.Printf("  📄 Sending '%s' service log template\n", templateName)
+		if err := sendServiceLog(ocmClient, &message); err != nil {
+			return err
+		}
+		fmt.Printf("  📧 Service log notification sent successfully\n")
+	} else {
+		fmt.Printf("  ℹ️  Skipping service log notification\n")
+	}
+
+	return nil
+}
+
+// sendServiceLog sends the prepared service log message
+func sendServiceLog(ocmClient *sdk.Connection, message *servicelog.Message) error {
+	request := ocmClient.Post()
+	if err := arguments.ApplyPathArg(request, "/api/service_logs/v1/cluster_logs"); err != nil {
+		return fmt.Errorf("cannot parse API path: %v", err)
+	}
+
+	messageBytes, err := json.Marshal(message)
+	if err != nil {
+		return fmt.Errorf("cannot marshal service log message: %v", err)
+	}
+
+	request.Bytes(messageBytes)
+
+	response, err := ocmutils.SendRequest(request)
+	if err != nil {
+		return fmt.Errorf("failed to send service log: %w", err)
+	}
+
+	if response.Status() != 201 {
+		return fmt.Errorf("service log request failed with status: %d", response.Status())
+	}
+
+	return nil
+}
+
+
+func (o *transitionOptions) printSummary(successful, failed []string) {
+	fmt.Print("\n" + strings.Repeat("=", 60) + "\n")
+	fmt.Print("EUS TRANSITION SUMMARY\n")
+	fmt.Print(strings.Repeat("=", 60) + "\n")
+
+	total := len(successful) + len(failed)
+	fmt.Printf("Total clusters processed: %d\n", total)
+	fmt.Printf("Successfully transitioned: %d\n", len(successful))
+	fmt.Printf("Failed: %d\n", len(failed))
+
+	if len(failed) > 0 {
+		fmt.Printf("\n⚠️ Failed to transition the following clusters (please follow-up manually):\n")
+		for _, entry := range failed {
+			fmt.Printf("  - %s\n", entry)
+		}
+	}
+
+	fmt.Print(strings.Repeat("=", 60) + "\n")
+}
+
+// printPreProcessingSummary displays the clusters before processing
+func (o *transitionOptions) printPreProcessingSummary(clusters []*v1.Cluster) error {
+	fmt.Print("\n" + strings.Repeat("=", 60) + "\n")
+	fmt.Print("PRE-PROCESSING SUMMARY\n")
+	fmt.Print(strings.Repeat("=", 60) + "\n")
+
+	fmt.Printf("\nClusters to transition from 'stable' to 'eus' channel:\n")
+	for i, cluster := range clusters {
+		fmt.Printf("%2d. %s (%s) - %s - %s - Channel: %s\n",
+			i+1,
+			cluster.ExternalID(),
+			cluster.Name(),
+			cluster.State(),
+			cluster.OpenshiftVersion(),
+			cluster.Version().ChannelGroup(),
+		)
+	}
+
+	if !o.dryRun {
+		fmt.Printf("\nService Log Behavior:\n")
+		fmt.Printf("  You will be prompted after each successful transition to send a service log notification.\n")
+	}
+
+	fmt.Print(strings.Repeat("=", 60) + "\n")
+
+	return nil
+}

--- a/cmd/hcp/transitiontoeus/transitiontoeus.go
+++ b/cmd/hcp/transitiontoeus/transitiontoeus.go
@@ -345,13 +345,20 @@ func (o *transitionOptions) preValidateClusters(clusters []*v1.Cluster) ([]*v1.C
 	return eligible, skipped
 }
 
-// policyDetails stores information about a cluster's upgrade policy
+// recurringPolicyBackup stores complete information needed to restore a recurring upgrade policy
+type recurringPolicyBackup struct {
+	id          string
+	schedule    string
+	scheduleType v1.ScheduleType
+	upgradeType v1.UpgradeType
+	enableMinor bool
+	version     string // May be empty for automatic policies
+}
+
+// policyDetails stores information about a cluster's upgrade policies
 type policyDetails struct {
-	hasRecurringPolicy bool
-	policyID           string
-	schedule           string
-	scheduleType       string
-	enableMinor        bool
+	hasRecurringPolicies bool
+	recurringPolicies    []recurringPolicyBackup
 }
 
 // clusterProcessResult contains the result of processing a cluster
@@ -383,23 +390,27 @@ func (o *transitionOptions) processCluster(ocmClient *sdk.Connection, cluster *v
 		return result
 	}
 
-	// Step 2: Delete recurring policy if it exists
-	if policy.hasRecurringPolicy {
-		fmt.Printf("  📋 Found recurring update policy (schedule: %s)\n", policy.schedule)
+	// Step 2: Delete recurring policies if they exist
+	if policy.hasRecurringPolicies {
+		if len(policy.recurringPolicies) == 1 {
+			fmt.Printf("  📋 Found recurring update policy (schedule: %s)\n", policy.recurringPolicies[0].schedule)
+		} else {
+			fmt.Printf("  📋 Found %d recurring update policies\n", len(policy.recurringPolicies))
+		}
 
 		if o.dryRun {
-			fmt.Printf("  🔍 DRY-RUN: Would delete upgrade policy\n")
+			fmt.Printf("  🔍 DRY-RUN: Would delete %d upgrade policy/policies\n", len(policy.recurringPolicies))
 		} else {
-			fmt.Printf("  🗑️  Deleting upgrade policy to allow channel transition\n")
-			if err := o.deleteUpgradePolicy(ocmClient, cluster, policy.policyID); err != nil {
-				result.err = fmt.Errorf("failed to delete upgrade policy: %w", err)
+			fmt.Printf("  🗑️  Deleting %d upgrade policy/policies to allow channel transition\n", len(policy.recurringPolicies))
+			if err := o.deleteUpgradePolicies(ocmClient, cluster, policy.recurringPolicies); err != nil {
+				result.err = fmt.Errorf("failed to delete upgrade policies: %w", err)
 				return result
 			}
-			// Mark that we've modified the policy
+			// Mark that we've modified the policies
 			result.policyWasModified = true
 		}
 	} else {
-		fmt.Printf("  ℹ️  Cluster uses individual updates (no policy to delete)\n")
+		fmt.Printf("  ℹ️  Cluster uses individual updates (no recurring policies to delete)\n")
 	}
 
 	// Step 3: Transition channel to EUS
@@ -408,15 +419,15 @@ func (o *transitionOptions) processCluster(ocmClient *sdk.Connection, cluster *v
 	} else {
 		fmt.Printf("  🔄 Transitioning channel from '%s' to 'eus'\n", currentChannel)
 		if err := o.transitionChannelToEUS(ocmClient, cluster); err != nil {
-			// Channel transition failed - try to restore policy if we deleted it
+			// Channel transition failed - try to restore policies if we deleted them
 			if result.policyWasModified {
-				fmt.Printf("  🔁 Channel transition failed - attempting to restore upgrade policy\n")
-				if restoreErr := o.restoreUpgradePolicy(ocmClient, cluster, policy); restoreErr != nil {
-					result.err = fmt.Errorf("failed to transition channel: %w (CRITICAL: also failed to restore policy: %v)", err, restoreErr)
+				fmt.Printf("  🔁 Channel transition failed - attempting to restore upgrade policies\n")
+				if restoreErr := o.restoreUpgradePolicies(ocmClient, cluster, policy.recurringPolicies); restoreErr != nil {
+					result.err = fmt.Errorf("failed to transition channel: %w (CRITICAL: also failed to restore policies: %v)", err, restoreErr)
 				} else {
 					result.policyWasRestored = true
-					result.err = fmt.Errorf("failed to transition channel: %w (upgrade policy was restored)", err)
-					fmt.Printf("  ✓ Upgrade policy restored after failure\n")
+					result.err = fmt.Errorf("failed to transition channel: %w (upgrade policies restored)", err)
+					fmt.Printf("  ✓ Upgrade policies restored after failure\n")
 				}
 			} else {
 				result.err = fmt.Errorf("failed to transition channel: %w", err)
@@ -428,15 +439,15 @@ func (o *transitionOptions) processCluster(ocmClient *sdk.Connection, cluster *v
 		fmt.Printf("  🔍 Verifying channel transition\n")
 		newChannel, err := o.pollChannelChange(ocmClient, cluster, "eus", 10, 2*time.Second)
 		if err != nil {
-			// Verification failed - try to restore policy if we deleted it
+			// Verification failed - try to restore policies if we deleted them
 			if result.policyWasModified {
-				fmt.Printf("  🔁 Channel verification failed - attempting to restore upgrade policy\n")
-				if restoreErr := o.restoreUpgradePolicy(ocmClient, cluster, policy); restoreErr != nil {
-					result.err = fmt.Errorf("failed to verify channel change: %w (CRITICAL: also failed to restore policy: %v)", err, restoreErr)
+				fmt.Printf("  🔁 Channel verification failed - attempting to restore upgrade policies\n")
+				if restoreErr := o.restoreUpgradePolicies(ocmClient, cluster, policy.recurringPolicies); restoreErr != nil {
+					result.err = fmt.Errorf("failed to verify channel change: %w (CRITICAL: also failed to restore policies: %v)", err, restoreErr)
 				} else {
 					result.policyWasRestored = true
-					result.err = fmt.Errorf("failed to verify channel change: %w (upgrade policy was restored)", err)
-					fmt.Printf("  ✓ Upgrade policy restored after failure\n")
+					result.err = fmt.Errorf("failed to verify channel change: %w (upgrade policies restored)", err)
+					fmt.Printf("  ✓ Upgrade policies restored after failure\n")
 				}
 			} else {
 				result.err = fmt.Errorf("failed to verify channel change: %w", err)
@@ -447,18 +458,18 @@ func (o *transitionOptions) processCluster(ocmClient *sdk.Connection, cluster *v
 		fmt.Printf("  ✓ Channel successfully transitioned to 'eus' (verified: %s)\n", newChannel)
 	}
 
-	// Step 5: Restore recurring policy if it existed
-	if policy.hasRecurringPolicy {
+	// Step 5: Restore recurring policies if they existed
+	if policy.hasRecurringPolicies {
 		if o.dryRun {
-			fmt.Printf("  🔍 DRY-RUN: Would restore upgrade policy\n")
+			fmt.Printf("  🔍 DRY-RUN: Would restore %d upgrade policy/policies\n", len(policy.recurringPolicies))
 		} else {
-			fmt.Printf("  🔁 Restoring upgrade policy\n")
-			if err := o.restoreUpgradePolicy(ocmClient, cluster, policy); err != nil {
-				result.err = fmt.Errorf("failed to restore upgrade policy: %w", err)
+			fmt.Printf("  🔁 Restoring %d upgrade policy/policies\n", len(policy.recurringPolicies))
+			if err := o.restoreUpgradePolicies(ocmClient, cluster, policy.recurringPolicies); err != nil {
+				result.err = fmt.Errorf("failed to restore upgrade policies: %w", err)
 				return result
 			}
 			result.policyWasRestored = true
-			fmt.Printf("  ✓ Upgrade policy restored\n")
+			fmt.Printf("  ✓ Upgrade policies restored\n")
 		}
 	}
 
@@ -480,40 +491,51 @@ func (o *transitionOptions) getUpgradePolicyDetails(ocmClient *sdk.Connection, c
 
 	policies := policiesResponse.Items().Slice()
 	if len(policies) == 0 {
-		return &policyDetails{hasRecurringPolicy: false}, nil
+		return &policyDetails{hasRecurringPolicies: false}, nil
 	}
 
-	// Filter for recurring (automatic) policies only - ignore one-off manual upgrade policies
+	// Filter and preserve all recurring (automatic) policies - ignore one-off manual upgrade policies
 	// One-off manual policies (ScheduleTypeManual) are customer-scheduled upgrades that should not be touched
-	var recurringPolicy *v1.ControlPlaneUpgradePolicy
+	var recurringPolicies []recurringPolicyBackup
 	for _, policy := range policies {
 		if policy.ScheduleType() == v1.ScheduleTypeAutomatic {
-			if recurringPolicy != nil {
-				return nil, fmt.Errorf("found multiple automatic recurring policies (IDs: %s, %s) - this is unexpected, please review cluster state manually", recurringPolicy.ID(), policy.ID())
+			// Preserve complete policy details for faithful restoration
+			backup := recurringPolicyBackup{
+				id:           policy.ID(),
+				schedule:     policy.Schedule(),
+				scheduleType: policy.ScheduleType(),
+				upgradeType:  policy.UpgradeType(),
+				enableMinor:  policy.EnableMinorVersionUpgrades(),
 			}
-			recurringPolicy = policy
+			// Version may be empty for automatic policies
+			if policy.Version() != "" {
+				backup.version = policy.Version()
+			}
+			recurringPolicies = append(recurringPolicies, backup)
 		}
 		// Skip manual one-off policies - these are customer-scheduled and should not be deleted
 	}
 
 	// No recurring policies found - cluster uses individual updates or only has one-off manual upgrades
-	if recurringPolicy == nil {
-		return &policyDetails{hasRecurringPolicy: false}, nil
+	if len(recurringPolicies) == 0 {
+		return &policyDetails{hasRecurringPolicies: false}, nil
 	}
 
 	return &policyDetails{
-		hasRecurringPolicy: true,
-		policyID:           recurringPolicy.ID(),
-		schedule:           recurringPolicy.Schedule(),
-		scheduleType:       string(recurringPolicy.ScheduleType()),
-		enableMinor:        recurringPolicy.EnableMinorVersionUpgrades(),
+		hasRecurringPolicies: true,
+		recurringPolicies:    recurringPolicies,
 	}, nil
 }
 
-func (o *transitionOptions) deleteUpgradePolicy(ocmClient *sdk.Connection, cluster *v1.Cluster, policyID string) error {
-	_, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).
-		ControlPlane().UpgradePolicies().ControlPlaneUpgradePolicy(policyID).Delete().Send()
-	return err
+func (o *transitionOptions) deleteUpgradePolicies(ocmClient *sdk.Connection, cluster *v1.Cluster, policies []recurringPolicyBackup) error {
+	for _, policy := range policies {
+		_, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).
+			ControlPlane().UpgradePolicies().ControlPlaneUpgradePolicy(policy.id).Delete().Send()
+		if err != nil {
+			return fmt.Errorf("failed to delete policy %s: %w", policy.id, err)
+		}
+	}
+	return nil
 }
 
 func (o *transitionOptions) transitionChannelToEUS(ocmClient *sdk.Connection, cluster *v1.Cluster) error {
@@ -528,25 +550,32 @@ func (o *transitionOptions) transitionChannelToEUS(ocmClient *sdk.Connection, cl
 	return err
 }
 
-func (o *transitionOptions) restoreUpgradePolicy(ocmClient *sdk.Connection, cluster *v1.Cluster, policy *policyDetails) error {
-	scheduleType := v1.ScheduleTypeAutomatic
-	if policy.scheduleType == "manual" {
-		scheduleType = v1.ScheduleTypeManual
-	}
+func (o *transitionOptions) restoreUpgradePolicies(ocmClient *sdk.Connection, cluster *v1.Cluster, policies []recurringPolicyBackup) error {
+	for _, backup := range policies {
+		// Build policy with all preserved fields
+		policyBuilder := v1.NewControlPlaneUpgradePolicy().
+			Schedule(backup.schedule).
+			ScheduleType(backup.scheduleType).
+			UpgradeType(backup.upgradeType).
+			EnableMinorVersionUpgrades(backup.enableMinor)
 
-	newPolicy, err := v1.NewControlPlaneUpgradePolicy().
-		Schedule(policy.schedule).
-		ScheduleType(scheduleType).
-		UpgradeType(v1.UpgradeTypeControlPlane).
-		EnableMinorVersionUpgrades(policy.enableMinor).
-		Build()
-	if err != nil {
-		return fmt.Errorf("failed to build upgrade policy: %w", err)
-	}
+		// Add version if it was present in the original policy
+		if backup.version != "" {
+			policyBuilder = policyBuilder.Version(backup.version)
+		}
 
-	_, err = ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).
-		ControlPlane().UpgradePolicies().Add().Body(newPolicy).Send()
-	return err
+		newPolicy, err := policyBuilder.Build()
+		if err != nil {
+			return fmt.Errorf("failed to build upgrade policy: %w", err)
+		}
+
+		_, err = ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).
+			ControlPlane().UpgradePolicies().Add().Body(newPolicy).Send()
+		if err != nil {
+			return fmt.Errorf("failed to restore policy: %w", err)
+		}
+	}
+	return nil
 }
 
 // pollChannelChange polls OCM to verify the channel change with bounded retries

--- a/cmd/hcp/transitiontoeus/transitiontoeus.go
+++ b/cmd/hcp/transitiontoeus/transitiontoeus.go
@@ -353,9 +353,9 @@ type policyDetails struct {
 
 // clusterProcessResult contains the result of processing a cluster
 type clusterProcessResult struct {
-	err                  error
-	policyWasModified    bool // true if we deleted recurring policy (even if later restored)
-	policyWasRestored    bool // true if we successfully restored the policy after modification
+	err               error
+	policyWasModified bool // true if we deleted recurring policy (even if later restored)
+	policyWasRestored bool // true if we successfully restored the policy after modification
 }
 
 func (o *transitionOptions) processCluster(ocmClient *sdk.Connection, cluster *v1.Cluster) *clusterProcessResult {
@@ -656,7 +656,6 @@ func sendServiceLog(ocmClient *sdk.Connection, message *servicelog.Message) erro
 
 	return nil
 }
-
 
 func (o *transitionOptions) printSummary(successful, failed []string) {
 	fmt.Print("\n" + strings.Repeat("=", 60) + "\n")

--- a/cmd/hcp/transitiontoeus/transitiontoeus.go
+++ b/cmd/hcp/transitiontoeus/transitiontoeus.go
@@ -205,19 +205,35 @@ func (o *transitionOptions) Run() error {
 			failed = append(failed, fmt.Sprintf("%s: %s", cluster.ExternalID(), result.err.Error()))
 			fmt.Printf("  ⚠️  Failed to transition: %v\n", result.err)
 
-			// Prompt to send "attempted" service log if we modified recurring policy and restored it
-			// This means we actually changed the customer's cluster configuration but transition failed
-			if result.policyWasModified && result.policyWasRestored {
-				if !o.dryRun {
-					fmt.Println()
-					fmt.Printf("  ℹ️  Note: The recurring upgrade policy was modified during this attempt but has been restored.\n")
+			// Handle service log notification based on policy modification state
+			if result.policyWasModified {
+				if result.policyWasRestored {
+					// Policy was modified and successfully restored - send "attempted" service log
+					if !o.dryRun {
+						fmt.Println()
+						fmt.Printf("  ℹ️  Note: The recurring upgrade policy was modified during this attempt but has been restored.\n")
 
-					// Show service log preview and prompt
-					if err := promptAndSendServiceLog(ocmClient, cluster, "attempted"); err != nil {
-						fmt.Printf("  ⚠️  Failed to send service log: %v\n", err)
+						// Show service log preview and prompt
+						if err := promptAndSendServiceLog(ocmClient, cluster, "attempted"); err != nil {
+							fmt.Printf("  ⚠️  Failed to send service log: %v\n", err)
+						}
+					} else {
+						fmt.Printf("  📧 DRY-RUN: Would prompt to send 'attempted' service log (policy was modified and restored)\n")
 					}
-				} else {
-					fmt.Printf("  📧 DRY-RUN: Would prompt to send 'attempted' service log (policy was modified and restored)\n")
+				} else if len(result.unrestoredPolicies) > 0 {
+					// CRITICAL: Policy was deleted but NOT restored - cluster is in bad state
+					if !o.dryRun {
+						fmt.Println()
+						fmt.Printf("  ⚠️  CRITICAL: %d recurring upgrade policy/policies were deleted but could not be restored!\n", len(result.unrestoredPolicies))
+						fmt.Printf("  ⚠️  Action required: Use the policy details printed above to manually restore.\n")
+
+						// Show service log preview and prompt for critical failure
+						if err := promptAndSendServiceLog(ocmClient, cluster, "attempted"); err != nil {
+							fmt.Printf("  ⚠️  Failed to send service log: %v\n", err)
+						}
+					} else {
+						fmt.Printf("  📧 DRY-RUN: Would prompt to send 'attempted' service log (CRITICAL: %d policies not restored)\n", len(result.unrestoredPolicies))
+					}
 				}
 			}
 		} else {
@@ -345,27 +361,18 @@ func (o *transitionOptions) preValidateClusters(clusters []*v1.Cluster) ([]*v1.C
 	return eligible, skipped
 }
 
-// recurringPolicyBackup stores complete information needed to restore a recurring upgrade policy
-type recurringPolicyBackup struct {
-	id           string
-	schedule     string
-	scheduleType v1.ScheduleType
-	upgradeType  v1.UpgradeType
-	enableMinor  bool
-	version      string // May be empty for automatic policies
-}
-
 // policyDetails stores information about a cluster's upgrade policies
 type policyDetails struct {
 	hasRecurringPolicies bool
-	recurringPolicies    []recurringPolicyBackup
+	recurringPolicies    []*v1.ControlPlaneUpgradePolicy
 }
 
 // clusterProcessResult contains the result of processing a cluster
 type clusterProcessResult struct {
-	err               error
-	policyWasModified bool // true if we deleted recurring policy (even if later restored)
-	policyWasRestored bool // true if we successfully restored the policy after modification
+	err                error
+	policyWasModified  bool                            // true if we deleted recurring policy (even if later restored)
+	policyWasRestored  bool                            // true if we successfully restored the policy after modification
+	unrestoredPolicies []*v1.ControlPlaneUpgradePolicy // policies that were deleted but could not be restored
 }
 
 func (o *transitionOptions) processCluster(ocmClient *sdk.Connection, cluster *v1.Cluster) *clusterProcessResult {
@@ -393,7 +400,7 @@ func (o *transitionOptions) processCluster(ocmClient *sdk.Connection, cluster *v
 	// Step 2: Delete recurring policies if they exist
 	if policy.hasRecurringPolicies {
 		if len(policy.recurringPolicies) == 1 {
-			fmt.Printf("  📋 Found recurring update policy (schedule: %s)\n", policy.recurringPolicies[0].schedule)
+			fmt.Printf("  📋 Found recurring update policy (schedule: %s)\n", policy.recurringPolicies[0].Schedule())
 		} else {
 			fmt.Printf("  📋 Found %d recurring update policies\n", len(policy.recurringPolicies))
 		}
@@ -411,13 +418,8 @@ func (o *transitionOptions) processCluster(ocmClient *sdk.Connection, cluster *v
 				// If we partially deleted policies, try to restore what we deleted
 				if len(deleted) > 0 {
 					fmt.Printf("  🔁 Deletion failed after deleting %d/%d policies - attempting to restore deleted policies\n", len(deleted), len(policy.recurringPolicies))
-					if restoreErr := o.restoreUpgradePolicies(ocmClient, cluster, deleted); restoreErr != nil {
-						result.err = fmt.Errorf("failed to delete upgrade policies: %w (CRITICAL: also failed to restore %d deleted policies: %v)", err, len(deleted), restoreErr)
-					} else {
-						result.policyWasRestored = true
-						result.err = fmt.Errorf("failed to delete upgrade policies: %w (deleted policies restored)", err)
-						fmt.Printf("  ✓ Deleted policies restored after failure\n")
-					}
+					result.err = o.attemptRestoreWithFallback(ocmClient, cluster, deleted, result,
+						fmt.Errorf("failed to delete upgrade policies: %w", err), "deletion failure")
 				} else {
 					result.err = fmt.Errorf("failed to delete upgrade policies: %w", err)
 				}
@@ -436,14 +438,8 @@ func (o *transitionOptions) processCluster(ocmClient *sdk.Connection, cluster *v
 		if err := o.transitionChannelToEUS(ocmClient, cluster); err != nil {
 			// Channel transition failed - try to restore policies if we deleted them
 			if result.policyWasModified {
-				fmt.Printf("  🔁 Channel transition failed - attempting to restore upgrade policies\n")
-				if restoreErr := o.restoreUpgradePolicies(ocmClient, cluster, policy.recurringPolicies); restoreErr != nil {
-					result.err = fmt.Errorf("failed to transition channel: %w (CRITICAL: also failed to restore policies: %v)", err, restoreErr)
-				} else {
-					result.policyWasRestored = true
-					result.err = fmt.Errorf("failed to transition channel: %w (upgrade policies restored)", err)
-					fmt.Printf("  ✓ Upgrade policies restored after failure\n")
-				}
+				result.err = o.attemptRestoreWithFallback(ocmClient, cluster, policy.recurringPolicies, result,
+					fmt.Errorf("failed to transition channel: %w", err), "channel transition failed")
 			} else {
 				result.err = fmt.Errorf("failed to transition channel: %w", err)
 			}
@@ -456,14 +452,8 @@ func (o *transitionOptions) processCluster(ocmClient *sdk.Connection, cluster *v
 		if err != nil {
 			// Verification failed - try to restore policies if we deleted them
 			if result.policyWasModified {
-				fmt.Printf("  🔁 Channel verification failed - attempting to restore upgrade policies\n")
-				if restoreErr := o.restoreUpgradePolicies(ocmClient, cluster, policy.recurringPolicies); restoreErr != nil {
-					result.err = fmt.Errorf("failed to verify channel change: %w (CRITICAL: also failed to restore policies: %v)", err, restoreErr)
-				} else {
-					result.policyWasRestored = true
-					result.err = fmt.Errorf("failed to verify channel change: %w (upgrade policies restored)", err)
-					fmt.Printf("  ✓ Upgrade policies restored after failure\n")
-				}
+				result.err = o.attemptRestoreWithFallback(ocmClient, cluster, policy.recurringPolicies, result,
+					fmt.Errorf("failed to verify channel change: %w", err), "channel verification failed")
 			} else {
 				result.err = fmt.Errorf("failed to verify channel change: %w", err)
 			}
@@ -511,22 +501,11 @@ func (o *transitionOptions) getUpgradePolicyDetails(ocmClient *sdk.Connection, c
 
 	// Filter and preserve all recurring (automatic) policies - ignore one-off manual upgrade policies
 	// One-off manual policies (ScheduleTypeManual) are customer-scheduled upgrades that should not be touched
-	var recurringPolicies []recurringPolicyBackup
+	var recurringPolicies []*v1.ControlPlaneUpgradePolicy
 	for _, policy := range policies {
 		if policy.ScheduleType() == v1.ScheduleTypeAutomatic {
-			// Preserve complete policy details for faithful restoration
-			backup := recurringPolicyBackup{
-				id:           policy.ID(),
-				schedule:     policy.Schedule(),
-				scheduleType: policy.ScheduleType(),
-				upgradeType:  policy.UpgradeType(),
-				enableMinor:  policy.EnableMinorVersionUpgrades(),
-			}
-			// Version may be empty for automatic policies
-			if policy.Version() != "" {
-				backup.version = policy.Version()
-			}
-			recurringPolicies = append(recurringPolicies, backup)
+			// Store the complete policy object from the SDK for faithful restoration
+			recurringPolicies = append(recurringPolicies, policy)
 		}
 		// Skip manual one-off policies - these are customer-scheduled and should not be deleted
 	}
@@ -542,13 +521,13 @@ func (o *transitionOptions) getUpgradePolicyDetails(ocmClient *sdk.Connection, c
 	}, nil
 }
 
-func (o *transitionOptions) deleteUpgradePolicies(ocmClient *sdk.Connection, cluster *v1.Cluster, policies []recurringPolicyBackup) ([]recurringPolicyBackup, error) {
-	deleted := make([]recurringPolicyBackup, 0, len(policies))
+func (o *transitionOptions) deleteUpgradePolicies(ocmClient *sdk.Connection, cluster *v1.Cluster, policies []*v1.ControlPlaneUpgradePolicy) ([]*v1.ControlPlaneUpgradePolicy, error) {
+	deleted := make([]*v1.ControlPlaneUpgradePolicy, 0, len(policies))
 	for _, policy := range policies {
 		_, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).
-			ControlPlane().UpgradePolicies().ControlPlaneUpgradePolicy(policy.id).Delete().Send()
+			ControlPlane().UpgradePolicies().ControlPlaneUpgradePolicy(policy.ID()).Delete().Send()
 		if err != nil {
-			return deleted, fmt.Errorf("failed to delete policy %s: %w", policy.id, err)
+			return deleted, fmt.Errorf("failed to delete policy %s: %w", policy.ID(), err)
 		}
 		deleted = append(deleted, policy)
 	}
@@ -567,22 +546,23 @@ func (o *transitionOptions) transitionChannelToEUS(ocmClient *sdk.Connection, cl
 	return err
 }
 
-func (o *transitionOptions) restoreUpgradePolicies(ocmClient *sdk.Connection, cluster *v1.Cluster, policies []recurringPolicyBackup) error {
+func (o *transitionOptions) restoreUpgradePolicies(ocmClient *sdk.Connection, cluster *v1.Cluster, policies []*v1.ControlPlaneUpgradePolicy) error {
 	// Track newly created policy IDs for rollback if needed
 	var restoredPolicyIDs []string
 
-	for i, backup := range policies {
-		// Build policy with all preserved fields
+	for i, originalPolicy := range policies {
+		// Build new policy from the original, preserving all fields except ID
+		// (ID will be generated by the API when we create it)
 		policyBuilder := v1.NewControlPlaneUpgradePolicy().
-			Schedule(backup.schedule).
-			ScheduleType(backup.scheduleType).
-			UpgradeType(backup.upgradeType).
-			EnableMinorVersionUpgrades(backup.enableMinor)
+			Schedule(originalPolicy.Schedule()).
+			ScheduleType(originalPolicy.ScheduleType()).
+			UpgradeType(originalPolicy.UpgradeType()).
+			EnableMinorVersionUpgrades(originalPolicy.EnableMinorVersionUpgrades())
 
 		// Add version only for manual policies - automatic policies must not have version set
 		// Manual policies target a specific version, automatic policies use the latest available
-		if backup.version != "" && backup.scheduleType == v1.ScheduleTypeManual {
-			policyBuilder = policyBuilder.Version(backup.version)
+		if originalPolicy.Version() != "" && originalPolicy.ScheduleType() == v1.ScheduleTypeManual {
+			policyBuilder = policyBuilder.Version(originalPolicy.Version())
 		}
 
 		newPolicy, err := policyBuilder.Build()
@@ -608,6 +588,90 @@ func (o *transitionOptions) restoreUpgradePolicies(ocmClient *sdk.Connection, cl
 		restoredPolicyIDs = append(restoredPolicyIDs, response.Body().ID())
 	}
 	return nil
+}
+
+// printPoliciesForManualRestore outputs policy details in YAML format so SRE can restore manually
+// and saves them to a file for later restoration
+func printPoliciesForManualRestore(policies []*v1.ControlPlaneUpgradePolicy, clusterID string) {
+	timestamp := time.Now().Format("20060102_150405")
+	filename := fmt.Sprintf("unrestored_policies_%s_%s.sh", clusterID, timestamp)
+
+	// Build the restoration script content
+	var scriptContent strings.Builder
+	scriptContent.WriteString("#!/bin/bash\n")
+	fmt.Fprintf(&scriptContent, "# Unrestored upgrade policies for cluster: %s\n", clusterID)
+	fmt.Fprintf(&scriptContent, "# Generated: %s\n", time.Now().Format(time.RFC3339))
+	fmt.Fprintf(&scriptContent, "# Total policies: %d\n\n", len(policies))
+	fmt.Fprintf(&scriptContent, "CLUSTER_ID=\"%s\"\n\n", clusterID)
+
+	for i, policy := range policies {
+		fmt.Fprintf(&scriptContent, "# Policy %d/%d\n", i+1, len(policies))
+		fmt.Fprintf(&scriptContent, "echo \"Restoring policy %d/%d...\"\n", i+1, len(policies))
+		scriptContent.WriteString("ocm post \"/api/clusters_mgmt/v1/clusters/${CLUSTER_ID}/control_plane/upgrade_policies\" <<'EOF'\n")
+		scriptContent.WriteString("{\n")
+		fmt.Fprintf(&scriptContent, "  \"schedule\": \"%s\",\n", policy.Schedule())
+		fmt.Fprintf(&scriptContent, "  \"schedule_type\": \"%s\",\n", policy.ScheduleType())
+		fmt.Fprintf(&scriptContent, "  \"upgrade_type\": \"%s\",\n", policy.UpgradeType())
+		fmt.Fprintf(&scriptContent, "  \"enable_minor_version_upgrades\": %t", policy.EnableMinorVersionUpgrades())
+		if policy.Version() != "" && policy.ScheduleType() == v1.ScheduleTypeManual {
+			fmt.Fprintf(&scriptContent, ",\n  \"version\": \"%s\"\n", policy.Version())
+		} else {
+			scriptContent.WriteString("\n")
+		}
+		scriptContent.WriteString("}\n")
+		scriptContent.WriteString("EOF\n")
+		if i < len(policies)-1 {
+			scriptContent.WriteString("\n")
+		}
+	}
+
+	// Save to file with read/write permissions (0600), then add execute permission
+	if err := os.WriteFile(filename, []byte(scriptContent.String()), 0600); err != nil {
+		fmt.Printf("  ⚠️  Warning: Failed to save policy restoration script to %s: %v\n", filename, err)
+	} else {
+		// Make the script executable by the owner
+		if err := os.Chmod(filename, 0700); err != nil {
+			fmt.Printf("  ⚠️  Warning: Failed to make script executable: %v\n", err)
+		}
+		fmt.Printf("  💾 Saved policy restoration script to: %s\n", filename)
+	}
+
+	// Also print to console
+	fmt.Println()
+	fmt.Printf("  📋 Policy details for manual restoration (cluster: %s):\n", clusterID)
+	fmt.Println("  " + strings.Repeat("-", 70))
+	for i, policy := range policies {
+		fmt.Printf("  Policy %d/%d:\n", i+1, len(policies))
+		fmt.Printf("    schedule: %s\n", policy.Schedule())
+		fmt.Printf("    schedule_type: %s\n", policy.ScheduleType())
+		fmt.Printf("    upgrade_type: %s\n", policy.UpgradeType())
+		fmt.Printf("    enable_minor_version_upgrades: %t\n", policy.EnableMinorVersionUpgrades())
+		if policy.Version() != "" && policy.ScheduleType() == v1.ScheduleTypeManual {
+			fmt.Printf("    version: %s\n", policy.Version())
+		}
+		fmt.Println()
+		fmt.Printf("    # To restore manually, run: ./%s\n", filename)
+		if i < len(policies)-1 {
+			fmt.Println("  " + strings.Repeat("-", 70))
+		}
+	}
+	fmt.Println("  " + strings.Repeat("-", 70))
+	fmt.Println()
+}
+
+// attemptRestoreWithFallback tries to restore policies and prints details if it fails
+func (o *transitionOptions) attemptRestoreWithFallback(ocmClient *sdk.Connection, cluster *v1.Cluster, policies []*v1.ControlPlaneUpgradePolicy, result *clusterProcessResult, contextErr error, context string) error {
+	fmt.Printf("  🔁 %s - attempting to restore upgrade policies\n", context)
+	if restoreErr := o.restoreUpgradePolicies(ocmClient, cluster, policies); restoreErr != nil {
+		// CRITICAL: Failed to restore policies - print details for manual restoration
+		fmt.Printf("  ⚠️  CRITICAL: Failed to restore policies after %s\n", context)
+		printPoliciesForManualRestore(policies, cluster.ID())
+		result.unrestoredPolicies = policies
+		return fmt.Errorf("%w (CRITICAL: also failed to restore %d policies: %v)", contextErr, len(policies), restoreErr)
+	}
+	result.policyWasRestored = true
+	fmt.Printf("  ✓ Upgrade policies restored after failure\n")
+	return fmt.Errorf("%w (upgrade policies restored)", contextErr)
 }
 
 // rollbackRestoredPolicies deletes policies that were just created during a failed restore operation

--- a/cmd/hcp/transitiontoeus/transitiontoeus.go
+++ b/cmd/hcp/transitiontoeus/transitiontoeus.go
@@ -35,6 +35,9 @@ var serviceLogTemplates = map[string]string{
 	"attempted": "https://raw.githubusercontent.com/openshift/managed-notifications/master/hcp/eus_transition_attempted.json",
 }
 
+// Template cache to avoid re-fetching the same templates in batch mode
+var templateCache = make(map[string][]byte)
+
 // Regular expression for valid cluster IDs - alphanumeric characters and hyphens only
 var validClusterIDRegex = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
 
@@ -421,9 +424,9 @@ func (o *transitionOptions) processCluster(ocmClient *sdk.Connection, cluster *v
 			return result
 		}
 
-		// Step 4: Verify channel change
-		time.Sleep(2 * time.Second) // Give OCM time to process
-		updatedCluster, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).Get().Send()
+		// Step 4: Verify channel change with bounded polling
+		fmt.Printf("  🔍 Verifying channel transition\n")
+		newChannel, err := o.pollChannelChange(ocmClient, cluster, "eus", 10, 2*time.Second)
 		if err != nil {
 			// Verification failed - try to restore policy if we deleted it
 			if result.policyWasModified {
@@ -441,25 +444,7 @@ func (o *transitionOptions) processCluster(ocmClient *sdk.Connection, cluster *v
 			return result
 		}
 
-		newChannel := updatedCluster.Body().Version().ChannelGroup()
-		if newChannel != "eus" {
-			// Verification failed - try to restore policy if we deleted it
-			if result.policyWasModified {
-				fmt.Printf("  🔁 Channel verification failed - attempting to restore upgrade policy\n")
-				if restoreErr := o.restoreUpgradePolicy(ocmClient, cluster, policy); restoreErr != nil {
-					result.err = fmt.Errorf("channel verification failed - expected 'eus' but got '%s' (CRITICAL: also failed to restore policy: %v)", newChannel, restoreErr)
-				} else {
-					result.policyWasRestored = true
-					result.err = fmt.Errorf("channel verification failed - expected 'eus' but got '%s' (upgrade policy was restored)", newChannel)
-					fmt.Printf("  ✓ Upgrade policy restored after failure\n")
-				}
-			} else {
-				result.err = fmt.Errorf("channel verification failed - expected 'eus' but got '%s'", newChannel)
-			}
-			return result
-		}
-
-		fmt.Printf("  ✓ Channel successfully transitioned to 'eus'\n")
+		fmt.Printf("  ✓ Channel successfully transitioned to 'eus' (verified: %s)\n", newChannel)
 	}
 
 	// Step 5: Restore recurring policy if it existed
@@ -549,7 +534,36 @@ func (o *transitionOptions) restoreUpgradePolicy(ocmClient *sdk.Connection, clus
 	return err
 }
 
+// pollChannelChange polls OCM to verify the channel change with bounded retries
+func (o *transitionOptions) pollChannelChange(ocmClient *sdk.Connection, cluster *v1.Cluster, expectedChannel string, maxAttempts int, interval time.Duration) (string, error) {
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		time.Sleep(interval)
+
+		updatedCluster, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).Get().Send()
+		if err != nil {
+			// Only fail on last attempt, otherwise retry
+			if attempt == maxAttempts {
+				return "", fmt.Errorf("failed to get cluster after %d attempts: %w", maxAttempts, err)
+			}
+			continue
+		}
+
+		currentChannel := updatedCluster.Body().Version().ChannelGroup()
+		if currentChannel == expectedChannel {
+			return currentChannel, nil
+		}
+
+		// Only fail on last attempt
+		if attempt == maxAttempts {
+			return currentChannel, fmt.Errorf("channel verification failed after %d attempts - expected '%s' but got '%s'", maxAttempts, expectedChannel, currentChannel)
+		}
+	}
+
+	return "", fmt.Errorf("unexpected error in polling loop")
+}
+
 // loadServiceLogTemplate loads a service log template from either a predefined template name or file path
+// Templates are cached to avoid re-fetching in batch mode
 func loadServiceLogTemplate(templateOrFile string) ([]byte, bool, error) {
 	var templateBytes []byte
 	var err error
@@ -557,14 +571,20 @@ func loadServiceLogTemplate(templateOrFile string) ([]byte, bool, error) {
 
 	// Check if it's a template name
 	if templateURL, exists := serviceLogTemplates[templateOrFile]; exists {
-		// Use predefined template URL
+		// Check cache first
+		if cached, found := templateCache[templateOrFile]; found {
+			return cached, true, nil
+		}
+
+		// Fetch and cache the template
 		templateBytes, err = utils.CurlThis(templateURL)
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to fetch template from %s: %w", templateURL, err)
 		}
+		templateCache[templateOrFile] = templateBytes
 		usingDefaultTemplate = true
 	} else {
-		// Treat as file path
+		// Treat as file path - don't cache file-based templates as they may be edited between runs
 		templateBytes, err = os.ReadFile(templateOrFile)
 		if err != nil {
 			return nil, false, fmt.Errorf("failed to read template file %s: %w", templateOrFile, err)
@@ -588,9 +608,12 @@ func promptAndSendServiceLog(ocmClient *sdk.Connection, cluster *v1.Cluster, tem
 		return fmt.Errorf("failed to parse service log template: %w", err)
 	}
 
-	// Set cluster-specific fields
+	// Set cluster-specific fields (matching cmd/servicelog/post.go:612-617)
 	message.ClusterUUID = cluster.ExternalID()
 	message.ClusterID = cluster.ID()
+	if subscription := cluster.Subscription(); subscription != nil {
+		message.SubscriptionID = subscription.ID()
+	}
 
 	// Validate that all required parameters were replaced
 	if leftoverParams, found := message.FindLeftovers(); found {
@@ -632,6 +655,7 @@ func promptAndSendServiceLog(ocmClient *sdk.Connection, cluster *v1.Cluster, tem
 }
 
 // sendServiceLog sends the prepared service log message
+// Implementation aligned with cmd/servicelog/post.go:304-310
 func sendServiceLog(ocmClient *sdk.Connection, message *servicelog.Message) error {
 	request := ocmClient.Post()
 	if err := arguments.ApplyPathArg(request, "/api/service_logs/v1/cluster_logs"); err != nil {
@@ -650,7 +674,8 @@ func sendServiceLog(ocmClient *sdk.Connection, message *servicelog.Message) erro
 		return fmt.Errorf("failed to send service log: %w", err)
 	}
 
-	if response.Status() != 201 {
+	// Match existing implementation: accept any 2xx/3xx status as success
+	if response.Status() >= 400 {
 		return fmt.Errorf("service log request failed with status: %d", response.Status())
 	}
 

--- a/cmd/hcp/transitiontoeus/transitiontoeus.go
+++ b/cmd/hcp/transitiontoeus/transitiontoeus.go
@@ -579,8 +579,9 @@ func (o *transitionOptions) restoreUpgradePolicies(ocmClient *sdk.Connection, cl
 			UpgradeType(backup.upgradeType).
 			EnableMinorVersionUpgrades(backup.enableMinor)
 
-		// Add version if it was present in the original policy
-		if backup.version != "" {
+		// Add version only for manual policies - automatic policies must not have version set
+		// Manual policies target a specific version, automatic policies use the latest available
+		if backup.version != "" && backup.scheduleType == v1.ScheduleTypeManual {
 			policyBuilder = policyBuilder.Version(backup.version)
 		}
 

--- a/cmd/hcp/transitiontoeus/transitiontoeus.go
+++ b/cmd/hcp/transitiontoeus/transitiontoeus.go
@@ -670,7 +670,7 @@ func promptAndSendServiceLog(ocmClient *sdk.Connection, cluster *v1.Cluster, tem
 }
 
 // sendServiceLog sends the prepared service log message
-// Implementation aligned with cmd/servicelog/post.go:304-310
+// Implementation aligned with cmd/servicelog/post.go:304-310 and common.go:24-56
 func sendServiceLog(ocmClient *sdk.Connection, message *servicelog.Message) error {
 	request := ocmClient.Post()
 	if err := arguments.ApplyPathArg(request, "/api/service_logs/v1/cluster_logs"); err != nil {
@@ -689,12 +689,70 @@ func sendServiceLog(ocmClient *sdk.Connection, message *servicelog.Message) erro
 		return fmt.Errorf("failed to send service log: %w", err)
 	}
 
-	// Match existing implementation: accept any 2xx/3xx status as success
-	if response.Status() >= 400 {
-		return fmt.Errorf("service log request failed with status: %d", response.Status())
+	body := response.Bytes()
+
+	// Validate response body - match cmd/servicelog/post.go:339-356
+	if response.Status() < 400 {
+		// Success response - validate that API echoed back expected fields
+		if err := validateServiceLogResponse(body, *message); err != nil {
+			return fmt.Errorf("service log sent but response validation failed: %w", err)
+		}
+		return nil
+	}
+
+	// Error response - parse and return the error reason
+	badReply, err := validateBadServiceLogResponse(body)
+	if err != nil {
+		return fmt.Errorf("service log request failed with status %d: %w", response.Status(), err)
+	}
+	return fmt.Errorf("service log request failed: %s (status: %d)", badReply.Reason, response.Status())
+}
+
+// validateServiceLogResponse validates that the API response echoes back the expected message fields
+// Implementation from cmd/servicelog/common.go:24-50
+func validateServiceLogResponse(body []byte, clusterMessage servicelog.Message) error {
+	if !json.Valid(body) {
+		return fmt.Errorf("server returned invalid JSON")
+	}
+
+	var goodReply servicelog.GoodReply
+	if err := json.Unmarshal(body, &goodReply); err != nil {
+		return fmt.Errorf("cannot parse the JSON response: %w", err)
+	}
+
+	// Validate that critical fields match what we sent
+	if goodReply.Severity != clusterMessage.Severity {
+		return fmt.Errorf("wrong severity echoed (sent %q, got %q)", clusterMessage.Severity, goodReply.Severity)
+	}
+	if goodReply.ServiceName != clusterMessage.ServiceName {
+		return fmt.Errorf("wrong service_name echoed (sent %q, got %q)", clusterMessage.ServiceName, goodReply.ServiceName)
+	}
+	if goodReply.ClusterUUID != clusterMessage.ClusterUUID {
+		return fmt.Errorf("wrong cluster_uuid echoed (sent %q, got %q)", clusterMessage.ClusterUUID, goodReply.ClusterUUID)
+	}
+	if goodReply.Summary != clusterMessage.Summary {
+		return fmt.Errorf("wrong summary echoed (sent %q, got %q)", clusterMessage.Summary, goodReply.Summary)
+	}
+	if goodReply.Description != clusterMessage.Description {
+		return fmt.Errorf("wrong description echoed (sent %q, got %q)", clusterMessage.Description, goodReply.Description)
 	}
 
 	return nil
+}
+
+// validateBadServiceLogResponse parses error response body
+// Implementation from cmd/servicelog/common.go:52-59
+func validateBadServiceLogResponse(body []byte) (*servicelog.BadReply, error) {
+	if !json.Valid(body) {
+		return nil, fmt.Errorf("server returned invalid JSON")
+	}
+
+	var badReply servicelog.BadReply
+	if err := json.Unmarshal(body, &badReply); err != nil {
+		return nil, fmt.Errorf("cannot parse error JSON response: %w", err)
+	}
+
+	return &badReply, nil
 }
 
 func (o *transitionOptions) printSummary(successful, failed []string) {

--- a/cmd/hcp/transitiontoeus/transitiontoeus.go
+++ b/cmd/hcp/transitiontoeus/transitiontoeus.go
@@ -402,12 +402,27 @@ func (o *transitionOptions) processCluster(ocmClient *sdk.Connection, cluster *v
 			fmt.Printf("  🔍 DRY-RUN: Would delete %d upgrade policy/policies\n", len(policy.recurringPolicies))
 		} else {
 			fmt.Printf("  🗑️  Deleting %d upgrade policy/policies to allow channel transition\n", len(policy.recurringPolicies))
-			if err := o.deleteUpgradePolicies(ocmClient, cluster, policy.recurringPolicies); err != nil {
-				result.err = fmt.Errorf("failed to delete upgrade policies: %w", err)
+			deleted, err := o.deleteUpgradePolicies(ocmClient, cluster, policy.recurringPolicies)
+			// Mark if we deleted any policies (even if later ones failed)
+			if len(deleted) > 0 {
+				result.policyWasModified = true
+			}
+			if err != nil {
+				// If we partially deleted policies, try to restore what we deleted
+				if len(deleted) > 0 {
+					fmt.Printf("  🔁 Deletion failed after deleting %d/%d policies - attempting to restore deleted policies\n", len(deleted), len(policy.recurringPolicies))
+					if restoreErr := o.restoreUpgradePolicies(ocmClient, cluster, deleted); restoreErr != nil {
+						result.err = fmt.Errorf("failed to delete upgrade policies: %w (CRITICAL: also failed to restore %d deleted policies: %v)", err, len(deleted), restoreErr)
+					} else {
+						result.policyWasRestored = true
+						result.err = fmt.Errorf("failed to delete upgrade policies: %w (deleted policies restored)", err)
+						fmt.Printf("  ✓ Deleted policies restored after failure\n")
+					}
+				} else {
+					result.err = fmt.Errorf("failed to delete upgrade policies: %w", err)
+				}
 				return result
 			}
-			// Mark that we've modified the policies
-			result.policyWasModified = true
 		}
 	} else {
 		fmt.Printf("  ℹ️  Cluster uses individual updates (no recurring policies to delete)\n")
@@ -527,15 +542,17 @@ func (o *transitionOptions) getUpgradePolicyDetails(ocmClient *sdk.Connection, c
 	}, nil
 }
 
-func (o *transitionOptions) deleteUpgradePolicies(ocmClient *sdk.Connection, cluster *v1.Cluster, policies []recurringPolicyBackup) error {
+func (o *transitionOptions) deleteUpgradePolicies(ocmClient *sdk.Connection, cluster *v1.Cluster, policies []recurringPolicyBackup) ([]recurringPolicyBackup, error) {
+	deleted := make([]recurringPolicyBackup, 0, len(policies))
 	for _, policy := range policies {
 		_, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).
 			ControlPlane().UpgradePolicies().ControlPlaneUpgradePolicy(policy.id).Delete().Send()
 		if err != nil {
-			return fmt.Errorf("failed to delete policy %s: %w", policy.id, err)
+			return deleted, fmt.Errorf("failed to delete policy %s: %w", policy.id, err)
 		}
+		deleted = append(deleted, policy)
 	}
-	return nil
+	return deleted, nil
 }
 
 func (o *transitionOptions) transitionChannelToEUS(ocmClient *sdk.Connection, cluster *v1.Cluster) error {
@@ -551,7 +568,10 @@ func (o *transitionOptions) transitionChannelToEUS(ocmClient *sdk.Connection, cl
 }
 
 func (o *transitionOptions) restoreUpgradePolicies(ocmClient *sdk.Connection, cluster *v1.Cluster, policies []recurringPolicyBackup) error {
-	for _, backup := range policies {
+	// Track newly created policy IDs for rollback if needed
+	var restoredPolicyIDs []string
+
+	for i, backup := range policies {
 		// Build policy with all preserved fields
 		policyBuilder := v1.NewControlPlaneUpgradePolicy().
 			Schedule(backup.schedule).
@@ -566,16 +586,39 @@ func (o *transitionOptions) restoreUpgradePolicies(ocmClient *sdk.Connection, cl
 
 		newPolicy, err := policyBuilder.Build()
 		if err != nil {
-			return fmt.Errorf("failed to build upgrade policy: %w", err)
+			// Rollback: delete any policies we've already restored
+			if len(restoredPolicyIDs) > 0 {
+				o.rollbackRestoredPolicies(ocmClient, cluster, restoredPolicyIDs)
+			}
+			return fmt.Errorf("failed to build upgrade policy %d/%d: %w", i+1, len(policies), err)
 		}
 
-		_, err = ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).
+		response, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).
 			ControlPlane().UpgradePolicies().Add().Body(newPolicy).Send()
 		if err != nil {
-			return fmt.Errorf("failed to restore policy: %w", err)
+			// Rollback: delete any policies we've already restored
+			if len(restoredPolicyIDs) > 0 {
+				o.rollbackRestoredPolicies(ocmClient, cluster, restoredPolicyIDs)
+			}
+			return fmt.Errorf("failed to restore policy %d/%d: %w", i+1, len(policies), err)
 		}
+
+		// Track the newly created policy ID for potential rollback
+		restoredPolicyIDs = append(restoredPolicyIDs, response.Body().ID())
 	}
 	return nil
+}
+
+// rollbackRestoredPolicies deletes policies that were just created during a failed restore operation
+func (o *transitionOptions) rollbackRestoredPolicies(ocmClient *sdk.Connection, cluster *v1.Cluster, policyIDs []string) {
+	fmt.Printf("  🔁 Rolling back %d partially restored policies\n", len(policyIDs))
+	for _, policyID := range policyIDs {
+		_, err := ocmClient.ClustersMgmt().V1().Clusters().Cluster(cluster.ID()).
+			ControlPlane().UpgradePolicies().ControlPlaneUpgradePolicy(policyID).Delete().Send()
+		if err != nil {
+			fmt.Printf("  ⚠️  Warning: failed to rollback policy %s during restore failure: %v\n", policyID, err)
+		}
+	}
 }
 
 // pollChannelChange polls OCM to verify the channel change with bounded retries

--- a/cmd/hcp/transitiontoeus/transitiontoeus_test.go
+++ b/cmd/hcp/transitiontoeus/transitiontoeus_test.go
@@ -3,7 +3,11 @@ package transitiontoeus
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift/osdctl/internal/servicelog"
 )
 
 func TestTransitionOptionsValidation(t *testing.T) {
@@ -200,4 +204,480 @@ func containsHelper(s, substr string) bool {
 		}
 	}
 	return false
+}
+
+func TestPrintPoliciesForManualRestore(t *testing.T) {
+	// Create a temporary directory for test output files
+	tmpDir := t.TempDir()
+	originalWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalWd); err != nil {
+			t.Errorf("Failed to restore working directory: %v", err)
+		}
+	}()
+
+	// Change to temp directory so the output file is created there
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
+
+	// Create test policies using OCM SDK types
+	policy1, err := v1.NewControlPlaneUpgradePolicy().
+		Schedule("0 2 * * 1").
+		ScheduleType(v1.ScheduleTypeAutomatic).
+		UpgradeType("ControlPlane").
+		EnableMinorVersionUpgrades(true).
+		Build()
+	if err != nil {
+		t.Fatalf("Failed to build test policy 1: %v", err)
+	}
+
+	policy2, err := v1.NewControlPlaneUpgradePolicy().
+		Schedule("0 3 * * 2").
+		ScheduleType(v1.ScheduleTypeManual).
+		UpgradeType("ControlPlane").
+		EnableMinorVersionUpgrades(false).
+		Version("4.14.5").
+		Build()
+	if err != nil {
+		t.Fatalf("Failed to build test policy 2: %v", err)
+	}
+
+	policies := []*v1.ControlPlaneUpgradePolicy{policy1, policy2}
+	clusterID := "test-cluster-123"
+
+	// Call the function
+	printPoliciesForManualRestore(policies, clusterID)
+
+	// Find the generated file
+	files, err := filepath.Glob("unrestored_policies_*.sh")
+	if err != nil {
+		t.Fatalf("Failed to glob for output files: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("Expected 1 output file, got %d", len(files))
+	}
+
+	// Read and validate the file
+	content, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatalf("Failed to read output file: %v", err)
+	}
+
+	contentStr := string(content)
+
+	// Validate file format
+	if !strings.HasPrefix(contentStr, "#!/bin/bash\n") {
+		t.Error("File should start with bash shebang")
+	}
+	if !contains(contentStr, clusterID) {
+		t.Error("File should contain cluster ID")
+	}
+	if !contains(contentStr, "0 2 * * 1") {
+		t.Error("File should contain policy 1 schedule")
+	}
+	if !contains(contentStr, "0 3 * * 2") {
+		t.Error("File should contain policy 2 schedule")
+	}
+	if !contains(contentStr, "automatic") {
+		t.Error("File should contain automatic schedule type")
+	}
+	if !contains(contentStr, "manual") {
+		t.Error("File should contain manual schedule type")
+	}
+	if !contains(contentStr, "4.14.5") {
+		t.Error("File should contain version for manual policy")
+	}
+	if !contains(contentStr, "ocm post") {
+		t.Error("File should contain ocm post commands")
+	}
+
+	// Check file is executable
+	fileInfo, err := os.Stat(files[0])
+	if err != nil {
+		t.Fatalf("Failed to stat output file: %v", err)
+	}
+	if fileInfo.Mode()&0111 == 0 {
+		t.Error("File should be executable")
+	}
+}
+
+func TestValidateServiceLogResponse(t *testing.T) {
+	tests := []struct {
+		name          string
+		responseBody  string
+		sentMessage   servicelog.Message
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "valid response - all fields match",
+			responseBody: `{
+				"id": "123",
+				"kind": "ServiceLog",
+				"href": "/api/service_logs/v1/cluster_logs/123",
+				"severity": "Info",
+				"service_name": "SREManualAction",
+				"cluster_uuid": "test-cluster-uuid",
+				"summary": "Test Summary",
+				"description": "Test Description"
+			}`,
+			sentMessage: servicelog.Message{
+				Severity:    "Info",
+				ServiceName: "SREManualAction",
+				ClusterUUID: "test-cluster-uuid",
+				Summary:     "Test Summary",
+				Description: "Test Description",
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid - severity mismatch",
+			responseBody: `{
+				"severity": "Warning",
+				"service_name": "SREManualAction",
+				"cluster_uuid": "test-cluster-uuid",
+				"summary": "Test Summary",
+				"description": "Test Description"
+			}`,
+			sentMessage: servicelog.Message{
+				Severity:    "Info",
+				ServiceName: "SREManualAction",
+				ClusterUUID: "test-cluster-uuid",
+				Summary:     "Test Summary",
+				Description: "Test Description",
+			},
+			expectError:   true,
+			errorContains: "wrong severity",
+		},
+		{
+			name: "invalid - service_name mismatch",
+			responseBody: `{
+				"severity": "Info",
+				"service_name": "Different",
+				"cluster_uuid": "test-cluster-uuid",
+				"summary": "Test Summary",
+				"description": "Test Description"
+			}`,
+			sentMessage: servicelog.Message{
+				Severity:    "Info",
+				ServiceName: "SREManualAction",
+				ClusterUUID: "test-cluster-uuid",
+				Summary:     "Test Summary",
+				Description: "Test Description",
+			},
+			expectError:   true,
+			errorContains: "wrong service_name",
+		},
+		{
+			name: "invalid - cluster_uuid mismatch",
+			responseBody: `{
+				"severity": "Info",
+				"service_name": "SREManualAction",
+				"cluster_uuid": "different-uuid",
+				"summary": "Test Summary",
+				"description": "Test Description"
+			}`,
+			sentMessage: servicelog.Message{
+				Severity:    "Info",
+				ServiceName: "SREManualAction",
+				ClusterUUID: "test-cluster-uuid",
+				Summary:     "Test Summary",
+				Description: "Test Description",
+			},
+			expectError:   true,
+			errorContains: "wrong cluster_uuid",
+		},
+		{
+			name:         "invalid - malformed JSON",
+			responseBody: `{invalid json`,
+			sentMessage: servicelog.Message{
+				Severity: "Info",
+			},
+			expectError:   true,
+			errorContains: "invalid JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateServiceLogResponse([]byte(tt.responseBody), tt.sentMessage)
+			if (err != nil) != tt.expectError {
+				t.Errorf("validateServiceLogResponse() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+			if tt.expectError && err != nil && tt.errorContains != "" {
+				if !contains(err.Error(), tt.errorContains) {
+					t.Errorf("validateServiceLogResponse() error = %v, want to contain %v", err.Error(), tt.errorContains)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateBadServiceLogResponse(t *testing.T) {
+	tests := []struct {
+		name          string
+		responseBody  string
+		expectError   bool
+		expectedCode  string
+		expectedMsg   string
+		errorContains string
+	}{
+		{
+			name: "valid bad response",
+			responseBody: `{
+				"id": "error-123",
+				"kind": "Error",
+				"code": "INVALID_REQUEST",
+				"reason": "Missing required field"
+			}`,
+			expectError:  false,
+			expectedCode: "INVALID_REQUEST",
+			expectedMsg:  "Missing required field",
+		},
+		{
+			name:          "invalid JSON",
+			responseBody:  `{invalid`,
+			expectError:   true,
+			errorContains: "invalid JSON",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			badReply, err := validateBadServiceLogResponse([]byte(tt.responseBody))
+			if (err != nil) != tt.expectError {
+				t.Errorf("validateBadServiceLogResponse() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+			if tt.expectError && err != nil && tt.errorContains != "" {
+				if !contains(err.Error(), tt.errorContains) {
+					t.Errorf("validateBadServiceLogResponse() error = %v, want to contain %v", err.Error(), tt.errorContains)
+				}
+			}
+			if !tt.expectError && badReply != nil {
+				if badReply.Code != tt.expectedCode {
+					t.Errorf("validateBadServiceLogResponse() code = %v, want %v", badReply.Code, tt.expectedCode)
+				}
+				if badReply.Reason != tt.expectedMsg {
+					t.Errorf("validateBadServiceLogResponse() reason = %v, want %v", badReply.Reason, tt.expectedMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadServiceLogTemplate(t *testing.T) {
+	// Create a temporary file for testing file-based loading
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test-template.json")
+	testTemplate := `{"test": "template", "severity": "Info"}`
+	if err := os.WriteFile(tmpFile, []byte(testTemplate), 0600); err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+
+	tests := []struct {
+		name                    string
+		templateOrFile          string
+		expectError             bool
+		expectDefaultTemplate   bool
+		errorContains           string
+		clearCacheBeforeTest    bool
+		expectedContentContains string
+	}{
+		{
+			name:                    "load from file",
+			templateOrFile:          tmpFile,
+			expectError:             false,
+			expectDefaultTemplate:   false,
+			expectedContentContains: "template",
+		},
+		{
+			name:           "file not found",
+			templateOrFile: "/nonexistent/file.json",
+			expectError:    true,
+			errorContains:  "failed to read template file",
+		},
+		{
+			name:                  "template name - success",
+			templateOrFile:        "success",
+			expectError:           false,
+			expectDefaultTemplate: true,
+			clearCacheBeforeTest:  true,
+		},
+		{
+			name:                  "template name - attempted",
+			templateOrFile:        "attempted",
+			expectError:           false,
+			expectDefaultTemplate: true,
+			clearCacheBeforeTest:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.clearCacheBeforeTest {
+				templateCache = make(map[string][]byte)
+			}
+
+			content, isDefault, err := loadServiceLogTemplate(tt.templateOrFile)
+			if (err != nil) != tt.expectError {
+				t.Errorf("loadServiceLogTemplate() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+			if tt.expectError && err != nil && tt.errorContains != "" {
+				if !contains(err.Error(), tt.errorContains) {
+					t.Errorf("loadServiceLogTemplate() error = %v, want to contain %v", err.Error(), tt.errorContains)
+				}
+			}
+			if !tt.expectError {
+				if isDefault != tt.expectDefaultTemplate {
+					t.Errorf("loadServiceLogTemplate() isDefault = %v, want %v", isDefault, tt.expectDefaultTemplate)
+				}
+				if content == nil {
+					t.Error("loadServiceLogTemplate() content should not be nil on success")
+				}
+				if tt.expectedContentContains != "" && !contains(string(content), tt.expectedContentContains) {
+					t.Errorf("loadServiceLogTemplate() content = %v, want to contain %v", string(content), tt.expectedContentContains)
+				}
+			}
+		})
+	}
+
+	// Test caching
+	t.Run("template caching", func(t *testing.T) {
+		// Clear cache
+		templateCache = make(map[string][]byte)
+
+		// Load template twice - should be cached on second call
+		_, _, err1 := loadServiceLogTemplate("success")
+		if err1 != nil {
+			t.Skipf("Skipping cache test - couldn't fetch template: %v", err1)
+		}
+
+		// Check cache was populated
+		if _, found := templateCache["success"]; !found {
+			t.Error("Template should be cached after first load")
+		}
+
+		// Load again - should use cache
+		_, _, err2 := loadServiceLogTemplate("success")
+		if err2 != nil {
+			t.Errorf("Second load should succeed using cache: %v", err2)
+		}
+	})
+}
+
+func TestClusterProcessResult(t *testing.T) {
+	// Test the result struct tracking
+	tests := []struct {
+		name               string
+		policyWasModified  bool
+		policyWasRestored  bool
+		unrestoredPolicies int
+		expectCritical     bool
+	}{
+		{
+			name:               "no modification",
+			policyWasModified:  false,
+			policyWasRestored:  false,
+			unrestoredPolicies: 0,
+			expectCritical:     false,
+		},
+		{
+			name:               "modified and restored",
+			policyWasModified:  true,
+			policyWasRestored:  true,
+			unrestoredPolicies: 0,
+			expectCritical:     false,
+		},
+		{
+			name:               "CRITICAL - modified but not restored",
+			policyWasModified:  true,
+			policyWasRestored:  false,
+			unrestoredPolicies: 2,
+			expectCritical:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &clusterProcessResult{
+				policyWasModified: tt.policyWasModified,
+				policyWasRestored: tt.policyWasRestored,
+			}
+
+			if tt.unrestoredPolicies > 0 {
+				// Create mock policies
+				for i := 0; i < tt.unrestoredPolicies; i++ {
+					policy, _ := v1.NewControlPlaneUpgradePolicy().
+						Schedule("0 2 * * 1").
+						ScheduleType(v1.ScheduleTypeAutomatic).
+						UpgradeType("ControlPlane").
+						EnableMinorVersionUpgrades(true).
+						Build()
+					result.unrestoredPolicies = append(result.unrestoredPolicies, policy)
+				}
+			}
+
+			// Verify critical state
+			isCritical := result.policyWasModified && !result.policyWasRestored && len(result.unrestoredPolicies) > 0
+			if isCritical != tt.expectCritical {
+				t.Errorf("Critical state = %v, want %v", isCritical, tt.expectCritical)
+			}
+		})
+	}
+}
+
+func TestPolicyDetails(t *testing.T) {
+	// Test the policyDetails struct
+	policy1, err := v1.NewControlPlaneUpgradePolicy().
+		Schedule("0 2 * * 1").
+		ScheduleType(v1.ScheduleTypeAutomatic).
+		UpgradeType("ControlPlane").
+		EnableMinorVersionUpgrades(true).
+		Build()
+	if err != nil {
+		t.Fatalf("Failed to build test policy: %v", err)
+	}
+
+	tests := []struct {
+		name                 string
+		hasRecurringPolicies bool
+		policyCount          int
+	}{
+		{
+			name:                 "no recurring policies",
+			hasRecurringPolicies: false,
+			policyCount:          0,
+		},
+		{
+			name:                 "has recurring policies",
+			hasRecurringPolicies: true,
+			policyCount:          1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			details := &policyDetails{
+				hasRecurringPolicies: tt.hasRecurringPolicies,
+			}
+
+			if tt.policyCount > 0 {
+				details.recurringPolicies = []*v1.ControlPlaneUpgradePolicy{policy1}
+			}
+
+			if details.hasRecurringPolicies != tt.hasRecurringPolicies {
+				t.Errorf("hasRecurringPolicies = %v, want %v", details.hasRecurringPolicies, tt.hasRecurringPolicies)
+			}
+			if len(details.recurringPolicies) != tt.policyCount {
+				t.Errorf("policy count = %v, want %v", len(details.recurringPolicies), tt.policyCount)
+			}
+		})
+	}
 }

--- a/cmd/hcp/transitiontoeus/transitiontoeus_test.go
+++ b/cmd/hcp/transitiontoeus/transitiontoeus_test.go
@@ -1,0 +1,203 @@
+package transitiontoeus
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTransitionOptionsValidation(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test-template.json")
+	err := os.WriteFile(tmpFile, []byte(`{"test": "template"}`), 0600)
+	if err != nil {
+		t.Fatalf("Failed to create temp file for test: %v", err)
+	}
+
+	tmpClustersFile := filepath.Join(tmpDir, "clusters.json")
+	err = os.WriteFile(tmpClustersFile, []byte(`{"clusters":["cluster1","cluster2"]}`), 0600)
+	if err != nil {
+		t.Fatalf("Failed to create temp clusters file for test: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		opts    *transitionOptions
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid with cluster ID",
+			opts: &transitionOptions{
+				clusterID: "test-cluster",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with clusters file",
+			opts: &transitionOptions{
+				clustersFile: tmpClustersFile,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid - no cluster targeting",
+			opts:    &transitionOptions{},
+			wantErr: true,
+			errMsg:  "no cluster identifier has been found, please specify either --cluster-id or --clusters-file",
+		},
+		{
+			name: "invalid - both cluster ID and file",
+			opts: &transitionOptions{
+				clusterID:    "test-cluster",
+				clustersFile: tmpClustersFile,
+			},
+			wantErr: true,
+			errMsg:  "cannot specify both --cluster-id and --clusters-file, choose one",
+		},
+		{
+			name: "valid - cluster ID with alphanumeric and hyphens",
+			opts: &transitionOptions{
+				clusterID: "abc123-test-cluster-456",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid - cluster ID with special characters",
+			opts: &transitionOptions{
+				clusterID: "cluster@123",
+			},
+			wantErr: true,
+			errMsg:  "cluster ID 'cluster@123' contains invalid characters",
+		},
+		{
+			name: "invalid - cluster ID with spaces",
+			opts: &transitionOptions{
+				clusterID: "cluster 123",
+			},
+			wantErr: true,
+			errMsg:  "cluster ID 'cluster 123' contains invalid characters",
+		},
+		{
+			name: "valid - dry-run enabled",
+			opts: &transitionOptions{
+				clusterID: "test-cluster",
+				dryRun:    true,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && err != nil && tt.errMsg != "" {
+				if !contains(err.Error(), tt.errMsg) {
+					t.Errorf("validate() error message = %v, want to contain %v", err.Error(), tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestClusterIDValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		clusterID string
+		wantValid bool
+	}{
+		{
+			name:      "valid - alphanumeric",
+			clusterID: "abc123",
+			wantValid: true,
+		},
+		{
+			name:      "valid - with hyphens",
+			clusterID: "abc-123-def",
+			wantValid: true,
+		},
+		{
+			name:      "valid - long cluster ID",
+			clusterID: "2abcdefg3hijklmn4opqrstu5vwxyz67",
+			wantValid: true,
+		},
+		{
+			name:      "invalid - with underscore",
+			clusterID: "cluster_123",
+			wantValid: false,
+		},
+		{
+			name:      "invalid - with special characters",
+			clusterID: "cluster@123",
+			wantValid: false,
+		},
+		{
+			name:      "invalid - with spaces",
+			clusterID: "cluster 123",
+			wantValid: false,
+		},
+		{
+			name:      "invalid - with dots",
+			clusterID: "cluster.123",
+			wantValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched := validClusterIDRegex.MatchString(tt.clusterID)
+			if matched != tt.wantValid {
+				t.Errorf("validClusterIDRegex.MatchString(%q) = %v, want %v", tt.clusterID, matched, tt.wantValid)
+			}
+		})
+	}
+}
+
+func TestServiceLogTemplates(t *testing.T) {
+	// Test that all expected templates are defined
+	expectedTemplates := []string{"success", "attempted"}
+
+	for _, template := range expectedTemplates {
+		t.Run("template_exists_"+template, func(t *testing.T) {
+			if _, exists := serviceLogTemplates[template]; !exists {
+				t.Errorf("Expected service log template %q to be defined", template)
+			}
+		})
+	}
+
+	// Test that all template URLs follow the expected pattern
+	for name, url := range serviceLogTemplates {
+		t.Run("template_url_format_"+name, func(t *testing.T) {
+			if !contains(url, "github.com") && !contains(url, "githubusercontent.com") {
+				t.Errorf("Template URL for %q does not appear to be a GitHub URL: %s", name, url)
+			}
+			if !contains(url, "/hcp/") {
+				t.Errorf("Template URL for %q does not contain '/hcp/' path: %s", name, url)
+			}
+			if !contains(url, ".json") {
+				t.Errorf("Template URL for %q does not end with .json: %s", name, url)
+			}
+		})
+	}
+}
+
+// Helper function to check if a string contains a substring
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && s[:len(substr)] == substr) ||
+		containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,7 @@
   - `get-cp-autoscaling-status` - Get control plane autoscaling status for hosted clusters on a management cluster
   - `must-gather --cluster-id <cluster-identifier>` - Create a must-gather for HCP cluster
   - `status` - Show HCP cluster health status from OCM live resources
+  - `transition-to-eus` - Transition ROSA HCP clusters from stable to EUS channel (Even Y-Stream EOL handling)
 - `hive` - hive related utilities
   - `clusterdeployment` - cluster deployment related utilities
     - `list` - List cluster deployment crs
@@ -3225,6 +3226,62 @@ osdctl hcp status [flags]
   -C, --cluster-id string                Cluster name, ID, or external ID
       --context string                   The name of the kubeconfig context to use
   -h, --help                             help for status
+      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
+  -o, --output string                    Valid formats are ['', 'json', 'yaml', 'env']
+      --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                    The address and port of the Kubernetes API server
+      --skip-aws-proxy-check aws_proxy   Don't use the configured aws_proxy value
+  -S, --skip-version-check               skip checking to see if this is the most recent release
+```
+
+### osdctl hcp transition-to-eus
+
+Transition ROSA HCP clusters from stable to EUS channel during End-of-Life handling.
+
+⚠️ IMPORTANT GUARDRAILS ⚠️
+This command is specifically designed for EVEN Y-STREAM end-of-life transitions (4.14, 4.16, 4.18, etc.).
+
+The command validates:
+- Cluster must be HCP (not Classic)
+- Cluster must be on an even y-stream (4.14, 4.16, 4.18, etc.)
+- Cluster must be on 'stable' channel (not already on 'eus')
+- Cluster must be in 'ready' state
+
+WORKFLOW:
+For clusters with recurring update policies:
+1. Saves the existing recurring update policy settings
+2. Deletes the recurring update policy
+3. Transitions the channel from 'stable' to 'eus'
+4. Verifies the channel change
+5. Restores the recurring update policy with original settings
+6. Prompts to send service log notification
+
+For clusters with individual updates:
+1. Transitions the channel from 'stable' to 'eus'
+2. Verifies the channel change
+3. Prompts to send service log notification
+
+SERVICE LOG BEHAVIOR:
+- After each successful transition, you will be prompted to optionally send a service log notification
+- On failures where recurring policy was modified and restored: You will be prompted to send an 'attempted' notification to the customer
+
+This approach extends the support lifecycle for clusters on even y-streams without forcing upgrades.
+
+```
+osdctl hcp transition-to-eus [flags]
+```
+
+#### Flags
+
+```
+      --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --cluster string                   The name of the kubeconfig cluster to use
+  -C, --cluster-id string                ID of the target HCP cluster
+  -c, --clusters-file string             JSON file containing cluster IDs (format: {"clusters":["$CLUSTERID1", "$CLUSTERID2"]})
+      --context string                   The name of the kubeconfig context to use
+      --dry-run                          Simulate the transition without making any changes
+  -h, --help                             help for transition-to-eus
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
   -o, --output string                    Valid formats are ['', 'json', 'yaml', 'env']

--- a/docs/README.md
+++ b/docs/README.md
@@ -3268,13 +3268,13 @@ SERVICE LOG BEHAVIOR:
 
 This approach extends the support lifecycle for clusters on even y-streams without forcing upgrades.
 
-```bash
+```
 osdctl hcp transition-to-eus [flags]
 ```
 
 #### Flags
 
-```text
+```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
   -C, --cluster-id string                ID of the target HCP cluster

--- a/docs/README.md
+++ b/docs/README.md
@@ -3268,13 +3268,13 @@ SERVICE LOG BEHAVIOR:
 
 This approach extends the support lifecycle for clusters on even y-streams without forcing upgrades.
 
-```
+```bash
 osdctl hcp transition-to-eus [flags]
 ```
 
 #### Flags
 
-```
+```text
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
   -C, --cluster-id string                ID of the target HCP cluster

--- a/docs/osdctl_hcp.md
+++ b/docs/osdctl_hcp.md
@@ -31,4 +31,5 @@
 * [osdctl hcp get-cp-autoscaling-status](osdctl_hcp_get-cp-autoscaling-status.md)	 - Get control plane autoscaling status for hosted clusters on a management cluster
 * [osdctl hcp must-gather](osdctl_hcp_must-gather.md)	 - Create a must-gather for HCP cluster
 * [osdctl hcp status](osdctl_hcp_status.md)	 - Show HCP cluster health status from OCM live resources
+* [osdctl hcp transition-to-eus](osdctl_hcp_transition-to-eus.md)	 - Transition ROSA HCP clusters from stable to EUS channel (Even Y-Stream EOL handling)
 

--- a/docs/osdctl_hcp_transition-to-eus.md
+++ b/docs/osdctl_hcp_transition-to-eus.md
@@ -1,0 +1,83 @@
+## osdctl hcp transition-to-eus
+
+Transition ROSA HCP clusters from stable to EUS channel (Even Y-Stream EOL handling)
+
+### Synopsis
+
+Transition ROSA HCP clusters from stable to EUS channel during End-of-Life handling.
+
+⚠️ IMPORTANT GUARDRAILS ⚠️
+This command is specifically designed for EVEN Y-STREAM end-of-life transitions (4.14, 4.16, 4.18, etc.).
+
+The command validates:
+- Cluster must be HCP (not Classic)
+- Cluster must be on an even y-stream (4.14, 4.16, 4.18, etc.)
+- Cluster must be on 'stable' channel (not already on 'eus')
+- Cluster must be in 'ready' state
+
+WORKFLOW:
+For clusters with recurring update policies:
+1. Saves the existing recurring update policy settings
+2. Deletes the recurring update policy
+3. Transitions the channel from 'stable' to 'eus'
+4. Verifies the channel change
+5. Restores the recurring update policy with original settings
+6. Prompts to send service log notification
+
+For clusters with individual updates:
+1. Transitions the channel from 'stable' to 'eus'
+2. Verifies the channel change
+3. Prompts to send service log notification
+
+SERVICE LOG BEHAVIOR:
+- After each successful transition, you will be prompted to optionally send a service log notification
+- On failures where recurring policy was modified and restored: You will be prompted to send an 'attempted' notification to the customer
+
+This approach extends the support lifecycle for clusters on even y-streams without forcing upgrades.
+
+```
+osdctl hcp transition-to-eus [flags]
+```
+
+### Examples
+
+```
+  # Transition single cluster (will prompt to send service log after success)
+  osdctl hcp transition-to-eus -C cluster123
+
+  # Multiple clusters from file
+  osdctl hcp transition-to-eus --clusters-file clusters.json
+
+  # Dry-run to preview changes
+  osdctl hcp transition-to-eus --clusters-file clusters.json --dry-run
+
+```
+
+### Options
+
+```
+  -C, --cluster-id string      ID of the target HCP cluster
+  -c, --clusters-file string   JSON file containing cluster IDs (format: {"clusters":["$CLUSTERID1", "$CLUSTERID2"]})
+      --dry-run                Simulate the transition without making any changes
+  -h, --help                   help for transition-to-eus
+```
+
+### Options inherited from parent commands
+
+```
+      --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --cluster string                   The name of the kubeconfig cluster to use
+      --context string                   The name of the kubeconfig context to use
+      --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
+  -o, --output string                    Valid formats are ['', 'json', 'yaml', 'env']
+      --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                    The address and port of the Kubernetes API server
+      --skip-aws-proxy-check aws_proxy   Don't use the configured aws_proxy value
+  -S, --skip-version-check               skip checking to see if this is the most recent release
+```
+
+### SEE ALSO
+
+* [osdctl hcp](osdctl_hcp.md)	 - 
+

--- a/docs/osdctl_hcp_transition-to-eus.md
+++ b/docs/osdctl_hcp_transition-to-eus.md
@@ -35,13 +35,13 @@ SERVICE LOG BEHAVIOR:
 
 This approach extends the support lifecycle for clusters on even y-streams without forcing upgrades.
 
-```bash
+```
 osdctl hcp transition-to-eus [flags]
 ```
 
 ### Examples
 
-```bash
+```
   # Transition single cluster (will prompt to send service log after success)
   osdctl hcp transition-to-eus -C cluster123
 
@@ -55,7 +55,7 @@ osdctl hcp transition-to-eus [flags]
 
 ### Options
 
-```text
+```
   -C, --cluster-id string      ID of the target HCP cluster
   -c, --clusters-file string   JSON file containing cluster IDs (format: {"clusters":["$CLUSTERID1", "$CLUSTERID2"]})
       --dry-run                Simulate the transition without making any changes
@@ -64,7 +64,7 @@ osdctl hcp transition-to-eus [flags]
 
 ### Options inherited from parent commands
 
-```text
+```
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use

--- a/docs/osdctl_hcp_transition-to-eus.md
+++ b/docs/osdctl_hcp_transition-to-eus.md
@@ -35,13 +35,13 @@ SERVICE LOG BEHAVIOR:
 
 This approach extends the support lifecycle for clusters on even y-streams without forcing upgrades.
 
-```
+```bash
 osdctl hcp transition-to-eus [flags]
 ```
 
 ### Examples
 
-```
+```bash
   # Transition single cluster (will prompt to send service log after success)
   osdctl hcp transition-to-eus -C cluster123
 
@@ -55,7 +55,7 @@ osdctl hcp transition-to-eus [flags]
 
 ### Options
 
-```
+```text
   -C, --cluster-id string      ID of the target HCP cluster
   -c, --clusters-file string   JSON file containing cluster IDs (format: {"clusters":["$CLUSTERID1", "$CLUSTERID2"]})
       --dry-run                Simulate the transition without making any changes
@@ -64,7 +64,7 @@ osdctl hcp transition-to-eus [flags]
 
 ### Options inherited from parent commands
 
-```
+```text
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
       --context string                   The name of the kubeconfig context to use


### PR DESCRIPTION
as part of [OHSS-49752] Handle 4.16 Stable channel EOL for ROSA HCP and post implementation SOP https://github.com/openshift/ops-sop/pull/3930 was suggested to develop an osdctl feature that automates this process and can be used in the future.  

[OHSS-49752]: https://redhat.atlassian.net/browse/OHSS-49752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Add osdctl hcp transition-to-eus command for Even Y-Stream EOL handling Introduces a new command to automate the transition of ROSA HCP clusters from the stable channel to the eus (Extended Update Support) channel during even y-stream end-of-life processes (e.g., 4.14, 4.16, 4.18).

Key Features:

- Built-in guardrails: Validates clusters are HCP, on even y-stream, on stable channel, and in ready state
- Recurring policy management: Automatically handles deletion and restoration of recurring upgrade policies that block channel transitions
- Interactive service logs: Prompts to send appropriate customer notifications after successful transitions or failures
- Batch processing: Supports single cluster (-C) or multiple clusters via JSON file (--clusters-file)
- Dry-run mode: Preview changes before applying (--dry-run)
Workflow:

- Validates cluster eligibility (HCP, even y-stream, stable channel, ready state)
- Saves and deletes recurring upgrade policies (if present)
- Transitions channel from stable to eus
- Restores recurring upgrade policies with original settings
- Prompts to send service log notifications to customers
- This command eliminates manual steps and reduces errors during the EUS transition process, which previously required complex API calls and manual policy manipulation.


The change developed with the help of Claude!