### PR TITLE
SREP-3738: fix misleading error messages in dynatrace gather-logs

### DIFF
--- a/cmd/dynatrace/hcpGatherLogsCmd.go
+++ b/cmd/dynatrace/hcpGatherLogsCmd.go
@@ -65,7 +65,7 @@ func NewCmdHCPMustGather() *cobra.Command {
 func (g *GatherLogsOpts) GatherLogs(clusterID string, elevationReasons ...string) (error error) {
 	tokenProvider, err := getStorageTokenProvider()
 	if err != nil {
-		return fmt.Errorf("failed to setup access token provider: %v", err)
+		return fmt.Errorf("failed to setup Dynatrace access token provider (is the vault CLI installed and configured?): %v", err)
 	}
 
 	// Eagerly fetch the first token to fail fast on auth issues
@@ -179,7 +179,7 @@ func (g *GatherLogsOpts) dumpEvents(deploys *appsv1.DeploymentList, parentDir st
 
 		eventsRequestToken, err := getDTQueryExecution(DTURL, accessToken, eventQuery.finalQuery)
 		if err != nil {
-			log.Print("failed to get request token", err)
+			log.Printf("failed to get request token: %v", err)
 			continue
 		}
 		err = getEvents(DTURL, accessToken, eventsRequestToken, f)
@@ -239,7 +239,7 @@ func (g *GatherLogsOpts) dumpPodLogs(pods *corev1.PodList, parentDir string, tar
 
 		podLogsRequestToken, err := getDTQueryExecution(DTURL, accessToken, podLogsQuery.finalQuery)
 		if err != nil {
-			log.Print("failed to get request token", err)
+			log.Printf("failed to get request token: %v", err)
 			continue
 		}
 		err = getLogs(DTURL, accessToken, podLogsRequestToken, f)
@@ -285,7 +285,7 @@ func (g *GatherLogsOpts) dumpRestartedPodLogs(pods *corev1.PodList, parentDir st
 
 	podLogsRequestToken, err := getDTQueryExecution(DTURL, accessToken, restartedPodLogsQuery.finalQuery)
 	if err != nil {
-		log.Print("failed to get request token", err)
+		log.Printf("failed to get request token: %v", err)
 
 	}
 	err = getLogs(DTURL, accessToken, podLogsRequestToken, f)

--- a/cmd/dynatrace/hcpGatherLogsCmd.go
+++ b/cmd/dynatrace/hcpGatherLogsCmd.go
@@ -157,20 +157,16 @@ func (g *GatherLogsOpts) dumpEvents(deploys *appsv1.DeploymentList, parentDir st
 		if err != nil {
 			return err
 		}
-		_, err = f.Write(deploymentYaml)
-		if err != nil {
-			return err
+		_, writeErr := f.Write(deploymentYaml)
+		closeErr := f.Close()
+		if writeErr != nil {
+			return writeErr
 		}
-		err = f.Close()
-		if err != nil {
-			return err
+		if closeErr != nil {
+			return closeErr
 		}
 
 		eventsFilePath := filepath.Join(eventsDirPath, eventsFileName)
-		f, err = os.OpenFile(eventsFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-		if err != nil {
-			return err
-		}
 
 		accessToken, err := tokenProvider.Token()
 		if err != nil {
@@ -182,8 +178,8 @@ func (g *GatherLogsOpts) dumpEvents(deploys *appsv1.DeploymentList, parentDir st
 			log.Printf("failed to get request token: %v", err)
 			continue
 		}
-		err = getEvents(DTURL, accessToken, eventsRequestToken, f)
-		_ = f.Close()
+
+		err = fetchAndWriteEvents(DTURL, accessToken, eventsRequestToken, eventsFilePath)
 		if err != nil {
 			log.Printf("failed to get logs, continuing: %v. Query: %v", err, eventQuery.finalQuery)
 			continue
@@ -220,17 +216,16 @@ func (g *GatherLogsOpts) dumpPodLogs(pods *corev1.PodList, parentDir string, tar
 		if err != nil {
 			return err
 		}
-		_, err = f.Write(podYaml)
-		if err != nil {
-			return err
+		_, writeErr := f.Write(podYaml)
+		closeErr := f.Close()
+		if writeErr != nil {
+			return writeErr
 		}
-		_ = f.Close()
+		if closeErr != nil {
+			return closeErr
+		}
 
 		podLogsFilePath := filepath.Join(podDirPath, podLogFileName)
-		f, err = os.OpenFile(podLogsFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-		if err != nil {
-			return err
-		}
 
 		accessToken, err := tokenProvider.Token()
 		if err != nil {
@@ -242,8 +237,8 @@ func (g *GatherLogsOpts) dumpPodLogs(pods *corev1.PodList, parentDir string, tar
 			log.Printf("failed to get request token: %v", err)
 			continue
 		}
-		err = getLogs(DTURL, accessToken, podLogsRequestToken, f)
-		_ = f.Close()
+
+		err = fetchAndWriteLogs(DTURL, accessToken, podLogsRequestToken, podLogsFilePath)
 		if err != nil {
 			log.Printf("failed to get logs, continuing: %v. Query: %v", err, podLogsQuery.finalQuery)
 			continue
@@ -273,10 +268,6 @@ func (g *GatherLogsOpts) dumpRestartedPodLogs(pods *corev1.PodList, parentDir st
 	}
 
 	restartedPodLogsFilePath := filepath.Join(podDirPath, restartedPodLogFileName)
-	f, err := os.OpenFile(restartedPodLogsFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0655)
-	if err != nil {
-		return err
-	}
 
 	accessToken, err := tokenProvider.Token()
 	if err != nil {
@@ -286,10 +277,9 @@ func (g *GatherLogsOpts) dumpRestartedPodLogs(pods *corev1.PodList, parentDir st
 	podLogsRequestToken, err := getDTQueryExecution(DTURL, accessToken, restartedPodLogsQuery.finalQuery)
 	if err != nil {
 		log.Printf("failed to get request token: %v", err)
-
+		return nil
 	}
-	err = getLogs(DTURL, accessToken, podLogsRequestToken, f)
-	f.Close()
+	err = fetchAndWriteLogs(DTURL, accessToken, podLogsRequestToken, restartedPodLogsFilePath)
 	if err != nil {
 		log.Printf("failed to get restarted pod logs: %v. Query: %v", err, restartedPodLogsQuery.finalQuery)
 	}
@@ -315,9 +305,12 @@ func addDir(dirs []string, filePaths []string) (path string, error error) {
 	}
 	for _, fp := range filePaths {
 		createdFile := filepath.Join(dirPath, fp)
-		_, err = os.Create(createdFile)
+		f, err := os.OpenFile(createdFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0600)
 		if err != nil {
-			return "", fmt.Errorf("file to create file %v in %v", fp, err)
+			return "", fmt.Errorf("failed to create file %v: %v", fp, err)
+		}
+		if err := f.Close(); err != nil {
+			return "", fmt.Errorf("failed to close file %v: %w", fp, err)
 		}
 	}
 

--- a/cmd/dynatrace/logsCmd.go
+++ b/cmd/dynatrace/logsCmd.go
@@ -195,7 +195,7 @@ func main(clusterID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get  vault token %v", err)
 	}
-	err = getLogs(hcpCluster.DynatraceURL, accessToken, requestToken, nil)
+	err = fetchAndWriteLogs(hcpCluster.DynatraceURL, accessToken, requestToken, "")
 	if err != nil {
 		return fmt.Errorf("failed to get logs %v", err)
 	}

--- a/cmd/dynatrace/requests.go
+++ b/cmd/dynatrace/requests.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 )
 
@@ -288,7 +289,7 @@ func getDocumentIDByNameAndType(dtURL string, accessToken string, docName string
 	return dtDashboard.Id, nil
 }
 
-func getLogs(dtURL string, accessToken string, requestToken string, dumpWriter io.Writer) error {
+func fetchAndWriteLogs(dtURL string, accessToken string, requestToken string, filePath string) error {
 	resp, err := getDTPollResults(dtURL, requestToken, accessToken)
 	if err != nil {
 		return err
@@ -300,19 +301,26 @@ func getLogs(dtURL string, accessToken string, requestToken string, dumpWriter i
 		return err
 	}
 
+	var w io.Writer = os.Stdout
+	if filePath != "" {
+		f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		w = f
+	}
+
 	for _, result := range dtPollRes.Result.Records {
-		content := result.Content
-		if dumpWriter != nil {
-			dumpWriter.Write([]byte(fmt.Sprintf("%s\n", content)))
-		} else {
-			fmt.Println(content)
+		if _, err := fmt.Fprintf(w, "%s\n", result.Content); err != nil {
+			return err
 		}
 	}
 
 	return nil
 }
 
-func getEvents(dtURL string, accessToken string, requestToken string, dumpWriter io.Writer) error {
+func fetchAndWriteEvents(dtURL string, accessToken string, requestToken string, filePath string) error {
 	resp, err := getDTPollResults(dtURL, requestToken, accessToken)
 	if err != nil {
 		return err
@@ -324,11 +332,19 @@ func getEvents(dtURL string, accessToken string, requestToken string, dumpWriter
 		return err
 	}
 
+	var w io.Writer = os.Stdout
+	if filePath != "" {
+		f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		w = f
+	}
+
 	for _, result := range dtPollRes.Result.Records {
-		if dumpWriter != nil {
-			dumpWriter.Write([]byte(fmt.Sprintf("%s\n", result)))
-		} else {
-			fmt.Println(result)
+		if _, err := fmt.Fprintf(w, "%s\n", result); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                      
  - Fix `log.Print("failed to get request token", err)` calls that concatenate                                                                                                                                                                                                                                    
    the message and error without a separator, producing garbled output like                                                                                                                                                                                                                                        
    `"failed to get request tokenrequest failed: 401 Unauthorized"`. Changed to                                                                                                                                                                                                                                     
    `log.Printf` with proper formatting.                                                                                                                                                                                                                                                                            
  - Improve the token provider error message to hint at a missing/misconfigured                                                                                                                                                                                                                                     
    vault CLI                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                    
  Ref: [SREP-3738](https://redhat.atlassian.net/browse/SREP-3738)                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
  ## Test plan                                                                                                                                                                                                                                                                                                      
  - [ ] Run `osdctl dt gather-logs` without `vault` installed and verify the                                                                                                                                                                                                                                      
        error message mentions the vault CLI                                                                                                                                                                                                                                                                        
  - [ ] Run `osdctl hcp must-gather` and confirm DT query errors are logged                                                                                                                                                                                                                                         
        with proper formatting (space/colon between message and error) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More specific error messages for storage/auth failures, including guidance about access token provider and CLI setup.
  * More consistent request-token error logging and early return on token failures for clearer diagnostics.

* **Refactor**
  * Safer log/event export: writing now targets a file path or standard output, with write and close errors checked and reported.
  * Removed pre-opened file-handle patterns; file creation/closing and error messages clarified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[SREP-3738]: https://redhat.atlassian.net/browse/SREP-3738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ