### PR TITLE
[SREP-726]  Add simulation to rotatecredentials and actual rotate them

### DIFF
--- a/cmd/account/rotate-secret.go
+++ b/cmd/account/rotate-secret.go
@@ -2,27 +2,23 @@ package account
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"os"
 	"strings"
-	"time"
 
 	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/iam"
-	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	stsTypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/api/v1alpha1"
-	hiveapiv1 "github.com/openshift/hive/apis/hive/v1"
-	hiveinternalv1alpha1 "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
 	"github.com/openshift/osdctl/cmd/common"
+	"github.com/openshift/osdctl/pkg/controller"
 	"github.com/openshift/osdctl/pkg/k8s"
 	awsprovider "github.com/openshift/osdctl/pkg/provider/aws"
+	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes/scheme"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -45,6 +41,8 @@ func newCmdRotateSecret(streams genericclioptions.IOStreams, client *k8s.LazyCli
 	rotateSecretCmd.Flags().BoolVar(&ops.updateCcsCreds, "ccs", false, "Also rotates osdCcsAdmin credential. Use caution.")
 	rotateSecretCmd.Flags().StringVar(&ops.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket)")
 	rotateSecretCmd.Flags().StringVar(&ops.osdManagedAdminUsername, "admin-username", "", "The admin username to use for generating access keys. Must be in the format of `osdManagedAdmin*`. If not specified, this is inferred from the account CR.")
+	rotateSecretCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "OCM internal/external cluster id or cluster name (required when using --hive-ocm-url)")
+	rotateSecretCmd.Flags().StringVar(&ops.hiveOcmUrl, "hive-ocm-url", "", "(optional) OCM environment URL for Hive operations. Aliases: 'production', 'staging', 'integration'. This only changes how the Hive cluster is resolved; the target cluster still comes from the current/default OCM environment.")
 	_ = rotateSecretCmd.MarkFlagRequired("reason")
 
 	return rotateSecretCmd
@@ -58,6 +56,8 @@ type rotateSecretOptions struct {
 	awsAccountTimeout       *int32
 	reason                  string
 	osdManagedAdminUsername string
+	clusterID               string
+	hiveOcmUrl              string
 
 	genericclioptions.IOStreams
 	kubeCli *k8s.LazyClient
@@ -72,53 +72,6 @@ func newRotateSecretOptions(streams genericclioptions.IOStreams, client *k8s.Laz
 
 func getSessionNameFromUserId(userid string) string {
 	return strings.Replace(userid, ":", "-", 1)
-}
-
-// verifyRotationPermissions checks if the assumed role has the necessary IAM permissions
-// to perform secret rotation by simulating the required actions on the osdManagedAdmin user
-func verifyRotationPermissions(awsClient awsprovider.Client, accountID string, osdManagedAdminUsername string) error {
-	// Define the required IAM actions for secret rotation
-	requiredActions := []string{
-		"iam:CreateAccessKey",
-		"iam:CreateUser",
-		"iam:DeleteAccessKey",
-		"iam:DeleteUser",
-		"iam:DeleteUserPolicy",
-		"iam:GetUser",
-		"iam:GetUserPolicy",
-		"iam:ListAccessKeys",
-		"iam:PutUserPolicy",
-		"iam:TagUser",
-	}
-
-	// Construct the ARN for the osdManagedAdmin user
-	userArn := fmt.Sprintf("arn:aws:iam::%s:user/%s", accountID, osdManagedAdminUsername)
-
-	fmt.Printf("Verifying IAM permissions for user %s...\n", osdManagedAdminUsername)
-
-	// Simulate the principal policy to check permissions
-	output, err := awsClient.SimulatePrincipalPolicy(&iam.SimulatePrincipalPolicyInput{
-		PolicySourceArn: awsSdk.String(userArn),
-		ActionNames:     requiredActions,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to simulate principal policy: %w", err)
-	}
-
-	// Check if all actions are allowed
-	var deniedActions []string
-	for _, result := range output.EvaluationResults {
-		if result.EvalDecision != iamTypes.PolicyEvaluationDecisionTypeAllowed {
-			deniedActions = append(deniedActions, *result.EvalActionName)
-		}
-	}
-
-	if len(deniedActions) > 0 {
-		return fmt.Errorf("insufficient permissions for secret rotation. Denied actions: %v", deniedActions)
-	}
-
-	fmt.Println("Permission verification successful. All required IAM actions are allowed.")
-	return nil
 }
 
 func (o *rotateSecretOptions) complete(cmd *cobra.Command, args []string) error {
@@ -137,6 +90,10 @@ func (o *rotateSecretOptions) complete(cmd *cobra.Command, args []string) error 
 		return cmdutil.UsageErrorf(cmd, "admin-username must start with %v", common.OSDManagedAdminIAM)
 	}
 
+	if o.hiveOcmUrl != "" && o.clusterID == "" {
+		return cmdutil.UsageErrorf(cmd, "--cluster-id is required when using --hive-ocm-url")
+	}
+
 	return nil
 }
 
@@ -145,24 +102,27 @@ func (o *rotateSecretOptions) run() error {
 	ctx := context.TODO()
 	var err error
 
-	// This action requires elevation
-	o.kubeCli.Impersonate("backplane-cluster-admin", o.reason, fmt.Sprintf("Elevation required to rotate secrets %s aws-account-cr-name", o.accountCRName))
+	// Resolve the k8s client for hive operations.
+	var kubeCli client.Client
+	if o.hiveOcmUrl != "" {
+		kubeCli, err = o.initHiveClient()
+		if err != nil {
+			return fmt.Errorf("failed to initialize hive client: %w", err)
+		}
+	} else {
+		o.kubeCli.Impersonate("backplane-cluster-admin", o.reason, fmt.Sprintf("Elevation required to rotate secrets %s aws-account-cr-name", o.accountCRName))
+		kubeCli = o.kubeCli
+	}
 
 	// Get the associated Account CR from the provided name
-	var accountID string
-	account, err := k8s.GetAWSAccount(ctx, o.kubeCli, common.AWSAccountNamespace, o.accountCRName)
+	account, err := k8s.GetAWSAccount(ctx, kubeCli, common.AWSAccountNamespace, o.accountCRName)
 	if err != nil {
 		return err
 	}
-	if account.Spec.ManualSTSMode {
-		return fmt.Errorf("Account %s is STS - No IAM User Credentials to Rotate", o.accountCRName)
-	}
 
-	// Set the account ID
-	accountID = account.Spec.AwsAccountID
+	accountID := account.Spec.AwsAccountID
 
-	// Get IAM user suffix from CR label
-
+	// Get IAM user suffix from CR label (needed for role chaining ARN)
 	accountIDSuffixLabel, ok := account.Labels["iamUserId"]
 	if !ok {
 		return fmt.Errorf("no label on Account CR for IAM User")
@@ -173,35 +133,61 @@ func (o *rotateSecretOptions) run() error {
 		return err
 	}
 
-	// Ensure AWS calls are successful with client
 	callerIdentityOutput, err := awsSetupClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 	if err != nil {
 		return err
 	}
 	roleSessionName := getSessionNameFromUserId(*callerIdentityOutput.UserId)
 
-	var credentials *stsTypes.Credentials
-	// Need to role chain if the cluster is CCS
+	// Build the final AWS client via role chaining
+	awsClient, err := o.buildAssumedRoleClient(ctx, kubeCli, awsSetupClient, account, accountID, accountIDSuffixLabel, &roleSessionName)
+	if err != nil {
+		return err
+	}
+
+	return controller.RotateSecret(ctx, &controller.RotateSecretInput{
+		AccountCRName:           o.accountCRName,
+		Account:                 account,
+		OsdManagedAdminUsername: o.osdManagedAdminUsername,
+		UpdateCcsCreds:          o.updateCcsCreds,
+		AwsClient:               awsClient,
+		HiveKubeClient:          kubeCli,
+		Out:                     os.Stdout,
+	})
+}
+
+// buildAssumedRoleClient performs the BYOC or non-BYOC role chain to get an
+// AWS client with permissions in the target account.
+func (o *rotateSecretOptions) buildAssumedRoleClient(
+	ctx context.Context,
+	kubeCli client.Client,
+	awsSetupClient awsprovider.Client,
+	account *awsv1alpha1.Account,
+	accountID string,
+	accountIDSuffixLabel string,
+	roleSessionName *string,
+) (awsprovider.Client, error) {
+
+	var credAccessKeyId, credSecretAccessKey, credSessionToken *string
+
 	if account.Spec.BYOC {
 		// Get the aws-account-operator configmap
 		cm := &corev1.ConfigMap{}
-		cmErr := o.kubeCli.Get(context.TODO(), types.NamespacedName{Namespace: common.AWSAccountNamespace, Name: common.DefaultConfigMap}, cm)
+		cmErr := kubeCli.Get(ctx, types.NamespacedName{Namespace: common.AWSAccountNamespace, Name: common.DefaultConfigMap}, cm)
 		if cmErr != nil {
-			return fmt.Errorf("there was an error getting the ConfigMap to get the SRE Access Role %s", cmErr)
+			return nil, fmt.Errorf("there was an error getting the ConfigMap to get the SRE Access Role %s", cmErr)
 		}
-		// Get the ARN value
+
 		SREAccessARN := cm.Data["CCS-Access-Arn"]
 		if SREAccessARN == "" {
-			return fmt.Errorf("SRE Access ARN is missing from configmap")
+			return nil, fmt.Errorf("SRE Access ARN is missing from configmap")
 		}
 
-		// Assume the ARN
-		srepRoleCredentials, err := awsprovider.GetAssumeRoleCredentials(awsSetupClient, o.awsAccountTimeout, &roleSessionName, &SREAccessARN)
+		srepRoleCredentials, err := awsprovider.GetAssumeRoleCredentials(awsSetupClient, o.awsAccountTimeout, roleSessionName, &SREAccessARN)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		// Create client with the SREP role
 		srepRoleClient, err := awsprovider.NewAwsClientWithInput(&awsprovider.ClientInput{
 			AccessKeyID:     *srepRoleCredentials.AccessKeyId,
 			SecretAccessKey: *srepRoleCredentials.SecretAccessKey,
@@ -209,20 +195,19 @@ func (o *rotateSecretOptions) run() error {
 			Region:          "us-east-1",
 		})
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		// Get the Jump ARN value
 		JumpARN := cm.Data["support-jump-role"]
 		if JumpARN == "" {
-			return fmt.Errorf("jump Access ARN is missing from configmap")
+			return nil, fmt.Errorf("jump Access ARN is missing from configmap")
 		}
-		// Assume the ARN
-		jumpRoleCreds, err := awsprovider.GetAssumeRoleCredentials(srepRoleClient, o.awsAccountTimeout, &roleSessionName, &JumpARN)
+
+		jumpRoleCreds, err := awsprovider.GetAssumeRoleCredentials(srepRoleClient, o.awsAccountTimeout, roleSessionName, &JumpARN)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		// Create client with the Jump role
+
 		jumpRoleClient, err := awsprovider.NewAwsClientWithInput(&awsprovider.ClientInput{
 			AccessKeyID:     *jumpRoleCreds.AccessKeyId,
 			SecretAccessKey: *jumpRoleCreds.SecretAccessKey,
@@ -230,226 +215,78 @@ func (o *rotateSecretOptions) run() error {
 			Region:          "us-east-1",
 		})
 		if err != nil {
-			return err
-		}
-		// Role chain to assume ManagedOpenShift-Support-{uid}
-		roleArn := awsSdk.String(fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, "ManagedOpenShift-Support-"+accountIDSuffixLabel))
-		credentials, err = awsprovider.GetAssumeRoleCredentials(jumpRoleClient, o.awsAccountTimeout,
-			&roleSessionName, roleArn)
-		if err != nil {
-			return err
+			return nil, err
 		}
 
-	} else {
-		// Assume the OrganizationAdminAccess role
-		roleArn := awsSdk.String(fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, awsv1alpha1.AccountOperatorIAMRole))
-		credentials, err = awsprovider.GetAssumeRoleCredentials(awsSetupClient, o.awsAccountTimeout,
-			&roleSessionName, roleArn)
+		roleArn := awsSdk.String(fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, "ManagedOpenShift-Support-"+accountIDSuffixLabel))
+		credentials, err := awsprovider.GetAssumeRoleCredentials(jumpRoleClient, o.awsAccountTimeout, roleSessionName, roleArn)
 		if err != nil {
-			return err
+			return nil, err
 		}
+		credAccessKeyId = credentials.AccessKeyId
+		credSecretAccessKey = credentials.SecretAccessKey
+		credSessionToken = credentials.SessionToken
+	} else {
+		roleArn := awsSdk.String(fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, awsv1alpha1.AccountOperatorIAMRole))
+		credentials, err := awsprovider.GetAssumeRoleCredentials(awsSetupClient, o.awsAccountTimeout, roleSessionName, roleArn)
+		if err != nil {
+			return nil, err
+		}
+		credAccessKeyId = credentials.AccessKeyId
+		credSecretAccessKey = credentials.SecretAccessKey
+		credSessionToken = credentials.SessionToken
 	}
 
-	// Build a new client with the assumed role
-	awsClient, err := awsprovider.NewAwsClientWithInput(&awsprovider.ClientInput{
-		AccessKeyID:     *credentials.AccessKeyId,
-		SecretAccessKey: *credentials.SecretAccessKey,
-		SessionToken:    *credentials.SessionToken,
+	return awsprovider.NewAwsClientWithInput(&awsprovider.ClientInput{
+		AccessKeyID:     *credAccessKeyId,
+		SecretAccessKey: *credSecretAccessKey,
+		SessionToken:    *credSessionToken,
 		Region:          "us-east-1",
 	})
+}
+
+// initHiveClient creates a k8s client connected to the hive cluster that manages the target cluster.
+func (o *rotateSecretOptions) initHiveClient() (client.Client, error) {
+	resolvedURL, err := utils.ValidateAndResolveOcmUrl(o.hiveOcmUrl)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("invalid --hive-ocm-url: %w", err)
 	}
 
-	// Update osdManagedAdmin secrets
-	osdManagedAdminUsername := o.osdManagedAdminUsername
-	if osdManagedAdminUsername == "" {
-		osdManagedAdminUsername = common.OSDManagedAdminIAM + "-" + accountIDSuffixLabel
-	}
-
-	// Verify that we have the necessary permissions to rotate secrets
-	err = verifyRotationPermissions(awsClient, accountID, osdManagedAdminUsername)
+	targetOCM, err := utils.CreateConnection()
 	if err != nil {
-		// If verification fails with the suffixed username, try without suffix
-		if osdManagedAdminUsername == common.OSDManagedAdminIAM+"-"+accountIDSuffixLabel {
-			fmt.Printf("Permission verification failed for %s, trying %s...\n", osdManagedAdminUsername, common.OSDManagedAdminIAM)
-			err = verifyRotationPermissions(awsClient, accountID, common.OSDManagedAdminIAM)
-			if err != nil {
-				return err
-			}
-			// Update username if verification succeeded without suffix
-			osdManagedAdminUsername = common.OSDManagedAdminIAM
-		} else {
-			return err
-		}
+		return nil, fmt.Errorf("failed to create target cluster OCM connection: %w", err)
 	}
+	defer targetOCM.Close()
 
-	// Create new access key
-	createAccessKeyOutput, err := awsClient.CreateAccessKey(&iam.CreateAccessKeyInput{UserName: awsSdk.String(osdManagedAdminUsername)})
+	hiveOCM, err := utils.CreateConnectionWithUrl(resolvedURL)
 	if err != nil {
-		var nse *iamTypes.NoSuchEntityException
-		if errors.As(err, &nse) {
-			// try removing accountIDSuffixLabel from the end of the username
-			osdManagedAdminUsername = common.OSDManagedAdminIAM
-			createAccessKeyOutput, err = awsClient.CreateAccessKey(&iam.CreateAccessKeyInput{UserName: awsSdk.String(osdManagedAdminUsername)})
-			if err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
+		return nil, fmt.Errorf("failed to create hive OCM connection with URL '%s': %w", resolvedURL, err)
 	}
+	defer hiveOCM.Close()
 
-	// Place new credentials into body for secret
-	newOsdManagedAdminSecretData := map[string][]byte{
-		"aws_user_name":         []byte(*createAccessKeyOutput.AccessKey.UserName),
-		"aws_access_key_id":     []byte(*createAccessKeyOutput.AccessKey.AccessKeyId),
-		"aws_secret_access_key": []byte(*createAccessKeyOutput.AccessKey.SecretAccessKey),
-	}
-
-	// Update existing osdManagedAdmin secret
-	err = common.UpdateSecret(o.kubeCli, o.accountCRName+"-secret", common.AWSAccountNamespace, newOsdManagedAdminSecretData)
+	cluster, err := utils.GetClusterAnyStatus(targetOCM, o.clusterID)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("failed to get OCM cluster info for %s: %w", o.clusterID, err)
 	}
 
-	// Update secret in ClusterDeployment's namespace
-	err = common.UpdateSecret(o.kubeCli, "aws", account.Spec.ClaimLinkNamespace, newOsdManagedAdminSecretData)
+	hive, err := utils.GetHiveClusterWithConn(cluster.ID(), targetOCM, hiveOCM)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("failed to get hive cluster (OCM URL:'%s'): %w", resolvedURL, err)
 	}
 
-	fmt.Println("AWS creds updated on hive.")
+	fmt.Printf("Connecting to hive cluster %s via OCM URL: %s\n", hive.Name(), resolvedURL)
 
-	clusterDeployments := &hiveapiv1.ClusterDeploymentList{}
-	listOpts := []client.ListOption{
-		client.InNamespace(account.Spec.ClaimLinkNamespace),
-	}
-
-	err = o.kubeCli.List(ctx, clusterDeployments, listOpts...)
+	elevationMsg := fmt.Sprintf("Elevation required to rotate secrets for %s", o.accountCRName)
+	hiveClient, err := k8s.NewAsBackplaneClusterAdminWithConn(
+		hive.ID(),
+		client.Options{Scheme: scheme.Scheme},
+		hiveOCM,
+		o.reason,
+		elevationMsg,
+	)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("failed to create hive k8s client (OCM URL:'%s'): %w", resolvedURL, err)
 	}
 
-	if len(clusterDeployments.Items) == 0 {
-		return fmt.Errorf("failed to retreive cluster deployments")
-	}
-	cdName := clusterDeployments.Items[0].ObjectMeta.Name
-
-	// Create syncset to deploy the updated creds to the cluster for CCO
-	syncSetName := "aws-sync"
-	syncSet := &hiveapiv1.SyncSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      syncSetName,
-			Namespace: account.Spec.ClaimLinkNamespace,
-		},
-		Spec: hiveapiv1.SyncSetSpec{
-			ClusterDeploymentRefs: []corev1.LocalObjectReference{
-				{
-					Name: cdName,
-				},
-			},
-			SyncSetCommonSpec: hiveapiv1.SyncSetCommonSpec{
-				ResourceApplyMode: "Upsert",
-				Secrets: []hiveapiv1.SecretMapping{
-					{
-						SourceRef: hiveapiv1.SecretReference{
-							Name: "aws",
-						},
-						TargetRef: hiveapiv1.SecretReference{
-							Name:      "aws-creds",
-							Namespace: "kube-system",
-						},
-					},
-				},
-			},
-		},
-	}
-	fmt.Println("Syncing AWS creds down to cluster.")
-	err = o.kubeCli.Create(ctx, syncSet)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("Watching Cluster Sync Status for deployment...")
-	err = hiveinternalv1alpha1.AddToScheme(o.kubeCli.Scheme())
-	if err != nil {
-		return err
-	}
-
-	searchStatus := &hiveinternalv1alpha1.ClusterSync{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cdName,
-			Namespace: account.Spec.ClaimLinkNamespace,
-		},
-	}
-	foundStatus := &hiveinternalv1alpha1.ClusterSync{}
-	isSSSynced := false
-	for i := 0; i < 6; i++ {
-		err = o.kubeCli.Get(ctx, client.ObjectKeyFromObject(searchStatus), foundStatus)
-		if err != nil {
-			return err
-		}
-
-		for _, status := range foundStatus.Status.SyncSets {
-			if status.Name == syncSetName {
-				if status.FirstSuccessTime != nil {
-					isSSSynced = true
-					break
-				}
-			}
-		}
-
-		if isSSSynced {
-			fmt.Printf("\nSync completed...\n")
-			break
-		}
-
-		fmt.Printf(".")
-		time.Sleep(time.Second * 5)
-	}
-	if !isSSSynced {
-		return fmt.Errorf("syncset failed to sync. Please verify")
-	}
-
-	// Clean up the SS on hive
-	err = o.kubeCli.Delete(ctx, syncSet)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("Successfully rotated secrets for %s\n", osdManagedAdminUsername)
-
-	// Only update osdCcsAdmin credential if specified
-	if o.updateCcsCreds {
-		// Only update if the Account CR is actually CCS
-		if account.Spec.BYOC {
-			// Rotate osdCcsAdmin creds
-			createAccessKeyOutputCCS, err := awsClient.CreateAccessKey(&iam.CreateAccessKeyInput{
-				UserName: awsSdk.String("osdCcsAdmin"),
-			})
-			if err != nil {
-				return err
-			}
-
-			newOsdCcsAdminSecretData := map[string][]byte{
-				"aws_user_name":         []byte(*createAccessKeyOutputCCS.AccessKey.UserName),
-				"aws_access_key_id":     []byte(*createAccessKeyOutputCCS.AccessKey.AccessKeyId),
-				"aws_secret_access_key": []byte(*createAccessKeyOutputCCS.AccessKey.SecretAccessKey),
-			}
-
-			// Update byoc secret with new creds
-			err = common.UpdateSecret(o.kubeCli, "byoc", account.Spec.ClaimLinkNamespace, newOsdCcsAdminSecretData)
-			if err != nil {
-				return err
-			}
-
-			fmt.Println("Successfully rotated secrets for osdCcsAdmin")
-		} else {
-			// Check yo self
-			fmt.Println("Account is not CCS, skipping osdCcsAdmin credential rotation")
-		}
-	}
-
-	return nil
+	return hiveClient, nil
 }

--- a/cmd/account/rotate-secret.go
+++ b/cmd/account/rotate-secret.go
@@ -9,6 +9,7 @@ import (
 	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/api/v1alpha1"
+	ccov1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/osdctl/cmd/common"
 	"github.com/openshift/osdctl/pkg/controller"
 	"github.com/openshift/osdctl/pkg/k8s"
@@ -16,6 +17,7 @@ import (
 	"github.com/openshift/osdctl/pkg/utils"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -41,9 +43,10 @@ func newCmdRotateSecret(streams genericclioptions.IOStreams, client *k8s.LazyCli
 	rotateSecretCmd.Flags().BoolVar(&ops.updateCcsCreds, "ccs", false, "Also rotates osdCcsAdmin credential. Use caution.")
 	rotateSecretCmd.Flags().StringVar(&ops.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket)")
 	rotateSecretCmd.Flags().StringVar(&ops.osdManagedAdminUsername, "admin-username", "", "The admin username to use for generating access keys. Must be in the format of `osdManagedAdmin*`. If not specified, this is inferred from the account CR.")
-	rotateSecretCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "OCM internal/external cluster id or cluster name (required when using --hive-ocm-url)")
+	rotateSecretCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "OCM internal/external cluster id or cluster name")
 	rotateSecretCmd.Flags().StringVar(&ops.hiveOcmUrl, "hive-ocm-url", "", "(optional) OCM environment URL for Hive operations. Aliases: 'production', 'staging', 'integration'. This only changes how the Hive cluster is resolved; the target cluster still comes from the current/default OCM environment.")
 	_ = rotateSecretCmd.MarkFlagRequired("reason")
+	_ = rotateSecretCmd.MarkFlagRequired("cluster-id")
 
 	return rotateSecretCmd
 }
@@ -88,10 +91,6 @@ func (o *rotateSecretOptions) complete(cmd *cobra.Command, args []string) error 
 
 	if o.osdManagedAdminUsername != "" && !strings.HasPrefix(o.osdManagedAdminUsername, common.OSDManagedAdminIAM) {
 		return cmdutil.UsageErrorf(cmd, "admin-username must start with %v", common.OSDManagedAdminIAM)
-	}
-
-	if o.hiveOcmUrl != "" && o.clusterID == "" {
-		return cmdutil.UsageErrorf(cmd, "--cluster-id is required when using --hive-ocm-url")
 	}
 
 	return nil
@@ -145,14 +144,29 @@ func (o *rotateSecretOptions) run() error {
 		return err
 	}
 
+	// Create a k8s client for the managed cluster (uses the default/target OCM
+	// environment, not the hive one) to delete CredentialRequests after sync.
+	managedScheme := runtime.NewScheme()
+	_ = ccov1.AddToScheme(managedScheme)
+	managedClient, err := k8s.NewAsBackplaneClusterAdmin(
+		o.clusterID,
+		client.Options{Scheme: managedScheme},
+		o.reason,
+		fmt.Sprintf("Elevation required to rotate CredentialRequests for %s", o.accountCRName),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create managed cluster client: %w", err)
+	}
+
 	return controller.RotateSecret(ctx, &controller.RotateSecretInput{
-		AccountCRName:           o.accountCRName,
-		Account:                 account,
+		AccountCRName:          o.accountCRName,
+		Account:                account,
 		OsdManagedAdminUsername: o.osdManagedAdminUsername,
-		UpdateCcsCreds:          o.updateCcsCreds,
-		AwsClient:               awsClient,
-		HiveKubeClient:          kubeCli,
-		Out:                     os.Stdout,
+		UpdateCcsCreds:         o.updateCcsCreds,
+		AwsClient:              awsClient,
+		HiveKubeClient:         kubeCli,
+		ManagedClusterClient:   managedClient,
+		Out:                    os.Stdout,
 	})
 }
 

--- a/cmd/account/rotate-secret.go
+++ b/cmd/account/rotate-secret.go
@@ -74,6 +74,53 @@ func getSessionNameFromUserId(userid string) string {
 	return strings.Replace(userid, ":", "-", 1)
 }
 
+// verifyRotationPermissions checks if the assumed role has the necessary IAM permissions
+// to perform secret rotation by simulating the required actions on the osdManagedAdmin user
+func verifyRotationPermissions(awsClient awsprovider.Client, accountID string, osdManagedAdminUsername string) error {
+	// Define the required IAM actions for secret rotation
+	requiredActions := []string{
+		"iam:CreateAccessKey",
+		"iam:CreateUser",
+		"iam:DeleteAccessKey",
+		"iam:DeleteUser",
+		"iam:DeleteUserPolicy",
+		"iam:GetUser",
+		"iam:GetUserPolicy",
+		"iam:ListAccessKeys",
+		"iam:PutUserPolicy",
+		"iam:TagUser",
+	}
+
+	// Construct the ARN for the osdManagedAdmin user
+	userArn := fmt.Sprintf("arn:aws:iam::%s:user/%s", accountID, osdManagedAdminUsername)
+
+	fmt.Printf("Verifying IAM permissions for user %s...\n", osdManagedAdminUsername)
+
+	// Simulate the principal policy to check permissions
+	output, err := awsClient.SimulatePrincipalPolicy(&iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: awsSdk.String(userArn),
+		ActionNames:     requiredActions,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to simulate principal policy: %w", err)
+	}
+
+	// Check if all actions are allowed
+	var deniedActions []string
+	for _, result := range output.EvaluationResults {
+		if result.EvalDecision != iamTypes.PolicyEvaluationDecisionTypeAllowed {
+			deniedActions = append(deniedActions, *result.EvalActionName)
+		}
+	}
+
+	if len(deniedActions) > 0 {
+		return fmt.Errorf("insufficient permissions for secret rotation. Denied actions: %v", deniedActions)
+	}
+
+	fmt.Println("Permission verification successful. All required IAM actions are allowed.")
+	return nil
+}
+
 func (o *rotateSecretOptions) complete(cmd *cobra.Command, args []string) error {
 
 	if len(args) != 1 {
@@ -218,6 +265,23 @@ func (o *rotateSecretOptions) run() error {
 	osdManagedAdminUsername := o.osdManagedAdminUsername
 	if osdManagedAdminUsername == "" {
 		osdManagedAdminUsername = common.OSDManagedAdminIAM + "-" + accountIDSuffixLabel
+	}
+
+	// Verify that we have the necessary permissions to rotate secrets
+	err = verifyRotationPermissions(awsClient, accountID, osdManagedAdminUsername)
+	if err != nil {
+		// If verification fails with the suffixed username, try without suffix
+		if osdManagedAdminUsername == common.OSDManagedAdminIAM+"-"+accountIDSuffixLabel {
+			fmt.Printf("Permission verification failed for %s, trying %s...\n", osdManagedAdminUsername, common.OSDManagedAdminIAM)
+			err = verifyRotationPermissions(awsClient, accountID, common.OSDManagedAdminIAM)
+			if err != nil {
+				return err
+			}
+			// Update username if verification succeeded without suffix
+			osdManagedAdminUsername = common.OSDManagedAdminIAM
+		} else {
+			return err
+		}
 	}
 
 	// Create new access key

--- a/cmd/account/rotate-secret.go
+++ b/cmd/account/rotate-secret.go
@@ -147,8 +147,10 @@ func (o *rotateSecretOptions) run() error {
 	}
 
 	// Create a k8s client for the managed cluster (uses the default/target OCM
-	// environment, not the hive one) to delete CredentialRequests after sync.
+	// environment, not the hive one) to list CredentialRequests and delete
+	// the secrets they reference.
 	managedScheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(managedScheme)
 	_ = ccov1.AddToScheme(managedScheme)
 	managedClient, err := k8s.NewAsBackplaneClusterAdmin(
 		o.clusterID,

--- a/cmd/account/rotate-secret.go
+++ b/cmd/account/rotate-secret.go
@@ -41,6 +41,7 @@ func newCmdRotateSecret(streams genericclioptions.IOStreams, client *k8s.LazyCli
 
 	rotateSecretCmd.Flags().StringVarP(&ops.profile, "aws-profile", "p", "", "specify AWS profile")
 	rotateSecretCmd.Flags().BoolVar(&ops.updateCcsCreds, "ccs", false, "Also rotates osdCcsAdmin credential. Use caution.")
+	rotateSecretCmd.Flags().BoolVar(&ops.dryRun, "dry-run", false, "Only print what actions would be taken without performing any mutations (no AWS key creation/deletion, no k8s resource changes)")
 	rotateSecretCmd.Flags().StringVar(&ops.reason, "reason", "", "The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket)")
 	rotateSecretCmd.Flags().StringVar(&ops.osdManagedAdminUsername, "admin-username", "", "The admin username to use for generating access keys. Must be in the format of `osdManagedAdmin*`. If not specified, this is inferred from the account CR.")
 	rotateSecretCmd.Flags().StringVarP(&ops.clusterID, "cluster-id", "C", "", "OCM internal/external cluster id or cluster name")
@@ -56,6 +57,7 @@ type rotateSecretOptions struct {
 	accountCRName           string
 	profile                 string
 	updateCcsCreds          bool
+	dryRun                  bool
 	awsAccountTimeout       *int32
 	reason                  string
 	osdManagedAdminUsername string
@@ -163,6 +165,7 @@ func (o *rotateSecretOptions) run() error {
 		Account:                account,
 		OsdManagedAdminUsername: o.osdManagedAdminUsername,
 		UpdateCcsCreds:         o.updateCcsCreds,
+		DryRun:                 o.dryRun,
 		AwsClient:              awsClient,
 		HiveKubeClient:         kubeCli,
 		ManagedClusterClient:   managedClient,

--- a/cmd/account/rotate-secret.go
+++ b/cmd/account/rotate-secret.go
@@ -161,15 +161,15 @@ func (o *rotateSecretOptions) run() error {
 	}
 
 	return controller.RotateSecret(ctx, &controller.RotateSecretInput{
-		AccountCRName:          o.accountCRName,
-		Account:                account,
+		AccountCRName:           o.accountCRName,
+		Account:                 account,
 		OsdManagedAdminUsername: o.osdManagedAdminUsername,
-		UpdateCcsCreds:         o.updateCcsCreds,
-		DryRun:                 o.dryRun,
-		AwsClient:              awsClient,
-		HiveKubeClient:         kubeCli,
-		ManagedClusterClient:   managedClient,
-		Out:                    os.Stdout,
+		UpdateCcsCreds:          o.updateCcsCreds,
+		DryRun:                  o.dryRun,
+		AwsClient:               awsClient,
+		HiveKubeClient:          kubeCli,
+		ManagedClusterClient:    managedClient,
+		Out:                     os.Stdout,
 	})
 }
 

--- a/cmd/account/rotate-secret_test.go
+++ b/cmd/account/rotate-secret_test.go
@@ -3,13 +3,9 @@ package account
 import (
 	"testing"
 
-	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/iam"
-	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
-	mock_aws "github.com/openshift/osdctl/pkg/provider/aws/mock"
+	"github.com/openshift/osdctl/pkg/k8s"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -57,7 +53,7 @@ func TestRotateSecretOptions_Complete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ops := newRotateSecretOptions(genericclioptions.IOStreams{}, nil)
+			ops := newRotateSecretOptions(genericclioptions.IOStreams{}, (*k8s.LazyClient)(nil))
 			cmd := &cobra.Command{}
 			cmd.Flags().StringVar(&ops.profile, "aws-profile", "", "")
 			cmd.Flags().BoolVar(&ops.updateCcsCreds, "ccs", false, "")
@@ -76,132 +72,6 @@ func TestRotateSecretOptions_Complete(t *testing.T) {
 				assert.Equal(t, tt.expectedProfile, ops.profile)
 				assert.NotNil(t, ops.awsAccountTimeout)
 				assert.Equal(t, int32(900), *ops.awsAccountTimeout)
-			}
-		})
-	}
-}
-
-func TestVerifyRotationPermissions(t *testing.T) {
-	tests := []struct {
-		name           string
-		accountID      string
-		username       string
-		mockResponse   *iam.SimulatePrincipalPolicyOutput
-		mockError      error
-		expectedErr    bool
-		expectedErrMsg string
-	}{
-		{
-			name:      "all_permissions_allowed",
-			accountID: "123456789012",
-			username:  "osdManagedAdmin-test",
-			mockResponse: &iam.SimulatePrincipalPolicyOutput{
-				EvaluationResults: []iamTypes.EvaluationResult{
-					{
-						EvalActionName: awsSdk.String("iam:CreateAccessKey"),
-						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
-					},
-					{
-						EvalActionName: awsSdk.String("iam:CreateUser"),
-						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
-					},
-					{
-						EvalActionName: awsSdk.String("iam:DeleteAccessKey"),
-						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
-					},
-					{
-						EvalActionName: awsSdk.String("iam:DeleteUser"),
-						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
-					},
-					{
-						EvalActionName: awsSdk.String("iam:DeleteUserPolicy"),
-						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
-					},
-					{
-						EvalActionName: awsSdk.String("iam:GetUser"),
-						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
-					},
-					{
-						EvalActionName: awsSdk.String("iam:GetUserPolicy"),
-						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
-					},
-					{
-						EvalActionName: awsSdk.String("iam:ListAccessKeys"),
-						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
-					},
-					{
-						EvalActionName: awsSdk.String("iam:PutUserPolicy"),
-						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
-					},
-					{
-						EvalActionName: awsSdk.String("iam:TagUser"),
-						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
-					},
-				},
-			},
-			mockError:   nil,
-			expectedErr: false,
-		},
-		{
-			name:      "some_permissions_denied",
-			accountID: "123456789012",
-			username:  "osdManagedAdmin-test",
-			mockResponse: &iam.SimulatePrincipalPolicyOutput{
-				EvaluationResults: []iamTypes.EvaluationResult{
-					{
-						EvalActionName: awsSdk.String("iam:CreateAccessKey"),
-						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
-					},
-					{
-						EvalActionName: awsSdk.String("iam:CreateUser"),
-						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeExplicitDeny,
-					},
-					{
-						EvalActionName: awsSdk.String("iam:DeleteAccessKey"),
-						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeImplicitDeny,
-					},
-				},
-			},
-			mockError:      nil,
-			expectedErr:    true,
-			expectedErrMsg: "insufficient permissions for secret rotation. Denied actions: [iam:CreateUser iam:DeleteAccessKey]",
-		},
-		{
-			name:           "simulate_api_error",
-			accountID:      "123456789012",
-			username:       "osdManagedAdmin-test",
-			mockResponse:   nil,
-			mockError:      assert.AnError,
-			expectedErr:    true,
-			expectedErrMsg: "failed to simulate principal policy",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
-			mockClient := mock_aws.NewMockClient(ctrl)
-
-			expectedArn := "arn:aws:iam::" + tt.accountID + ":user/" + tt.username
-			mockClient.EXPECT().
-				SimulatePrincipalPolicy(gomock.Any()).
-				DoAndReturn(func(input *iam.SimulatePrincipalPolicyInput) (*iam.SimulatePrincipalPolicyOutput, error) {
-					// Verify the input is correct
-					assert.Equal(t, expectedArn, *input.PolicySourceArn)
-					assert.Len(t, input.ActionNames, 10)
-					return tt.mockResponse, tt.mockError
-				}).
-				Times(1)
-
-			err := verifyRotationPermissions(mockClient, tt.accountID, tt.username)
-
-			if tt.expectedErr {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tt.expectedErrMsg)
-			} else {
-				assert.NoError(t, err)
 			}
 		})
 	}

--- a/cmd/account/rotate-secret_test.go
+++ b/cmd/account/rotate-secret_test.go
@@ -3,8 +3,13 @@ package account
 import (
 	"testing"
 
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	mock_aws "github.com/openshift/osdctl/pkg/provider/aws/mock"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
@@ -71,6 +76,132 @@ func TestRotateSecretOptions_Complete(t *testing.T) {
 				assert.Equal(t, tt.expectedProfile, ops.profile)
 				assert.NotNil(t, ops.awsAccountTimeout)
 				assert.Equal(t, int32(900), *ops.awsAccountTimeout)
+			}
+		})
+	}
+}
+
+func TestVerifyRotationPermissions(t *testing.T) {
+	tests := []struct {
+		name           string
+		accountID      string
+		username       string
+		mockResponse   *iam.SimulatePrincipalPolicyOutput
+		mockError      error
+		expectedErr    bool
+		expectedErrMsg string
+	}{
+		{
+			name:      "all_permissions_allowed",
+			accountID: "123456789012",
+			username:  "osdManagedAdmin-test",
+			mockResponse: &iam.SimulatePrincipalPolicyOutput{
+				EvaluationResults: []iamTypes.EvaluationResult{
+					{
+						EvalActionName: awsSdk.String("iam:CreateAccessKey"),
+						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
+					},
+					{
+						EvalActionName: awsSdk.String("iam:CreateUser"),
+						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
+					},
+					{
+						EvalActionName: awsSdk.String("iam:DeleteAccessKey"),
+						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
+					},
+					{
+						EvalActionName: awsSdk.String("iam:DeleteUser"),
+						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
+					},
+					{
+						EvalActionName: awsSdk.String("iam:DeleteUserPolicy"),
+						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
+					},
+					{
+						EvalActionName: awsSdk.String("iam:GetUser"),
+						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
+					},
+					{
+						EvalActionName: awsSdk.String("iam:GetUserPolicy"),
+						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
+					},
+					{
+						EvalActionName: awsSdk.String("iam:ListAccessKeys"),
+						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
+					},
+					{
+						EvalActionName: awsSdk.String("iam:PutUserPolicy"),
+						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
+					},
+					{
+						EvalActionName: awsSdk.String("iam:TagUser"),
+						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
+					},
+				},
+			},
+			mockError:   nil,
+			expectedErr: false,
+		},
+		{
+			name:      "some_permissions_denied",
+			accountID: "123456789012",
+			username:  "osdManagedAdmin-test",
+			mockResponse: &iam.SimulatePrincipalPolicyOutput{
+				EvaluationResults: []iamTypes.EvaluationResult{
+					{
+						EvalActionName: awsSdk.String("iam:CreateAccessKey"),
+						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeAllowed,
+					},
+					{
+						EvalActionName: awsSdk.String("iam:CreateUser"),
+						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeExplicitDeny,
+					},
+					{
+						EvalActionName: awsSdk.String("iam:DeleteAccessKey"),
+						EvalDecision:   iamTypes.PolicyEvaluationDecisionTypeImplicitDeny,
+					},
+				},
+			},
+			mockError:      nil,
+			expectedErr:    true,
+			expectedErrMsg: "insufficient permissions for secret rotation. Denied actions: [iam:CreateUser iam:DeleteAccessKey]",
+		},
+		{
+			name:           "simulate_api_error",
+			accountID:      "123456789012",
+			username:       "osdManagedAdmin-test",
+			mockResponse:   nil,
+			mockError:      assert.AnError,
+			expectedErr:    true,
+			expectedErrMsg: "failed to simulate principal policy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockClient := mock_aws.NewMockClient(ctrl)
+
+			expectedArn := "arn:aws:iam::" + tt.accountID + ":user/" + tt.username
+			mockClient.EXPECT().
+				SimulatePrincipalPolicy(gomock.Any()).
+				DoAndReturn(func(input *iam.SimulatePrincipalPolicyInput) (*iam.SimulatePrincipalPolicyOutput, error) {
+					// Verify the input is correct
+					assert.Equal(t, expectedArn, *input.PolicySourceArn)
+					assert.Len(t, input.ActionNames, 10)
+					return tt.mockResponse, tt.mockError
+				}).
+				Times(1)
+
+			err := verifyRotationPermissions(mockClient, tt.accountID, tt.username)
+
+			if tt.expectedErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/docs/README.md
+++ b/docs/README.md
@@ -788,8 +788,11 @@ osdctl account rotate-secret <aws-account-cr-name> [flags]
   -p, --aws-profile string                specify AWS profile
       --ccs                               Also rotates osdCcsAdmin credential. Use caution.
       --cluster string                    The name of the kubeconfig cluster to use
+  -C, --cluster-id string                 OCM internal/external cluster id or cluster name
       --context string                    The name of the kubeconfig context to use
+      --dry-run                           Only print what actions would be taken without performing any mutations (no AWS key creation/deletion, no k8s resource changes)
   -h, --help                              help for rotate-secret
+      --hive-ocm-url string               (optional) OCM environment URL for Hive operations. Aliases: 'production', 'staging', 'integration'. This only changes how the Hive cluster is resolved; the target cluster still comes from the current/default OCM environment.
       --insecure-skip-tls-verify          If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string                 Path to the kubeconfig file to use for CLI requests.
   -o, --output string                     Valid formats are ['', 'json', 'yaml', 'env']

--- a/docs/osdctl_account_rotate-secret.md
+++ b/docs/osdctl_account_rotate-secret.md
@@ -16,7 +16,10 @@ osdctl account rotate-secret <aws-account-cr-name> [flags]
       --admin-username osdManagedAdmin*   The admin username to use for generating access keys. Must be in the format of osdManagedAdmin*. If not specified, this is inferred from the account CR.
   -p, --aws-profile string                specify AWS profile
       --ccs                               Also rotates osdCcsAdmin credential. Use caution.
+  -C, --cluster-id string                 OCM internal/external cluster id or cluster name
+      --dry-run                           Only print what actions would be taken without performing any mutations (no AWS key creation/deletion, no k8s resource changes)
   -h, --help                              help for rotate-secret
+      --hive-ocm-url string               (optional) OCM environment URL for Hive operations. Aliases: 'production', 'staging', 'integration'. This only changes how the Hive cluster is resolved; the target cluster still comes from the current/default OCM environment.
       --reason string                     The reason for this command, which requires elevation, to be run (usually an OHSS or PD ticket)
 ```
 

--- a/pkg/controller/rotatesecret.go
+++ b/pkg/controller/rotatesecret.go
@@ -204,6 +204,12 @@ func RotateSecret(ctx context.Context, input *RotateSecretInput) error {
 		}
 	}
 
+	if !input.DryRun {
+		fmt.Fprintln(input.Out, "The rotation should be successfully finished:- do not forget to remove the old access key!")
+		fmt.Fprintln(input.Out, "- Confirm secrets are recreated and new access key was used")
+		fmt.Fprintln(input.Out, "- Remove the old access key (use rh-aws-saml-login)")
+	}
+
 	return nil
 }
 
@@ -298,7 +304,7 @@ func reportAccessKeys(awsClient awsprovider.Client, username, newKeyID string, o
 		}
 	}
 	if hasOldKeys {
-		fmt.Fprintf(out, "\nThe old access key(s) listed above should now be removed.\n")
+		fmt.Fprintf(out, "\nThe old access key(s) listed above be removed once rotation is finished.\n")
 		fmt.Fprintf(out, "Use 'rh-aws-saml-login' to gain access to the account and delete them.\n\n")
 	}
 

--- a/pkg/controller/rotatesecret.go
+++ b/pkg/controller/rotatesecret.go
@@ -63,6 +63,11 @@ type RotateSecretInput struct {
 	// CredentialRequests so CCO recreates them with the new credentials.
 	ManagedClusterClient client.Client
 
+	// DryRun, when true, prints what actions would be taken without performing
+	// any mutating operations (no AWS key creation/deletion, no k8s resource
+	// creation/deletion/updates).
+	DryRun bool
+
 	// Out is the writer for informational output.
 	Out io.Writer
 }
@@ -146,9 +151,15 @@ func RotateSecret(ctx context.Context, input *RotateSecretInput) error {
 		}
 	}
 
+	newKeyID := *createAccessKeyOutput.AccessKey.AccessKeyId
+
+	if err := reportAccessKeys(input.AwsClient, adminUsername, newKeyID, input.Out); err != nil {
+		return err
+	}
+
 	newSecretData := map[string][]byte{
 		"aws_user_name":         []byte(*createAccessKeyOutput.AccessKey.UserName),
-		"aws_access_key_id":     []byte(*createAccessKeyOutput.AccessKey.AccessKeyId),
+		"aws_access_key_id":     []byte(newKeyID),
 		"aws_secret_access_key": []byte(*createAccessKeyOutput.AccessKey.SecretAccessKey),
 	}
 
@@ -244,6 +255,41 @@ func resolveAdminUsername(out io.Writer, awsClient awsprovider.Client, accountID
 		return "", err
 	}
 	return username, nil
+}
+
+// reportAccessKeys lists all access keys for a user and prints each one,
+// highlighting which is the newly created key and which are old keys that
+// should be removed manually.
+func reportAccessKeys(awsClient awsprovider.Client, username, newKeyID string, out io.Writer) error {
+	listOutput, err := awsClient.ListAccessKeys(&iam.ListAccessKeysInput{
+		UserName: awsSdk.String(username),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list access keys for user %s: %w", username, err)
+	}
+
+	fmt.Fprintf(out, "\nAccess keys for IAM user %s:\n", username)
+	for _, key := range listOutput.AccessKeyMetadata {
+		if *key.AccessKeyId == newKeyID {
+			fmt.Fprintf(out, "  - %s (new - just created)\n", *key.AccessKeyId)
+		} else {
+			fmt.Fprintf(out, "  - %s (old - should be removed)\n", *key.AccessKeyId)
+		}
+	}
+
+	hasOldKeys := false
+	for _, key := range listOutput.AccessKeyMetadata {
+		if *key.AccessKeyId != newKeyID {
+			hasOldKeys = true
+			break
+		}
+	}
+	if hasOldKeys {
+		fmt.Fprintf(out, "\nThe old access key(s) listed above should now be removed.\n")
+		fmt.Fprintf(out, "Use 'rh-aws-saml-login' to gain access to the account and delete them.\n\n")
+	}
+
+	return nil
 }
 
 // updateSecret fetches an existing k8s secret and replaces its data.
@@ -351,16 +397,23 @@ func rotateCcsAdminCredentials(ctx context.Context, awsClient awsprovider.Client
 		return nil
 	}
 
+	ccsUsername := "osdCcsAdmin"
 	createAccessKeyOutput, err := awsClient.CreateAccessKey(&iam.CreateAccessKeyInput{
-		UserName: awsSdk.String("osdCcsAdmin"),
+		UserName: awsSdk.String(ccsUsername),
 	})
 	if err != nil {
 		return err
 	}
 
+	ccsNewKeyID := *createAccessKeyOutput.AccessKey.AccessKeyId
+
+	if err := reportAccessKeys(awsClient, ccsUsername, ccsNewKeyID, out); err != nil {
+		return err
+	}
+
 	newSecretData := map[string][]byte{
 		"aws_user_name":         []byte(*createAccessKeyOutput.AccessKey.UserName),
-		"aws_access_key_id":     []byte(*createAccessKeyOutput.AccessKey.AccessKeyId),
+		"aws_access_key_id":     []byte(ccsNewKeyID),
 		"aws_secret_access_key": []byte(*createAccessKeyOutput.AccessKey.SecretAccessKey),
 	}
 

--- a/pkg/controller/rotatesecret.go
+++ b/pkg/controller/rotatesecret.go
@@ -18,6 +18,7 @@ import (
 	hiveinternalv1alpha1 "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
 	awsprovider "github.com/openshift/osdctl/pkg/provider/aws"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,6 +28,16 @@ const (
 	awsAccountNamespace = "aws-account-operator"
 	osdManagedAdminIAM  = "osdManagedAdmin"
 )
+
+// InsufficientPermissionsError is returned when SimulatePrincipalPolicy
+// reports that one or more required IAM actions are denied.
+type InsufficientPermissionsError struct {
+	DeniedActions []string
+}
+
+func (e *InsufficientPermissionsError) Error() string {
+	return fmt.Sprintf("insufficient permissions for secret rotation. Denied actions: %v", e.DeniedActions)
+}
 
 // SyncPollInterval is the delay between ClusterSync status checks.
 var SyncPollInterval = 5 * time.Second
@@ -232,7 +243,7 @@ func VerifyRotationPermissions(out io.Writer, awsClient awsprovider.Client, acco
 	}
 
 	if len(deniedActions) > 0 {
-		return fmt.Errorf("insufficient permissions for secret rotation. Denied actions: %v", deniedActions)
+		return &InsufficientPermissionsError{DeniedActions: deniedActions}
 	}
 
 	fmt.Fprintln(out, "Permission verification successful. All required IAM actions are allowed.")
@@ -240,12 +251,14 @@ func VerifyRotationPermissions(out io.Writer, awsClient awsprovider.Client, acco
 }
 
 // resolveAdminUsername verifies rotation permissions for the given username,
-// falling back to the unsuffixed osdManagedAdmin if needed.
+// falling back to the unsuffixed osdManagedAdmin only when the suffixed user
+// has insufficient permissions. Transport or API errors are never retried
+// with a different principal.
 func resolveAdminUsername(out io.Writer, awsClient awsprovider.Client, accountID, username, suffix string) (string, error) {
 	err := VerifyRotationPermissions(out, awsClient, accountID, username)
 	if err != nil {
-		// If the suffixed username failed, try without the suffix
-		if username == osdManagedAdminIAM+"-"+suffix {
+		var permErr *InsufficientPermissionsError
+		if errors.As(err, &permErr) && username == osdManagedAdminIAM+"-"+suffix {
 			fmt.Fprintf(out, "Permission verification failed for %s, trying %s...\n", username, osdManagedAdminIAM)
 			if err := VerifyRotationPermissions(out, awsClient, accountID, osdManagedAdminIAM); err != nil {
 				return "", err
@@ -344,7 +357,16 @@ func syncCredentialsToCluster(ctx context.Context, kubeClient client.Client, cla
 	}
 
 	fmt.Fprintln(out, "Syncing AWS creds down to cluster.")
-	if err := kubeClient.Create(ctx, syncSet); err != nil {
+	if err := kubeClient.Create(ctx, syncSet); apierrors.IsAlreadyExists(err) {
+		existing := &hiveapiv1.SyncSet{}
+		if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(syncSet), existing); err != nil {
+			return err
+		}
+		syncSet.ResourceVersion = existing.ResourceVersion
+		if err := kubeClient.Update(ctx, syncSet); err != nil {
+			return err
+		}
+	} else if err != nil {
 		return err
 	}
 

--- a/pkg/controller/rotatesecret.go
+++ b/pkg/controller/rotatesecret.go
@@ -2,15 +2,18 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/api/v1alpha1"
+	ccov1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	hiveapiv1 "github.com/openshift/hive/apis/hive/v1"
 	hiveinternalv1alpha1 "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
 	awsprovider "github.com/openshift/osdctl/pkg/provider/aws"
@@ -55,6 +58,11 @@ type RotateSecretInput struct {
 	// HiveKubeClient is the k8s client connected to the hive cluster.
 	HiveKubeClient client.Client
 
+	// ManagedClusterClient is the k8s client connected to the managed cluster
+	// (via backplane using the target OCM environment). Used to delete
+	// CredentialRequests so CCO recreates them with the new credentials.
+	ManagedClusterClient client.Client
+
 	// Out is the writer for informational output.
 	Out io.Writer
 }
@@ -91,6 +99,31 @@ func RotateSecret(ctx context.Context, input *RotateSecretInput) error {
 	adminUsername, err := resolveAdminUsername(input.Out, input.AwsClient, accountID, adminUsername, accountIDSuffixLabel)
 	if err != nil {
 		return err
+	}
+
+	if input.DryRun {
+		fmt.Fprintln(input.Out, "[Dry Run] Would create a new IAM access key for user:", adminUsername)
+		fmt.Fprintln(input.Out, "[Dry Run] Would list access keys and report old keys to remove via rh-aws-saml-login")
+		fmt.Fprintf(input.Out, "[Dry Run] Would update secret %s/%s with new credentials\n", awsAccountNamespace, input.AccountCRName+"-secret")
+		fmt.Fprintf(input.Out, "[Dry Run] Would update secret %s/%s with new credentials\n", account.Spec.ClaimLinkNamespace, "aws")
+		fmt.Fprintf(input.Out, "[Dry Run] Would create SyncSet %s/%s to sync credentials to cluster\n", account.Spec.ClaimLinkNamespace, "aws-sync")
+		fmt.Fprintf(input.Out, "[Dry Run] Would poll ClusterSync and then delete SyncSet %s/%s\n", account.Spec.ClaimLinkNamespace, "aws-sync")
+
+		if err := dryRunDeleteCredentialSecrets(ctx, input.ManagedClusterClient, input.Out); err != nil {
+			return err
+		}
+
+		if input.UpdateCcsCreds {
+			if account.Spec.BYOC {
+				fmt.Fprintln(input.Out, "[Dry Run] Would create a new IAM access key for user: osdCcsAdmin")
+				fmt.Fprintf(input.Out, "[Dry Run] Would update secret %s/%s with new osdCcsAdmin credentials\n", account.Spec.ClaimLinkNamespace, "byoc")
+			} else {
+				fmt.Fprintln(input.Out, "[Dry Run] Account is not CCS, would skip osdCcsAdmin credential rotation")
+			}
+		}
+
+		fmt.Fprintln(input.Out, "[Dry Run] No changes were made.")
+		return nil
 	}
 
 	// Create new access key
@@ -136,6 +169,12 @@ func RotateSecret(ctx context.Context, input *RotateSecretInput) error {
 	}
 
 	fmt.Fprintf(input.Out, "Successfully rotated secrets for %s\n", adminUsername)
+
+	// Delete the secrets referenced by AWS CredentialRequests so CCO recreates
+	// them with the newly synced credentials.
+	if err := deleteCredentialSecrets(ctx, input.ManagedClusterClient, input.Out); err != nil {
+		return err
+	}
 
 	if input.UpdateCcsCreds {
 		if err := rotateCcsAdminCredentials(ctx, input.AwsClient, input.HiveKubeClient, account, input.Out); err != nil {
@@ -330,5 +369,90 @@ func rotateCcsAdminCredentials(ctx context.Context, awsClient awsprovider.Client
 	}
 
 	fmt.Fprintln(out, "Successfully rotated secrets for osdCcsAdmin")
+	return nil
+}
+
+const (
+	credentialRequestNamespace = "openshift-cloud-credential-operator"
+	credentialRequestPrefix    = "openshift-"
+)
+
+// isAWSCredentialRequest returns true when the CredentialRequest has the
+// "openshift-" name prefix and its providerSpec.kind is "AWSProviderSpec".
+func isAWSCredentialRequest(cr *ccov1.CredentialsRequest) bool {
+	if !strings.HasPrefix(cr.Name, credentialRequestPrefix) {
+		return false
+	}
+	if cr.Spec.ProviderSpec == nil || cr.Spec.ProviderSpec.Raw == nil {
+		return false
+	}
+	var provider struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(cr.Spec.ProviderSpec.Raw, &provider); err != nil {
+		return false
+	}
+	return provider.Kind == "AWSProviderSpec"
+}
+
+// dryRunDeleteCredentialSecrets lists the secrets referenced by AWS
+// CredentialRequests that would be deleted during a real rotation.
+func dryRunDeleteCredentialSecrets(ctx context.Context, managedClient client.Client, out io.Writer) error {
+	crList := &ccov1.CredentialsRequestList{}
+	if err := managedClient.List(ctx, crList, client.InNamespace(credentialRequestNamespace)); err != nil {
+		return fmt.Errorf("failed to list CredentialRequests in %s: %w", credentialRequestNamespace, err)
+	}
+
+	count := 0
+	for i := range crList.Items {
+		cr := &crList.Items[i]
+		if !isAWSCredentialRequest(cr) {
+			continue
+		}
+		fmt.Fprintf(out, "[Dry Run] Would delete secret %s/%s (referenced by CredentialRequest %s)\n",
+			cr.Spec.SecretRef.Namespace, cr.Spec.SecretRef.Name, cr.Name)
+		count++
+	}
+	fmt.Fprintf(out, "[Dry Run] Would delete %d credential secret(s) total\n", count)
+	return nil
+}
+
+// deleteCredentialSecrets lists AWS CredentialRequests on the managed cluster,
+// resolves the secret each one references via .spec.secretRef, and deletes
+// those secrets so CCO recreates them using the newly synced credentials.
+func deleteCredentialSecrets(ctx context.Context, managedClient client.Client, out io.Writer) error {
+	fmt.Fprintln(out, "The 'aws-creds' secret in 'kube-system' has been updated via SyncSet.")
+	fmt.Fprintln(out, "Deleting credential secrets so CCO recreates them with the new credentials...")
+
+	crList := &ccov1.CredentialsRequestList{}
+	if err := managedClient.List(ctx, crList, client.InNamespace(credentialRequestNamespace)); err != nil {
+		return fmt.Errorf("failed to list CredentialRequests in %s: %w", credentialRequestNamespace, err)
+	}
+
+	deletedCount := 0
+	for i := range crList.Items {
+		cr := &crList.Items[i]
+		if !isAWSCredentialRequest(cr) {
+			continue
+		}
+		ref := cr.Spec.SecretRef
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ref.Name,
+				Namespace: ref.Namespace,
+			},
+		}
+		if err := managedClient.Delete(ctx, secret); err != nil {
+			if apierrors.IsNotFound(err) {
+				fmt.Fprintf(out, "  Secret %s/%s already absent, skipping\n", ref.Namespace, ref.Name)
+				continue
+			}
+			return fmt.Errorf("failed to delete secret %s/%s (from CredentialRequest %s): %w", ref.Namespace, ref.Name, cr.Name, err)
+		}
+		fmt.Fprintf(out, "  Deleted secret %s/%s (referenced by CredentialRequest %s)\n", ref.Namespace, ref.Name, cr.Name)
+		deletedCount++
+	}
+
+	fmt.Fprintf(out, "Deleted %d credential secret(s). CCO will recreate them with the updated credentials.\n", deletedCount)
 	return nil
 }

--- a/pkg/controller/rotatesecret.go
+++ b/pkg/controller/rotatesecret.go
@@ -150,6 +150,10 @@ func RotateSecret(ctx context.Context, input *RotateSecretInput) error {
 		var nse *iamTypes.NoSuchEntityException
 		if errors.As(err, &nse) {
 			// Retry without the suffix
+			// Retry without the suffix, re-verifying permissions first.
+			if err := VerifyRotationPermissions(input.Out, input.AwsClient, accountID, osdManagedAdminIAM); err != nil {
+				return err
+			}
 			adminUsername = osdManagedAdminIAM
 			createAccessKeyOutput, err = input.AwsClient.CreateAccessKey(&iam.CreateAccessKeyInput{
 				UserName: awsSdk.String(adminUsername),
@@ -163,6 +167,16 @@ func RotateSecret(ctx context.Context, input *RotateSecretInput) error {
 	}
 
 	newKeyID := *createAccessKeyOutput.AccessKey.AccessKeyId
+	rotationCommitted := false
+	defer func() {
+		if rotationCommitted {
+			return
+		}
+		_, _ = input.AwsClient.DeleteAccessKey(&iam.DeleteAccessKeyInput{
+			UserName:    awsSdk.String(adminUsername),
+			AccessKeyId: awsSdk.String(newKeyID),
+		})
+	}()
 
 	if err := reportAccessKeys(input.AwsClient, adminUsername, newKeyID, input.Out); err != nil {
 		return err
@@ -179,18 +193,24 @@ func RotateSecret(ctx context.Context, input *RotateSecretInput) error {
 		return err
 	}
 
+	// The AAO secret has been updated - if anything fails from this point onward it must either be manually fixed or rolled back
+	rotationCommitted = true
+
 	// Update the secret in ClusterDeployment's namespace
 	if err := updateSecret(ctx, input.HiveKubeClient, "aws", account.Spec.ClaimLinkNamespace, newSecretData); err != nil {
+		fmt.Fprintln(input.Out, "AWS creds updated for AAO account but failed for Cluster namespace")
+		fmt.Fprintln(input.Out, "Please update the cluster secret by hand and sync to cluster.")
 		return err
 	}
 
 	fmt.Fprintln(input.Out, "AWS creds updated on hive.")
 
 	if err := syncCredentialsToCluster(ctx, input.HiveKubeClient, account.Spec.ClaimLinkNamespace, input.Out); err != nil {
+		fmt.Fprintln(input.Out, "AWS creds updated on hive but not synced to cluster")
 		return err
 	}
 
-	fmt.Fprintf(input.Out, "Successfully rotated secrets for %s\n", adminUsername)
+	fmt.Fprintf(input.Out, "Successfully rotated access keys for %s\n", adminUsername)
 
 	// Delete the secrets referenced by AWS CredentialRequests so CCO recreates
 	// them with the newly synced credentials.
@@ -205,7 +225,8 @@ func RotateSecret(ctx context.Context, input *RotateSecretInput) error {
 	}
 
 	if !input.DryRun {
-		fmt.Fprintln(input.Out, "The rotation should be successfully finished:- do not forget to remove the old access key!")
+		fmt.Fprintln(input.Out, "The rotation should be successfully finished:")
+		fmt.Fprintln(input.Out, "- do not forget to remove the old access key in AWS!")
 		fmt.Fprintln(input.Out, "- Confirm secrets are recreated and new access key was used")
 		fmt.Fprintln(input.Out, "- Remove the old access key (use rh-aws-saml-login)")
 	}
@@ -304,7 +325,7 @@ func reportAccessKeys(awsClient awsprovider.Client, username, newKeyID string, o
 		}
 	}
 	if hasOldKeys {
-		fmt.Fprintf(out, "\nThe old access key(s) listed above be removed once rotation is finished.\n")
+		fmt.Fprintf(out, "\nThe old access key(s) listed above should be removed once rotation is finished.\n")
 		fmt.Fprintf(out, "Use 'rh-aws-saml-login' to gain access to the account and delete them.\n\n")
 	}
 
@@ -391,6 +412,12 @@ func syncCredentialsToCluster(ctx context.Context, kubeClient client.Client, cla
 	isSSSynced := false
 	for range SyncMaxRetries {
 		if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(searchStatus), foundStatus); err != nil {
+			// Allow some time to pass before retrying - maybe object creation was slow.
+			if apierrors.IsNotFound(err) {
+				fmt.Fprintf(out, ".")
+				time.Sleep(SyncPollInterval)
+				continue
+			}
 			return err
 		}
 

--- a/pkg/controller/rotatesecret.go
+++ b/pkg/controller/rotatesecret.go
@@ -1,0 +1,334 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	awsv1alpha1 "github.com/openshift/aws-account-operator/api/v1alpha1"
+	hiveapiv1 "github.com/openshift/hive/apis/hive/v1"
+	hiveinternalv1alpha1 "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
+	awsprovider "github.com/openshift/osdctl/pkg/provider/aws"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	awsAccountNamespace = "aws-account-operator"
+	osdManagedAdminIAM  = "osdManagedAdmin"
+)
+
+// SyncPollInterval is the delay between ClusterSync status checks.
+var SyncPollInterval = 5 * time.Second
+
+// SyncMaxRetries is the maximum number of ClusterSync poll attempts.
+var SyncMaxRetries = 6
+
+// RotateSecretInput holds all resolved dependencies for secret rotation.
+// The CLI layer is responsible for resolving AWS and k8s clients before
+// calling RotateSecret.
+type RotateSecretInput struct {
+	// AccountCRName is the name of the Account CR.
+	AccountCRName string
+
+	// Account is the pre-fetched Account CR.
+	Account *awsv1alpha1.Account
+
+	// OsdManagedAdminUsername is an explicit admin username override.
+	// If empty, it is derived from the Account CR's iamUserId label.
+	OsdManagedAdminUsername string
+
+	// UpdateCcsCreds controls whether osdCcsAdmin credentials are also rotated.
+	UpdateCcsCreds bool
+
+	// AwsClient is the fully-authenticated AWS client with permissions in the
+	// target AWS account (after all role chaining has been completed).
+	AwsClient awsprovider.Client
+
+	// HiveKubeClient is the k8s client connected to the hive cluster.
+	HiveKubeClient client.Client
+
+	// Out is the writer for informational output.
+	Out io.Writer
+}
+
+// RotateSecret performs the IAM credential rotation workflow:
+//  1. Validates the Account CR (not STS, has iamUserId label)
+//  2. Resolves the osdManagedAdmin username
+//  3. Verifies rotation permissions via SimulatePrincipalPolicy
+//  4. Creates a new IAM access key
+//  5. Updates k8s secrets on hive
+//  6. Creates a SyncSet to push credentials to the cluster
+//  7. Polls ClusterSync for completion and cleans up the SyncSet
+//  8. Optionally rotates osdCcsAdmin credentials
+func RotateSecret(ctx context.Context, input *RotateSecretInput) error {
+	account := input.Account
+
+	if account.Spec.ManualSTSMode {
+		return fmt.Errorf("Account %s is STS - No IAM User Credentials to Rotate", input.AccountCRName)
+	}
+
+	accountID := account.Spec.AwsAccountID
+
+	accountIDSuffixLabel, ok := account.Labels["iamUserId"]
+	if !ok {
+		return fmt.Errorf("no label on Account CR for IAM User")
+	}
+
+	// Resolve the admin username, with fallback from suffixed to unsuffixed
+	adminUsername := input.OsdManagedAdminUsername
+	if adminUsername == "" {
+		adminUsername = osdManagedAdminIAM + "-" + accountIDSuffixLabel
+	}
+
+	adminUsername, err := resolveAdminUsername(input.Out, input.AwsClient, accountID, adminUsername, accountIDSuffixLabel)
+	if err != nil {
+		return err
+	}
+
+	// Create new access key
+	createAccessKeyOutput, err := input.AwsClient.CreateAccessKey(&iam.CreateAccessKeyInput{
+		UserName: awsSdk.String(adminUsername),
+	})
+	if err != nil {
+		var nse *iamTypes.NoSuchEntityException
+		if errors.As(err, &nse) {
+			// Retry without the suffix
+			adminUsername = osdManagedAdminIAM
+			createAccessKeyOutput, err = input.AwsClient.CreateAccessKey(&iam.CreateAccessKeyInput{
+				UserName: awsSdk.String(adminUsername),
+			})
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	newSecretData := map[string][]byte{
+		"aws_user_name":         []byte(*createAccessKeyOutput.AccessKey.UserName),
+		"aws_access_key_id":     []byte(*createAccessKeyOutput.AccessKey.AccessKeyId),
+		"aws_secret_access_key": []byte(*createAccessKeyOutput.AccessKey.SecretAccessKey),
+	}
+
+	// Update the account secret
+	if err := updateSecret(ctx, input.HiveKubeClient, input.AccountCRName+"-secret", awsAccountNamespace, newSecretData); err != nil {
+		return err
+	}
+
+	// Update the secret in ClusterDeployment's namespace
+	if err := updateSecret(ctx, input.HiveKubeClient, "aws", account.Spec.ClaimLinkNamespace, newSecretData); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(input.Out, "AWS creds updated on hive.")
+
+	if err := syncCredentialsToCluster(ctx, input.HiveKubeClient, account.Spec.ClaimLinkNamespace, input.Out); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(input.Out, "Successfully rotated secrets for %s\n", adminUsername)
+
+	if input.UpdateCcsCreds {
+		if err := rotateCcsAdminCredentials(ctx, input.AwsClient, input.HiveKubeClient, account, input.Out); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// VerifyRotationPermissions checks if the assumed role has the necessary IAM
+// permissions to perform secret rotation by simulating the required actions.
+func VerifyRotationPermissions(out io.Writer, awsClient awsprovider.Client, accountID string, username string) error {
+	requiredActions := []string{
+		"iam:CreateAccessKey",
+		"iam:CreateUser",
+		"iam:DeleteAccessKey",
+		"iam:DeleteUser",
+		"iam:DeleteUserPolicy",
+		"iam:GetUser",
+		"iam:GetUserPolicy",
+		"iam:ListAccessKeys",
+		"iam:PutUserPolicy",
+		"iam:TagUser",
+	}
+
+	userArn := fmt.Sprintf("arn:aws:iam::%s:user/%s", accountID, username)
+
+	fmt.Fprintf(out, "Verifying IAM permissions for user %s...\n", username)
+
+	output, err := awsClient.SimulatePrincipalPolicy(&iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: awsSdk.String(userArn),
+		ActionNames:     requiredActions,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to simulate principal policy: %w", err)
+	}
+
+	var deniedActions []string
+	for _, result := range output.EvaluationResults {
+		if result.EvalDecision != iamTypes.PolicyEvaluationDecisionTypeAllowed {
+			deniedActions = append(deniedActions, *result.EvalActionName)
+		}
+	}
+
+	if len(deniedActions) > 0 {
+		return fmt.Errorf("insufficient permissions for secret rotation. Denied actions: %v", deniedActions)
+	}
+
+	fmt.Fprintln(out, "Permission verification successful. All required IAM actions are allowed.")
+	return nil
+}
+
+// resolveAdminUsername verifies rotation permissions for the given username,
+// falling back to the unsuffixed osdManagedAdmin if needed.
+func resolveAdminUsername(out io.Writer, awsClient awsprovider.Client, accountID, username, suffix string) (string, error) {
+	err := VerifyRotationPermissions(out, awsClient, accountID, username)
+	if err != nil {
+		// If the suffixed username failed, try without the suffix
+		if username == osdManagedAdminIAM+"-"+suffix {
+			fmt.Fprintf(out, "Permission verification failed for %s, trying %s...\n", username, osdManagedAdminIAM)
+			if err := VerifyRotationPermissions(out, awsClient, accountID, osdManagedAdminIAM); err != nil {
+				return "", err
+			}
+			return osdManagedAdminIAM, nil
+		}
+		return "", err
+	}
+	return username, nil
+}
+
+// updateSecret fetches an existing k8s secret and replaces its data.
+func updateSecret(ctx context.Context, kubeClient client.Client, secretName, secretNamespace string, secretBody map[string][]byte) error {
+	secret := &corev1.Secret{}
+	if err := kubeClient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: secretNamespace}, secret); err != nil {
+		return err
+	}
+	secret.Data = secretBody
+	return kubeClient.Update(ctx, secret)
+}
+
+// syncCredentialsToCluster creates a SyncSet to push the "aws" secret to the
+// cluster's kube-system namespace, polls ClusterSync for completion, and
+// cleans up the SyncSet.
+func syncCredentialsToCluster(ctx context.Context, kubeClient client.Client, claimLinkNamespace string, out io.Writer) error {
+	clusterDeployments := &hiveapiv1.ClusterDeploymentList{}
+	if err := kubeClient.List(ctx, clusterDeployments, client.InNamespace(claimLinkNamespace)); err != nil {
+		return err
+	}
+
+	if len(clusterDeployments.Items) == 0 {
+		return fmt.Errorf("failed to retreive cluster deployments")
+	}
+	cdName := clusterDeployments.Items[0].ObjectMeta.Name
+
+	syncSetName := "aws-sync"
+	syncSet := &hiveapiv1.SyncSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      syncSetName,
+			Namespace: claimLinkNamespace,
+		},
+		Spec: hiveapiv1.SyncSetSpec{
+			ClusterDeploymentRefs: []corev1.LocalObjectReference{
+				{Name: cdName},
+			},
+			SyncSetCommonSpec: hiveapiv1.SyncSetCommonSpec{
+				ResourceApplyMode: "Upsert",
+				Secrets: []hiveapiv1.SecretMapping{
+					{
+						SourceRef: hiveapiv1.SecretReference{
+							Name: "aws",
+						},
+						TargetRef: hiveapiv1.SecretReference{
+							Name:      "aws-creds",
+							Namespace: "kube-system",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fmt.Fprintln(out, "Syncing AWS creds down to cluster.")
+	if err := kubeClient.Create(ctx, syncSet); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Watching Cluster Sync Status for deployment...")
+	if err := hiveinternalv1alpha1.AddToScheme(kubeClient.Scheme()); err != nil {
+		return err
+	}
+
+	searchStatus := &hiveinternalv1alpha1.ClusterSync{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cdName,
+			Namespace: claimLinkNamespace,
+		},
+	}
+	foundStatus := &hiveinternalv1alpha1.ClusterSync{}
+	isSSSynced := false
+	for range SyncMaxRetries {
+		if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(searchStatus), foundStatus); err != nil {
+			return err
+		}
+
+		for _, status := range foundStatus.Status.SyncSets {
+			if status.Name == syncSetName && status.FirstSuccessTime != nil {
+				isSSSynced = true
+				break
+			}
+		}
+
+		if isSSSynced {
+			fmt.Fprintf(out, "\nSync completed...\n")
+			break
+		}
+
+		fmt.Fprintf(out, ".")
+		time.Sleep(SyncPollInterval)
+	}
+	if !isSSSynced {
+		return fmt.Errorf("syncset failed to sync. Please verify")
+	}
+
+	// Clean up the SyncSet
+	return kubeClient.Delete(ctx, syncSet)
+}
+
+// rotateCcsAdminCredentials rotates the osdCcsAdmin IAM user credentials
+// if the account is CCS (BYOC).
+func rotateCcsAdminCredentials(ctx context.Context, awsClient awsprovider.Client, kubeClient client.Client, account *awsv1alpha1.Account, out io.Writer) error {
+	if !account.Spec.BYOC {
+		fmt.Fprintln(out, "Account is not CCS, skipping osdCcsAdmin credential rotation")
+		return nil
+	}
+
+	createAccessKeyOutput, err := awsClient.CreateAccessKey(&iam.CreateAccessKeyInput{
+		UserName: awsSdk.String("osdCcsAdmin"),
+	})
+	if err != nil {
+		return err
+	}
+
+	newSecretData := map[string][]byte{
+		"aws_user_name":         []byte(*createAccessKeyOutput.AccessKey.UserName),
+		"aws_access_key_id":     []byte(*createAccessKeyOutput.AccessKey.AccessKeyId),
+		"aws_secret_access_key": []byte(*createAccessKeyOutput.AccessKey.SecretAccessKey),
+	}
+
+	if err := updateSecret(ctx, kubeClient, "byoc", account.Spec.ClaimLinkNamespace, newSecretData); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out, "Successfully rotated secrets for osdCcsAdmin")
+	return nil
+}

--- a/pkg/controller/rotatesecret.go
+++ b/pkg/controller/rotatesecret.go
@@ -85,7 +85,7 @@ func RotateSecret(ctx context.Context, input *RotateSecretInput) error {
 	account := input.Account
 
 	if account.Spec.ManualSTSMode {
-		return fmt.Errorf("Account %s is STS - No IAM User Credentials to Rotate", input.AccountCRName)
+		return fmt.Errorf("account %s is STS - No IAM User Credentials to Rotate", input.AccountCRName)
 	}
 
 	accountID := account.Spec.AwsAccountID
@@ -312,9 +312,9 @@ func syncCredentialsToCluster(ctx context.Context, kubeClient client.Client, cla
 	}
 
 	if len(clusterDeployments.Items) == 0 {
-		return fmt.Errorf("failed to retreive cluster deployments")
+		return fmt.Errorf("failed to retrieve cluster deployments")
 	}
-	cdName := clusterDeployments.Items[0].ObjectMeta.Name
+	cdName := clusterDeployments.Items[0].Name
 
 	syncSetName := "aws-sync"
 	syncSet := &hiveapiv1.SyncSet{

--- a/pkg/controller/rotatesecret_test.go
+++ b/pkg/controller/rotatesecret_test.go
@@ -1,0 +1,616 @@
+package controller
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	awsv1alpha1 "github.com/openshift/aws-account-operator/api/v1alpha1"
+	hiveapiv1 "github.com/openshift/hive/apis/hive/v1"
+	hiveinternalv1alpha1 "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
+	mock_aws "github.com/openshift/osdctl/pkg/provider/aws/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, awsv1alpha1.AddToScheme(s))
+	require.NoError(t, hiveapiv1.AddToScheme(s))
+	require.NoError(t, hiveinternalv1alpha1.AddToScheme(s))
+	return s
+}
+
+// testAccount returns a basic Account CR for testing.
+func testAccount(byoc bool, stsMode bool) *awsv1alpha1.Account {
+	return &awsv1alpha1.Account{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-account",
+			Namespace: awsAccountNamespace,
+			Labels:    map[string]string{"iamUserId": "abcd"},
+		},
+		Spec: awsv1alpha1.AccountSpec{
+			AwsAccountID:       "123456789012",
+			BYOC:               byoc,
+			ManualSTSMode:      stsMode,
+			ClaimLinkNamespace: "uhc-production-test",
+		},
+	}
+}
+
+// testSecrets returns the two k8s secrets that RotateSecret updates.
+func testSecrets() []runtime.Object {
+	return []runtime.Object{
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-account-secret",
+				Namespace: awsAccountNamespace,
+			},
+			Data: map[string][]byte{
+				"aws_user_name":         []byte("old-user"),
+				"aws_access_key_id":     []byte("old-key"),
+				"aws_secret_access_key": []byte("old-secret"),
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "aws",
+				Namespace: "uhc-production-test",
+			},
+			Data: map[string][]byte{
+				"aws_user_name":         []byte("old-user"),
+				"aws_access_key_id":     []byte("old-key"),
+				"aws_secret_access_key": []byte("old-secret"),
+			},
+		},
+	}
+}
+
+func testClusterDeployment() *hiveapiv1.ClusterDeployment {
+	return &hiveapiv1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cd",
+			Namespace: "uhc-production-test",
+		},
+	}
+}
+
+func testClusterSync(synced bool) *hiveinternalv1alpha1.ClusterSync {
+	cs := &hiveinternalv1alpha1.ClusterSync{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cd",
+			Namespace: "uhc-production-test",
+		},
+	}
+	if synced {
+		now := metav1.Now()
+		cs.Status.SyncSets = []hiveinternalv1alpha1.SyncStatus{
+			{
+				Name:             "aws-sync",
+				FirstSuccessTime: &now,
+			},
+		}
+	}
+	return cs
+}
+
+func mockSimulateAllAllowed(mockClient *mock_aws.MockClient) *gomock.Call {
+	return mockClient.EXPECT().
+		SimulatePrincipalPolicy(gomock.Any()).
+		Return(&iam.SimulatePrincipalPolicyOutput{
+			EvaluationResults: []iamTypes.EvaluationResult{
+				{EvalActionName: awsSdk.String("iam:CreateAccessKey"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+				{EvalActionName: awsSdk.String("iam:CreateUser"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+				{EvalActionName: awsSdk.String("iam:DeleteAccessKey"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+				{EvalActionName: awsSdk.String("iam:DeleteUser"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+				{EvalActionName: awsSdk.String("iam:DeleteUserPolicy"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+				{EvalActionName: awsSdk.String("iam:GetUser"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+				{EvalActionName: awsSdk.String("iam:GetUserPolicy"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+				{EvalActionName: awsSdk.String("iam:ListAccessKeys"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+				{EvalActionName: awsSdk.String("iam:PutUserPolicy"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+				{EvalActionName: awsSdk.String("iam:TagUser"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+			},
+		}, nil)
+}
+
+func mockCreateAccessKey(mockClient *mock_aws.MockClient, username string) *gomock.Call {
+	return mockClient.EXPECT().
+		CreateAccessKey(gomock.Any()).
+		DoAndReturn(func(input *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
+			return &iam.CreateAccessKeyOutput{
+				AccessKey: &iamTypes.AccessKey{
+					UserName:        input.UserName,
+					AccessKeyId:     awsSdk.String("NEWKEY123"),
+					SecretAccessKey: awsSdk.String("NEWSECRET456"),
+				},
+			}, nil
+		})
+}
+
+func TestRotateSecret_STSAccount(t *testing.T) {
+	account := testAccount(false, true)
+	out := &bytes.Buffer{}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_aws.NewMockClient(ctrl)
+
+	kubeCli := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	err := RotateSecret(context.Background(), &RotateSecretInput{
+		AccountCRName:  "test-account",
+		Account:        account,
+		AwsClient:      mockClient,
+		HiveKubeClient: kubeCli,
+		Out:            out,
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "STS - No IAM User Credentials to Rotate")
+}
+
+func TestRotateSecret_MissingIamUserIdLabel(t *testing.T) {
+	account := testAccount(false, false)
+	delete(account.Labels, "iamUserId")
+
+	out := &bytes.Buffer{}
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_aws.NewMockClient(ctrl)
+
+	kubeCli := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
+
+	err := RotateSecret(context.Background(), &RotateSecretInput{
+		AccountCRName:  "test-account",
+		Account:        account,
+		AwsClient:      mockClient,
+		HiveKubeClient: kubeCli,
+		Out:            out,
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no label on Account CR for IAM User")
+}
+
+func TestRotateSecret_SuccessfulRotation(t *testing.T) {
+	// Set fast polling for tests
+	origInterval := SyncPollInterval
+	origRetries := SyncMaxRetries
+	SyncPollInterval = 0
+	SyncMaxRetries = 1
+	defer func() {
+		SyncPollInterval = origInterval
+		SyncMaxRetries = origRetries
+	}()
+
+	account := testAccount(false, false)
+	secrets := testSecrets()
+	cd := testClusterDeployment()
+	cs := testClusterSync(true)
+
+	objs := append(secrets, account, cd, cs)
+	scheme := testScheme(t)
+	kubeCli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).WithStatusSubresource(cs).Build()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_aws.NewMockClient(ctrl)
+
+	mockSimulateAllAllowed(mockClient)
+	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+
+	out := &bytes.Buffer{}
+
+	err := RotateSecret(context.Background(), &RotateSecretInput{
+		AccountCRName:  "test-account",
+		Account:        account,
+		AwsClient:      mockClient,
+		HiveKubeClient: kubeCli,
+		Out:            out,
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, out.String(), "AWS creds updated on hive.")
+	assert.Contains(t, out.String(), "Successfully rotated secrets for osdManagedAdmin-abcd")
+}
+
+func TestRotateSecret_SuccessfulRotationWithCCS(t *testing.T) {
+	origInterval := SyncPollInterval
+	origRetries := SyncMaxRetries
+	SyncPollInterval = 0
+	SyncMaxRetries = 1
+	defer func() {
+		SyncPollInterval = origInterval
+		SyncMaxRetries = origRetries
+	}()
+
+	account := testAccount(true, false)
+	secrets := testSecrets()
+	byocSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "byoc",
+			Namespace: "uhc-production-test",
+		},
+		Data: map[string][]byte{
+			"aws_user_name":         []byte("old-ccs-user"),
+			"aws_access_key_id":     []byte("old-ccs-key"),
+			"aws_secret_access_key": []byte("old-ccs-secret"),
+		},
+	}
+	cd := testClusterDeployment()
+	cs := testClusterSync(true)
+
+	objs := append(secrets, account, cd, cs, byocSecret)
+	scheme := testScheme(t)
+	kubeCli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).WithStatusSubresource(cs).Build()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_aws.NewMockClient(ctrl)
+
+	mockSimulateAllAllowed(mockClient)
+	// First call: osdManagedAdmin key
+	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+	// Second call: osdCcsAdmin key
+	mockCreateAccessKey(mockClient, "osdCcsAdmin")
+
+	out := &bytes.Buffer{}
+
+	err := RotateSecret(context.Background(), &RotateSecretInput{
+		AccountCRName:  "test-account",
+		Account:        account,
+		UpdateCcsCreds: true,
+		AwsClient:      mockClient,
+		HiveKubeClient: kubeCli,
+		Out:            out,
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, out.String(), "Successfully rotated secrets for osdManagedAdmin-abcd")
+	assert.Contains(t, out.String(), "Successfully rotated secrets for osdCcsAdmin")
+}
+
+func TestRotateSecret_CCSFlagOnNonBYOCAccount(t *testing.T) {
+	origInterval := SyncPollInterval
+	origRetries := SyncMaxRetries
+	SyncPollInterval = 0
+	SyncMaxRetries = 1
+	defer func() {
+		SyncPollInterval = origInterval
+		SyncMaxRetries = origRetries
+	}()
+
+	account := testAccount(false, false)
+	secrets := testSecrets()
+	cd := testClusterDeployment()
+	cs := testClusterSync(true)
+
+	objs := append(secrets, account, cd, cs)
+	scheme := testScheme(t)
+	kubeCli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).WithStatusSubresource(cs).Build()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_aws.NewMockClient(ctrl)
+
+	mockSimulateAllAllowed(mockClient)
+	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+
+	out := &bytes.Buffer{}
+
+	err := RotateSecret(context.Background(), &RotateSecretInput{
+		AccountCRName:  "test-account",
+		Account:        account,
+		UpdateCcsCreds: true,
+		AwsClient:      mockClient,
+		HiveKubeClient: kubeCli,
+		Out:            out,
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, out.String(), "Account is not CCS, skipping osdCcsAdmin credential rotation")
+}
+
+func TestRotateSecret_AdminUsernameFallback(t *testing.T) {
+	origInterval := SyncPollInterval
+	origRetries := SyncMaxRetries
+	SyncPollInterval = 0
+	SyncMaxRetries = 1
+	defer func() {
+		SyncPollInterval = origInterval
+		SyncMaxRetries = origRetries
+	}()
+
+	account := testAccount(false, false)
+	secrets := testSecrets()
+	cd := testClusterDeployment()
+	cs := testClusterSync(true)
+
+	objs := append(secrets, account, cd, cs)
+	scheme := testScheme(t)
+	kubeCli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).WithStatusSubresource(cs).Build()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_aws.NewMockClient(ctrl)
+
+	// First simulate call fails (suffixed username)
+	mockClient.EXPECT().
+		SimulatePrincipalPolicy(gomock.Any()).
+		DoAndReturn(func(input *iam.SimulatePrincipalPolicyInput) (*iam.SimulatePrincipalPolicyOutput, error) {
+			if *input.PolicySourceArn == "arn:aws:iam::123456789012:user/osdManagedAdmin-abcd" {
+				return &iam.SimulatePrincipalPolicyOutput{
+					EvaluationResults: []iamTypes.EvaluationResult{
+						{EvalActionName: awsSdk.String("iam:CreateAccessKey"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeExplicitDeny},
+					},
+				}, nil
+			}
+			// Second call with unsuffixed username succeeds
+			return &iam.SimulatePrincipalPolicyOutput{
+				EvaluationResults: []iamTypes.EvaluationResult{
+					{EvalActionName: awsSdk.String("iam:CreateAccessKey"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:CreateUser"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:DeleteAccessKey"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:DeleteUser"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:DeleteUserPolicy"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:GetUser"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:GetUserPolicy"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:ListAccessKeys"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:PutUserPolicy"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:TagUser"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+				},
+			}, nil
+		}).Times(2)
+
+	mockCreateAccessKey(mockClient, "osdManagedAdmin")
+
+	out := &bytes.Buffer{}
+
+	err := RotateSecret(context.Background(), &RotateSecretInput{
+		AccountCRName:  "test-account",
+		Account:        account,
+		AwsClient:      mockClient,
+		HiveKubeClient: kubeCli,
+		Out:            out,
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, out.String(), "Permission verification failed for osdManagedAdmin-abcd, trying osdManagedAdmin...")
+	assert.Contains(t, out.String(), "Successfully rotated secrets for osdManagedAdmin")
+}
+
+func TestRotateSecret_CreateAccessKeyNoSuchEntityFallback(t *testing.T) {
+	origInterval := SyncPollInterval
+	origRetries := SyncMaxRetries
+	SyncPollInterval = 0
+	SyncMaxRetries = 1
+	defer func() {
+		SyncPollInterval = origInterval
+		SyncMaxRetries = origRetries
+	}()
+
+	account := testAccount(false, false)
+	secrets := testSecrets()
+	cd := testClusterDeployment()
+	cs := testClusterSync(true)
+
+	objs := append(secrets, account, cd, cs)
+	scheme := testScheme(t)
+	kubeCli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).WithStatusSubresource(cs).Build()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_aws.NewMockClient(ctrl)
+
+	mockSimulateAllAllowed(mockClient)
+
+	// First CreateAccessKey call fails with NoSuchEntityException
+	nse := &iamTypes.NoSuchEntityException{Message: awsSdk.String("user not found")}
+	gomock.InOrder(
+		mockClient.EXPECT().
+			CreateAccessKey(gomock.Any()).
+			Return(nil, nse),
+		mockClient.EXPECT().
+			CreateAccessKey(gomock.Any()).
+			DoAndReturn(func(input *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
+				assert.Equal(t, "osdManagedAdmin", *input.UserName)
+				return &iam.CreateAccessKeyOutput{
+					AccessKey: &iamTypes.AccessKey{
+						UserName:        input.UserName,
+						AccessKeyId:     awsSdk.String("NEWKEY123"),
+						SecretAccessKey: awsSdk.String("NEWSECRET456"),
+					},
+				}, nil
+			}),
+	)
+
+	out := &bytes.Buffer{}
+
+	err := RotateSecret(context.Background(), &RotateSecretInput{
+		AccountCRName:  "test-account",
+		Account:        account,
+		AwsClient:      mockClient,
+		HiveKubeClient: kubeCli,
+		Out:            out,
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, out.String(), "Successfully rotated secrets for osdManagedAdmin")
+}
+
+func TestRotateSecret_SyncSetTimeout(t *testing.T) {
+	origInterval := SyncPollInterval
+	origRetries := SyncMaxRetries
+	SyncPollInterval = 0
+	SyncMaxRetries = 1
+	defer func() {
+		SyncPollInterval = origInterval
+		SyncMaxRetries = origRetries
+	}()
+
+	account := testAccount(false, false)
+	secrets := testSecrets()
+	cd := testClusterDeployment()
+	// ClusterSync without successful sync status
+	cs := testClusterSync(false)
+
+	objs := append(secrets, account, cd, cs)
+	scheme := testScheme(t)
+	kubeCli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).WithStatusSubresource(cs).Build()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_aws.NewMockClient(ctrl)
+
+	mockSimulateAllAllowed(mockClient)
+	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+
+	out := &bytes.Buffer{}
+
+	err := RotateSecret(context.Background(), &RotateSecretInput{
+		AccountCRName:  "test-account",
+		Account:        account,
+		AwsClient:      mockClient,
+		HiveKubeClient: kubeCli,
+		Out:            out,
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "syncset failed to sync")
+}
+
+func TestVerifyRotationPermissions(t *testing.T) {
+	tests := []struct {
+		name           string
+		accountID      string
+		username       string
+		mockResponse   *iam.SimulatePrincipalPolicyOutput
+		mockError      error
+		expectedErr    bool
+		expectedErrMsg string
+	}{
+		{
+			name:      "all_permissions_allowed",
+			accountID: "123456789012",
+			username:  "osdManagedAdmin-test",
+			mockResponse: &iam.SimulatePrincipalPolicyOutput{
+				EvaluationResults: []iamTypes.EvaluationResult{
+					{EvalActionName: awsSdk.String("iam:CreateAccessKey"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:CreateUser"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:DeleteAccessKey"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:DeleteUser"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:DeleteUserPolicy"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:GetUser"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:GetUserPolicy"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:ListAccessKeys"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:PutUserPolicy"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:TagUser"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name:      "some_permissions_denied",
+			accountID: "123456789012",
+			username:  "osdManagedAdmin-test",
+			mockResponse: &iam.SimulatePrincipalPolicyOutput{
+				EvaluationResults: []iamTypes.EvaluationResult{
+					{EvalActionName: awsSdk.String("iam:CreateAccessKey"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeAllowed},
+					{EvalActionName: awsSdk.String("iam:CreateUser"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeExplicitDeny},
+					{EvalActionName: awsSdk.String("iam:DeleteAccessKey"), EvalDecision: iamTypes.PolicyEvaluationDecisionTypeImplicitDeny},
+				},
+			},
+			expectedErr:    true,
+			expectedErrMsg: "insufficient permissions for secret rotation. Denied actions: [iam:CreateUser iam:DeleteAccessKey]",
+		},
+		{
+			name:           "simulate_api_error",
+			accountID:      "123456789012",
+			username:       "osdManagedAdmin-test",
+			mockResponse:   nil,
+			mockError:      assert.AnError,
+			expectedErr:    true,
+			expectedErrMsg: "failed to simulate principal policy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockClient := mock_aws.NewMockClient(ctrl)
+
+			expectedArn := "arn:aws:iam::" + tt.accountID + ":user/" + tt.username
+			mockClient.EXPECT().
+				SimulatePrincipalPolicy(gomock.Any()).
+				DoAndReturn(func(input *iam.SimulatePrincipalPolicyInput) (*iam.SimulatePrincipalPolicyOutput, error) {
+					assert.Equal(t, expectedArn, *input.PolicySourceArn)
+					assert.Len(t, input.ActionNames, 10)
+					return tt.mockResponse, tt.mockError
+				}).
+				Times(1)
+
+			out := &bytes.Buffer{}
+			err := VerifyRotationPermissions(out, mockClient, tt.accountID, tt.username)
+
+			if tt.expectedErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRotateSecret_ExplicitAdminUsername(t *testing.T) {
+	origInterval := SyncPollInterval
+	origRetries := SyncMaxRetries
+	SyncPollInterval = 0
+	SyncMaxRetries = 1
+	defer func() {
+		SyncPollInterval = origInterval
+		SyncMaxRetries = origRetries
+	}()
+
+	account := testAccount(false, false)
+	secrets := testSecrets()
+	cd := testClusterDeployment()
+	cs := testClusterSync(true)
+
+	objs := append(secrets, account, cd, cs)
+	scheme := testScheme(t)
+	kubeCli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).WithStatusSubresource(cs).Build()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_aws.NewMockClient(ctrl)
+
+	mockSimulateAllAllowed(mockClient)
+	mockCreateAccessKey(mockClient, "osdManagedAdmin-custom")
+
+	out := &bytes.Buffer{}
+
+	err := RotateSecret(context.Background(), &RotateSecretInput{
+		AccountCRName:           "test-account",
+		Account:                 account,
+		OsdManagedAdminUsername: "osdManagedAdmin-custom",
+		AwsClient:               mockClient,
+		HiveKubeClient:          kubeCli,
+		Out:                     out,
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, out.String(), "Successfully rotated secrets for osdManagedAdmin-custom")
+}

--- a/pkg/controller/rotatesecret_test.go
+++ b/pkg/controller/rotatesecret_test.go
@@ -3,12 +3,14 @@ package controller
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
 
 	awsSdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	awsv1alpha1 "github.com/openshift/aws-account-operator/api/v1alpha1"
+	ccov1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	hiveapiv1 "github.com/openshift/hive/apis/hive/v1"
 	hiveinternalv1alpha1 "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
 	mock_aws "github.com/openshift/osdctl/pkg/provider/aws/mock"
@@ -18,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -28,6 +31,7 @@ func testScheme(t *testing.T) *runtime.Scheme {
 	require.NoError(t, awsv1alpha1.AddToScheme(s))
 	require.NoError(t, hiveapiv1.AddToScheme(s))
 	require.NoError(t, hiveinternalv1alpha1.AddToScheme(s))
+	require.NoError(t, ccov1.AddToScheme(s))
 	return s
 }
 
@@ -104,6 +108,13 @@ func testClusterSync(synced bool) *hiveinternalv1alpha1.ClusterSync {
 	return cs
 }
 
+// testManagedClient creates a fake managed cluster client with optional
+// CredentialRequest objects pre-seeded.
+func testManagedClient(t *testing.T, crs ...runtime.Object) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().WithScheme(testScheme(t)).WithRuntimeObjects(crs...).Build()
+}
+
 func mockSimulateAllAllowed(mockClient *mock_aws.MockClient) *gomock.Call {
 	return mockClient.EXPECT().
 		SimulatePrincipalPolicy(gomock.Any()).
@@ -148,11 +159,12 @@ func TestRotateSecret_STSAccount(t *testing.T) {
 	kubeCli := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
 
 	err := RotateSecret(context.Background(), &RotateSecretInput{
-		AccountCRName:  "test-account",
-		Account:        account,
-		AwsClient:      mockClient,
-		HiveKubeClient: kubeCli,
-		Out:            out,
+		AccountCRName:        "test-account",
+		Account:              account,
+		AwsClient:            mockClient,
+		HiveKubeClient:       kubeCli,
+		ManagedClusterClient: testManagedClient(t),
+		Out:                  out,
 	})
 
 	assert.Error(t, err)
@@ -171,11 +183,12 @@ func TestRotateSecret_MissingIamUserIdLabel(t *testing.T) {
 	kubeCli := fake.NewClientBuilder().WithScheme(testScheme(t)).Build()
 
 	err := RotateSecret(context.Background(), &RotateSecretInput{
-		AccountCRName:  "test-account",
-		Account:        account,
-		AwsClient:      mockClient,
-		HiveKubeClient: kubeCli,
-		Out:            out,
+		AccountCRName:        "test-account",
+		Account:              account,
+		AwsClient:            mockClient,
+		HiveKubeClient:       kubeCli,
+		ManagedClusterClient: testManagedClient(t),
+		Out:                  out,
 	})
 
 	assert.Error(t, err)
@@ -212,11 +225,12 @@ func TestRotateSecret_SuccessfulRotation(t *testing.T) {
 	out := &bytes.Buffer{}
 
 	err := RotateSecret(context.Background(), &RotateSecretInput{
-		AccountCRName:  "test-account",
-		Account:        account,
-		AwsClient:      mockClient,
-		HiveKubeClient: kubeCli,
-		Out:            out,
+		AccountCRName:        "test-account",
+		Account:              account,
+		AwsClient:            mockClient,
+		HiveKubeClient:       kubeCli,
+		ManagedClusterClient: testManagedClient(t),
+		Out:                  out,
 	})
 
 	assert.NoError(t, err)
@@ -267,12 +281,13 @@ func TestRotateSecret_SuccessfulRotationWithCCS(t *testing.T) {
 	out := &bytes.Buffer{}
 
 	err := RotateSecret(context.Background(), &RotateSecretInput{
-		AccountCRName:  "test-account",
-		Account:        account,
-		UpdateCcsCreds: true,
-		AwsClient:      mockClient,
-		HiveKubeClient: kubeCli,
-		Out:            out,
+		AccountCRName:        "test-account",
+		Account:              account,
+		UpdateCcsCreds:       true,
+		AwsClient:            mockClient,
+		HiveKubeClient:       kubeCli,
+		ManagedClusterClient: testManagedClient(t),
+		Out:                  out,
 	})
 
 	assert.NoError(t, err)
@@ -309,12 +324,13 @@ func TestRotateSecret_CCSFlagOnNonBYOCAccount(t *testing.T) {
 	out := &bytes.Buffer{}
 
 	err := RotateSecret(context.Background(), &RotateSecretInput{
-		AccountCRName:  "test-account",
-		Account:        account,
-		UpdateCcsCreds: true,
-		AwsClient:      mockClient,
-		HiveKubeClient: kubeCli,
-		Out:            out,
+		AccountCRName:        "test-account",
+		Account:              account,
+		UpdateCcsCreds:       true,
+		AwsClient:            mockClient,
+		HiveKubeClient:       kubeCli,
+		ManagedClusterClient: testManagedClient(t),
+		Out:                  out,
 	})
 
 	assert.NoError(t, err)
@@ -377,11 +393,12 @@ func TestRotateSecret_AdminUsernameFallback(t *testing.T) {
 	out := &bytes.Buffer{}
 
 	err := RotateSecret(context.Background(), &RotateSecretInput{
-		AccountCRName:  "test-account",
-		Account:        account,
-		AwsClient:      mockClient,
-		HiveKubeClient: kubeCli,
-		Out:            out,
+		AccountCRName:        "test-account",
+		Account:              account,
+		AwsClient:            mockClient,
+		HiveKubeClient:       kubeCli,
+		ManagedClusterClient: testManagedClient(t),
+		Out:                  out,
 	})
 
 	assert.NoError(t, err)
@@ -437,11 +454,12 @@ func TestRotateSecret_CreateAccessKeyNoSuchEntityFallback(t *testing.T) {
 	out := &bytes.Buffer{}
 
 	err := RotateSecret(context.Background(), &RotateSecretInput{
-		AccountCRName:  "test-account",
-		Account:        account,
-		AwsClient:      mockClient,
-		HiveKubeClient: kubeCli,
-		Out:            out,
+		AccountCRName:        "test-account",
+		Account:              account,
+		AwsClient:            mockClient,
+		HiveKubeClient:       kubeCli,
+		ManagedClusterClient: testManagedClient(t),
+		Out:                  out,
 	})
 
 	assert.NoError(t, err)
@@ -478,11 +496,12 @@ func TestRotateSecret_SyncSetTimeout(t *testing.T) {
 	out := &bytes.Buffer{}
 
 	err := RotateSecret(context.Background(), &RotateSecretInput{
-		AccountCRName:  "test-account",
-		Account:        account,
-		AwsClient:      mockClient,
-		HiveKubeClient: kubeCli,
-		Out:            out,
+		AccountCRName:        "test-account",
+		Account:              account,
+		AwsClient:            mockClient,
+		HiveKubeClient:       kubeCli,
+		ManagedClusterClient: testManagedClient(t),
+		Out:                  out,
 	})
 
 	assert.Error(t, err)
@@ -608,9 +627,234 @@ func TestRotateSecret_ExplicitAdminUsername(t *testing.T) {
 		OsdManagedAdminUsername: "osdManagedAdmin-custom",
 		AwsClient:               mockClient,
 		HiveKubeClient:          kubeCli,
+		ManagedClusterClient:    testManagedClient(t),
 		Out:                     out,
 	})
 
 	assert.NoError(t, err)
 	assert.Contains(t, out.String(), "Successfully rotated secrets for osdManagedAdmin-custom")
+}
+
+func TestRotateSecret_DryRun(t *testing.T) {
+	account := testAccount(false, false)
+	secrets := testSecrets()
+
+	objs := append(secrets, account)
+	scheme := testScheme(t)
+	kubeCli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_aws.NewMockClient(ctrl)
+
+	// Only SimulatePrincipalPolicy should be called (read-only validation).
+	// No CreateAccessKey calls should happen.
+	mockSimulateAllAllowed(mockClient)
+
+	crIngress := &ccov1.CredentialsRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openshift-ingress",
+			Namespace: credentialRequestNamespace,
+		},
+		Spec: ccov1.CredentialsRequestSpec{
+			SecretRef:    corev1.ObjectReference{Name: "ingress-creds", Namespace: "openshift-ingress-operator"},
+			ProviderSpec: awsProviderSpec(t),
+		},
+	}
+	crCustom := &ccov1.CredentialsRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "custom-cr",
+			Namespace: credentialRequestNamespace,
+		},
+		Spec: ccov1.CredentialsRequestSpec{
+			SecretRef:    corev1.ObjectReference{Name: "custom-creds", Namespace: "custom-ns"},
+			ProviderSpec: awsProviderSpec(t),
+		},
+	}
+	managedClient := testManagedClient(t, crIngress, crCustom)
+
+	out := &bytes.Buffer{}
+
+	err := RotateSecret(context.Background(), &RotateSecretInput{
+		AccountCRName:        "test-account",
+		Account:              account,
+		DryRun:               true,
+		AwsClient:            mockClient,
+		HiveKubeClient:       kubeCli,
+		ManagedClusterClient: managedClient,
+		Out:                  out,
+	})
+
+	assert.NoError(t, err)
+	output := out.String()
+	assert.Contains(t, output, "[Dry Run] Would create a new IAM access key for user: osdManagedAdmin-abcd")
+	assert.Contains(t, output, "[Dry Run] Would update secret aws-account-operator/test-account-secret")
+	assert.Contains(t, output, "[Dry Run] Would update secret uhc-production-test/aws")
+	assert.Contains(t, output, "[Dry Run] Would create SyncSet")
+	assert.Contains(t, output, "[Dry Run] Would delete secret openshift-ingress-operator/ingress-creds (referenced by CredentialRequest openshift-ingress)")
+	assert.NotContains(t, output, "custom-creds")
+	assert.Contains(t, output, "[Dry Run] Would delete 1 credential secret(s) total")
+	assert.Contains(t, output, "[Dry Run] No changes were made.")
+
+	// Verify secrets were NOT modified
+	secret := &corev1.Secret{}
+	err = kubeCli.Get(context.Background(), types.NamespacedName{Name: "test-account-secret", Namespace: awsAccountNamespace}, secret)
+	assert.NoError(t, err)
+	assert.Equal(t, "old-key", string(secret.Data["aws_access_key_id"]))
+}
+
+func TestRotateSecret_DryRunWithCCS(t *testing.T) {
+	account := testAccount(true, false)
+	secrets := testSecrets()
+
+	objs := append(secrets, account)
+	scheme := testScheme(t)
+	kubeCli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_aws.NewMockClient(ctrl)
+
+	mockSimulateAllAllowed(mockClient)
+
+	managedClient := testManagedClient(t)
+
+	out := &bytes.Buffer{}
+
+	err := RotateSecret(context.Background(), &RotateSecretInput{
+		AccountCRName:        "test-account",
+		Account:              account,
+		DryRun:               true,
+		UpdateCcsCreds:       true,
+		AwsClient:            mockClient,
+		HiveKubeClient:       kubeCli,
+		ManagedClusterClient: managedClient,
+		Out:                  out,
+	})
+
+	assert.NoError(t, err)
+	output := out.String()
+	assert.Contains(t, output, "[Dry Run] Would create a new IAM access key for user: osdCcsAdmin")
+	assert.Contains(t, output, "[Dry Run] Would update secret uhc-production-test/byoc")
+	assert.Contains(t, output, "[Dry Run] No changes were made.")
+}
+
+func awsProviderSpec(t *testing.T) *runtime.RawExtension {
+	t.Helper()
+	raw, err := json.Marshal(map[string]string{"kind": "AWSProviderSpec"})
+	require.NoError(t, err)
+	return &runtime.RawExtension{Raw: raw}
+}
+
+func gcpProviderSpec(t *testing.T) *runtime.RawExtension {
+	t.Helper()
+	raw, err := json.Marshal(map[string]string{"kind": "GCPProviderSpec"})
+	require.NoError(t, err)
+	return &runtime.RawExtension{Raw: raw}
+}
+
+func TestRotateSecret_CredentialSecretDeletion(t *testing.T) {
+	origInterval := SyncPollInterval
+	origRetries := SyncMaxRetries
+	SyncPollInterval = 0
+	SyncMaxRetries = 1
+	defer func() {
+		SyncPollInterval = origInterval
+		SyncMaxRetries = origRetries
+	}()
+
+	account := testAccount(false, false)
+	secrets := testSecrets()
+	cd := testClusterDeployment()
+	cs := testClusterSync(true)
+
+	objs := append(secrets, account, cd, cs)
+	scheme := testScheme(t)
+	kubeCli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).WithStatusSubresource(cs).Build()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_aws.NewMockClient(ctrl)
+
+	mockSimulateAllAllowed(mockClient)
+	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+
+	// Two AWS CredentialRequests with "openshift-" prefix → their secrets should be deleted.
+	// One non-AWS CR with "openshift-" prefix → its secret should be kept.
+	// One CR without the prefix → its secret should be kept.
+	ingressSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "ingress-creds", Namespace: "openshift-ingress-operator"},
+	}
+	machineAPISecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "machine-api-creds", Namespace: "openshift-machine-api"},
+	}
+	gcpSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "gcp-creds", Namespace: "openshift-gcp"},
+	}
+	customSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "custom-creds", Namespace: "custom-ns"},
+	}
+
+	crIngress := &ccov1.CredentialsRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "openshift-ingress", Namespace: credentialRequestNamespace},
+		Spec: ccov1.CredentialsRequestSpec{
+			SecretRef:    corev1.ObjectReference{Name: "ingress-creds", Namespace: "openshift-ingress-operator"},
+			ProviderSpec: awsProviderSpec(t),
+		},
+	}
+	crMachineAPI := &ccov1.CredentialsRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "openshift-machine-api", Namespace: credentialRequestNamespace},
+		Spec: ccov1.CredentialsRequestSpec{
+			SecretRef:    corev1.ObjectReference{Name: "machine-api-creds", Namespace: "openshift-machine-api"},
+			ProviderSpec: awsProviderSpec(t),
+		},
+	}
+	crGCP := &ccov1.CredentialsRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "openshift-gcp-thing", Namespace: credentialRequestNamespace},
+		Spec: ccov1.CredentialsRequestSpec{
+			SecretRef:    corev1.ObjectReference{Name: "gcp-creds", Namespace: "openshift-gcp"},
+			ProviderSpec: gcpProviderSpec(t),
+		},
+	}
+	crCustom := &ccov1.CredentialsRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "custom-cr", Namespace: credentialRequestNamespace},
+		Spec: ccov1.CredentialsRequestSpec{
+			SecretRef:    corev1.ObjectReference{Name: "custom-creds", Namespace: "custom-ns"},
+			ProviderSpec: awsProviderSpec(t),
+		},
+	}
+
+	managedClient := testManagedClient(t,
+		ingressSecret, machineAPISecret, gcpSecret, customSecret,
+		crIngress, crMachineAPI, crGCP, crCustom,
+	)
+
+	out := &bytes.Buffer{}
+
+	err := RotateSecret(context.Background(), &RotateSecretInput{
+		AccountCRName:        "test-account",
+		Account:              account,
+		AwsClient:            mockClient,
+		HiveKubeClient:       kubeCli,
+		ManagedClusterClient: managedClient,
+		Out:                  out,
+	})
+
+	assert.NoError(t, err)
+	output := out.String()
+	assert.Contains(t, output, "Deleted secret openshift-ingress-operator/ingress-creds")
+	assert.Contains(t, output, "Deleted secret openshift-machine-api/machine-api-creds")
+	assert.NotContains(t, output, "gcp-creds")
+	assert.NotContains(t, output, "custom-creds")
+	assert.Contains(t, output, "Deleted 2 credential secret(s)")
+
+	// Verify that the GCP and custom secrets still exist
+	s := &corev1.Secret{}
+	assert.NoError(t, managedClient.Get(context.Background(), types.NamespacedName{Name: "gcp-creds", Namespace: "openshift-gcp"}, s))
+	assert.NoError(t, managedClient.Get(context.Background(), types.NamespacedName{Name: "custom-creds", Namespace: "custom-ns"}, s))
+
+	// Verify all CredentialRequests still exist (they should not be deleted)
+	remaining := &ccov1.CredentialsRequestList{}
+	assert.NoError(t, managedClient.List(context.Background(), remaining, client.InNamespace(credentialRequestNamespace)))
+	assert.Len(t, remaining.Items, 4)
 }

--- a/pkg/controller/rotatesecret_test.go
+++ b/pkg/controller/rotatesecret_test.go
@@ -530,6 +530,61 @@ func TestRotateSecret_SyncSetTimeout(t *testing.T) {
 	assert.Contains(t, err.Error(), "syncset failed to sync")
 }
 
+func TestRotateSecret_StaleSyncSetIsUpdated(t *testing.T) {
+	origInterval := SyncPollInterval
+	origRetries := SyncMaxRetries
+	SyncPollInterval = 0
+	SyncMaxRetries = 1
+	defer func() {
+		SyncPollInterval = origInterval
+		SyncMaxRetries = origRetries
+	}()
+
+	account := testAccount(false, false)
+	secrets := testSecrets()
+	cd := testClusterDeployment()
+	cs := testClusterSync(true)
+
+	// Pre-seed a stale SyncSet left behind by a previous run.
+	staleSyncSet := &hiveapiv1.SyncSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-sync",
+			Namespace: "uhc-production-test",
+		},
+		Spec: hiveapiv1.SyncSetSpec{
+			ClusterDeploymentRefs: []corev1.LocalObjectReference{
+				{Name: "old-cd"},
+			},
+		},
+	}
+
+	objs := append(secrets, account, cd, cs, staleSyncSet)
+	scheme := testScheme(t)
+	kubeCli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).WithStatusSubresource(cs).Build()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := mock_aws.NewMockClient(ctrl)
+
+	mockSimulateAllAllowed(mockClient)
+	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
+
+	out := &bytes.Buffer{}
+
+	err := RotateSecret(context.Background(), &RotateSecretInput{
+		AccountCRName:        "test-account",
+		Account:              account,
+		AwsClient:            mockClient,
+		HiveKubeClient:       kubeCli,
+		ManagedClusterClient: testManagedClient(t),
+		Out:                  out,
+	})
+
+	assert.NoError(t, err)
+	assert.Contains(t, out.String(), "Successfully rotated secrets for osdManagedAdmin-abcd")
+}
+
 func TestVerifyRotationPermissions(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/controller/rotatesecret_test.go
+++ b/pkg/controller/rotatesecret_test.go
@@ -135,7 +135,7 @@ func mockSimulateAllAllowed(mockClient *mock_aws.MockClient) *gomock.Call {
 		}, nil)
 }
 
-func mockCreateAccessKey(mockClient *mock_aws.MockClient, username string) *gomock.Call {
+func mockCreateAccessKey(mockClient *mock_aws.MockClient) *gomock.Call {
 	return mockClient.EXPECT().
 		CreateAccessKey(gomock.Any()).
 		DoAndReturn(func(input *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
@@ -232,7 +232,7 @@ func TestRotateSecret_SuccessfulRotation(t *testing.T) {
 	mockClient := mock_aws.NewMockClient(ctrl)
 
 	mockSimulateAllAllowed(mockClient)
-	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+	mockCreateAccessKey(mockClient)
 	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 
 	out := &bytes.Buffer{}
@@ -248,7 +248,7 @@ func TestRotateSecret_SuccessfulRotation(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Contains(t, out.String(), "AWS creds updated on hive.")
-	assert.Contains(t, out.String(), "Successfully rotated secrets for osdManagedAdmin-abcd")
+	assert.Contains(t, out.String(), "Successfully rotated access keys for osdManagedAdmin-abcd")
 	assert.Contains(t, out.String(), "OLDKEY999 (old - should be removed)")
 	assert.Contains(t, out.String(), "NEWKEY123 (new - just created)")
 	assert.Contains(t, out.String(), "rh-aws-saml-login")
@@ -290,10 +290,10 @@ func TestRotateSecret_SuccessfulRotationWithCCS(t *testing.T) {
 
 	mockSimulateAllAllowed(mockClient)
 	// First call: osdManagedAdmin key
-	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+	mockCreateAccessKey(mockClient)
 	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 	// Second call: osdCcsAdmin key
-	mockCreateAccessKey(mockClient, "osdCcsAdmin")
+	mockCreateAccessKey(mockClient)
 	mockListAccessKeys(mockClient, "OLDCCSKEY", "NEWKEY123")
 
 	out := &bytes.Buffer{}
@@ -309,7 +309,7 @@ func TestRotateSecret_SuccessfulRotationWithCCS(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	assert.Contains(t, out.String(), "Successfully rotated secrets for osdManagedAdmin-abcd")
+	assert.Contains(t, out.String(), "Successfully rotated access keys for osdManagedAdmin-abcd")
 	assert.Contains(t, out.String(), "Successfully rotated secrets for osdCcsAdmin")
 }
 
@@ -337,7 +337,7 @@ func TestRotateSecret_CCSFlagOnNonBYOCAccount(t *testing.T) {
 	mockClient := mock_aws.NewMockClient(ctrl)
 
 	mockSimulateAllAllowed(mockClient)
-	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+	mockCreateAccessKey(mockClient)
 	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 
 	out := &bytes.Buffer{}
@@ -407,7 +407,7 @@ func TestRotateSecret_AdminUsernameFallback(t *testing.T) {
 			}, nil
 		}).Times(2)
 
-	mockCreateAccessKey(mockClient, "osdManagedAdmin")
+	mockCreateAccessKey(mockClient)
 	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 
 	out := &bytes.Buffer{}
@@ -423,7 +423,7 @@ func TestRotateSecret_AdminUsernameFallback(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Contains(t, out.String(), "Permission verification failed for osdManagedAdmin-abcd, trying osdManagedAdmin...")
-	assert.Contains(t, out.String(), "Successfully rotated secrets for osdManagedAdmin")
+	assert.Contains(t, out.String(), "Successfully rotated access keys for osdManagedAdmin")
 }
 
 func TestRotateSecret_CreateAccessKeyNoSuchEntityFallback(t *testing.T) {
@@ -449,6 +449,9 @@ func TestRotateSecret_CreateAccessKeyNoSuchEntityFallback(t *testing.T) {
 	defer ctrl.Finish()
 	mockClient := mock_aws.NewMockClient(ctrl)
 
+	// First SimulatePrincipalPolicy for the suffixed user (passes),
+	// second for the unsuffixed fallback user after CreateAccessKey returns NoSuchEntityException.
+	mockSimulateAllAllowed(mockClient)
 	mockSimulateAllAllowed(mockClient)
 
 	// First CreateAccessKey call fails with NoSuchEntityException
@@ -484,7 +487,7 @@ func TestRotateSecret_CreateAccessKeyNoSuchEntityFallback(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	assert.Contains(t, out.String(), "Successfully rotated secrets for osdManagedAdmin")
+	assert.Contains(t, out.String(), "Successfully rotated access keys for osdManagedAdmin")
 }
 
 func TestRotateSecret_SyncSetTimeout(t *testing.T) {
@@ -512,7 +515,7 @@ func TestRotateSecret_SyncSetTimeout(t *testing.T) {
 	mockClient := mock_aws.NewMockClient(ctrl)
 
 	mockSimulateAllAllowed(mockClient)
-	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+	mockCreateAccessKey(mockClient)
 	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 
 	out := &bytes.Buffer{}
@@ -567,7 +570,7 @@ func TestRotateSecret_StaleSyncSetIsUpdated(t *testing.T) {
 	mockClient := mock_aws.NewMockClient(ctrl)
 
 	mockSimulateAllAllowed(mockClient)
-	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+	mockCreateAccessKey(mockClient)
 	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 
 	out := &bytes.Buffer{}
@@ -582,7 +585,7 @@ func TestRotateSecret_StaleSyncSetIsUpdated(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	assert.Contains(t, out.String(), "Successfully rotated secrets for osdManagedAdmin-abcd")
+	assert.Contains(t, out.String(), "Successfully rotated access keys for osdManagedAdmin-abcd")
 }
 
 func TestVerifyRotationPermissions(t *testing.T) {
@@ -694,7 +697,7 @@ func TestRotateSecret_ExplicitAdminUsername(t *testing.T) {
 	mockClient := mock_aws.NewMockClient(ctrl)
 
 	mockSimulateAllAllowed(mockClient)
-	mockCreateAccessKey(mockClient, "osdManagedAdmin-custom")
+	mockCreateAccessKey(mockClient)
 	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 
 	out := &bytes.Buffer{}
@@ -710,7 +713,7 @@ func TestRotateSecret_ExplicitAdminUsername(t *testing.T) {
 	})
 
 	assert.NoError(t, err)
-	assert.Contains(t, out.String(), "Successfully rotated secrets for osdManagedAdmin-custom")
+	assert.Contains(t, out.String(), "Successfully rotated access keys for osdManagedAdmin-custom")
 }
 
 func TestRotateSecret_DryRun(t *testing.T) {
@@ -855,7 +858,7 @@ func TestRotateSecret_CredentialSecretDeletion(t *testing.T) {
 	mockClient := mock_aws.NewMockClient(ctrl)
 
 	mockSimulateAllAllowed(mockClient)
-	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+	mockCreateAccessKey(mockClient)
 	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 
 	// Two AWS CredentialRequests with "openshift-" prefix → their secrets should be deleted.

--- a/pkg/controller/rotatesecret_test.go
+++ b/pkg/controller/rotatesecret_test.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -148,6 +149,17 @@ func mockCreateAccessKey(mockClient *mock_aws.MockClient, username string) *gomo
 		})
 }
 
+func mockListAccessKeys(mockClient *mock_aws.MockClient, oldKeyID, newKeyID string) *gomock.Call {
+	return mockClient.EXPECT().
+		ListAccessKeys(gomock.Any()).
+		Return(&iam.ListAccessKeysOutput{
+			AccessKeyMetadata: []iamTypes.AccessKeyMetadata{
+				{AccessKeyId: awsSdk.String(oldKeyID)},
+				{AccessKeyId: awsSdk.String(newKeyID)},
+			},
+		}, nil)
+}
+
 func TestRotateSecret_STSAccount(t *testing.T) {
 	account := testAccount(false, true)
 	out := &bytes.Buffer{}
@@ -221,6 +233,7 @@ func TestRotateSecret_SuccessfulRotation(t *testing.T) {
 
 	mockSimulateAllAllowed(mockClient)
 	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 
 	out := &bytes.Buffer{}
 
@@ -236,6 +249,9 @@ func TestRotateSecret_SuccessfulRotation(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, out.String(), "AWS creds updated on hive.")
 	assert.Contains(t, out.String(), "Successfully rotated secrets for osdManagedAdmin-abcd")
+	assert.Contains(t, out.String(), "OLDKEY999 (old - should be removed)")
+	assert.Contains(t, out.String(), "NEWKEY123 (new - just created)")
+	assert.Contains(t, out.String(), "rh-aws-saml-login")
 }
 
 func TestRotateSecret_SuccessfulRotationWithCCS(t *testing.T) {
@@ -275,8 +291,10 @@ func TestRotateSecret_SuccessfulRotationWithCCS(t *testing.T) {
 	mockSimulateAllAllowed(mockClient)
 	// First call: osdManagedAdmin key
 	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 	// Second call: osdCcsAdmin key
 	mockCreateAccessKey(mockClient, "osdCcsAdmin")
+	mockListAccessKeys(mockClient, "OLDCCSKEY", "NEWKEY123")
 
 	out := &bytes.Buffer{}
 
@@ -320,6 +338,7 @@ func TestRotateSecret_CCSFlagOnNonBYOCAccount(t *testing.T) {
 
 	mockSimulateAllAllowed(mockClient)
 	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 
 	out := &bytes.Buffer{}
 
@@ -389,6 +408,7 @@ func TestRotateSecret_AdminUsernameFallback(t *testing.T) {
 		}).Times(2)
 
 	mockCreateAccessKey(mockClient, "osdManagedAdmin")
+	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 
 	out := &bytes.Buffer{}
 
@@ -450,6 +470,7 @@ func TestRotateSecret_CreateAccessKeyNoSuchEntityFallback(t *testing.T) {
 				}, nil
 			}),
 	)
+	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 
 	out := &bytes.Buffer{}
 
@@ -492,6 +513,7 @@ func TestRotateSecret_SyncSetTimeout(t *testing.T) {
 
 	mockSimulateAllAllowed(mockClient)
 	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 
 	out := &bytes.Buffer{}
 
@@ -618,6 +640,7 @@ func TestRotateSecret_ExplicitAdminUsername(t *testing.T) {
 
 	mockSimulateAllAllowed(mockClient)
 	mockCreateAccessKey(mockClient, "osdManagedAdmin-custom")
+	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 
 	out := &bytes.Buffer{}
 
@@ -778,6 +801,7 @@ func TestRotateSecret_CredentialSecretDeletion(t *testing.T) {
 
 	mockSimulateAllAllowed(mockClient)
 	mockCreateAccessKey(mockClient, "osdManagedAdmin-abcd")
+	mockListAccessKeys(mockClient, "OLDKEY999", "NEWKEY123")
 
 	// Two AWS CredentialRequests with "openshift-" prefix → their secrets should be deleted.
 	// One non-AWS CR with "openshift-" prefix → its secret should be kept.

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -84,6 +84,7 @@ type Client interface {
 	ListRoles(*iam.ListRolesInput) (*iam.ListRolesOutput, error)
 	DeleteRole(*iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error)
 	DeleteUser(*iam.DeleteUserInput) (*iam.DeleteUserOutput, error)
+	SimulatePrincipalPolicy(*iam.SimulatePrincipalPolicyInput) (*iam.SimulatePrincipalPolicyOutput, error)
 
 	//ec2
 	DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
@@ -397,6 +398,10 @@ func (c *AwsClient) DeleteRole(input *iam.DeleteRoleInput) (*iam.DeleteRoleOutpu
 
 func (c *AwsClient) DeleteUser(input *iam.DeleteUserInput) (*iam.DeleteUserOutput, error) {
 	return c.iamClient.DeleteUser(context.TODO(), input)
+}
+
+func (c *AwsClient) SimulatePrincipalPolicy(input *iam.SimulatePrincipalPolicyInput) (*iam.SimulatePrincipalPolicyOutput, error) {
+	return c.iamClient.SimulatePrincipalPolicy(context.TODO(), input)
 }
 
 func (c *AwsClient) ListAccounts(input *organizations.ListAccountsInput) (*organizations.ListAccountsOutput, error) {

--- a/pkg/provider/aws/client.go
+++ b/pkg/provider/aws/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/servicequotas"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/openshift/osdctl/pkg/osdctlConfig"
 	"github.com/spf13/viper"
 )
 
@@ -158,6 +159,7 @@ func addProxyConfigToSessionOptConfig(config *aws.Config) {
 		return
 	}
 
+	_ = osdctlConfig.EnsureConfigFile()
 	awsProxyUrl := viper.GetString(ProxyConfigKey)
 	if awsProxyUrl == "" {
 		_, _ = fmt.Fprintf(os.Stderr, "[ERROR] `%s` not configured. Please add this to your osdctl configuration to ensure traffic is routed though a proxy.\n", ProxyConfigKey)

--- a/pkg/provider/aws/mock/client.go
+++ b/pkg/provider/aws/mock/client.go
@@ -1041,6 +1041,21 @@ func (mr *MockClientMockRecorder) RequestServiceQuotaIncrease(arg0 any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestServiceQuotaIncrease", reflect.TypeOf((*MockClient)(nil).RequestServiceQuotaIncrease), arg0)
 }
 
+// SimulatePrincipalPolicy mocks base method.
+func (m *MockClient) SimulatePrincipalPolicy(arg0 *iam.SimulatePrincipalPolicyInput) (*iam.SimulatePrincipalPolicyOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SimulatePrincipalPolicy", arg0)
+	ret0, _ := ret[0].(*iam.SimulatePrincipalPolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SimulatePrincipalPolicy indicates an expected call of SimulatePrincipalPolicy.
+func (mr *MockClientMockRecorder) SimulatePrincipalPolicy(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulatePrincipalPolicy", reflect.TypeOf((*MockClient)(nil).SimulatePrincipalPolicy), arg0)
+}
+
 // TagResource mocks base method.
 func (m *MockClient) TagResource(input *organizations.TagResourceInput) (*organizations.TagResourceOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This adds a initial simulation to the rotate credentials command and it will also now actually rotate the credentials on cluster and deactivate the old AWS key if the rotation succeeded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end credential rotation flow that updates AWS keys, updates cluster secrets, and triggers cluster sync
  * New CLI flags: --dry-run, --cluster-id, and --hive-ocm-url
  * Pre-rotation IAM permission verification with admin-username fallback
  * Optional CCS (BYOC) credential rotation support

* **Tests**
  * Extensive unit tests covering rotation paths, permission checks, sync behavior, secret-deletion rules, and dry-run

* **Documentation**
  * Updated command docs and README with new flags and dry-run behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->