### PR TITLE
Add describe-nodes investigation and --params flag to cad run

### DIFF
--- a/cmd/cluster/cad/run.go
+++ b/cmd/cluster/cad/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/openshift/osdctl/cmd/setup"
 	"github.com/openshift/osdctl/pkg/k8s"
@@ -34,6 +35,7 @@ var validInvestigations = []string{
 	"must-gather",
 	"upgrade-config",
 	"restart-controlplane",
+	"describe-nodes",
 }
 
 var validEnvironments = []string{
@@ -47,6 +49,7 @@ type cadRunOptions struct {
 	elevationReason string
 	environment     string
 	isDryRun        bool
+	params          []string
 }
 
 func newCmdRun() *cobra.Command {
@@ -66,7 +69,8 @@ Prerequisites:
 
 Available Investigations:
   chgm, cmbb, can-not-retrieve-updates, ai, cpd, etcd-quota-low,
-  insightsoperatordown, machine-health-check, must-gather, upgrade-config
+  insightsoperatordown, machine-health-check, must-gather, upgrade-config,
+  restart-controlplane, describe-nodes
 
 Examples:
 ` + "```bash" + `
@@ -84,6 +88,14 @@ osdctl cluster cad run \
   --environment production \
   --reason "OHSS-12345" \
   --dry-run
+
+# Run describe-nodes on master nodes only
+osdctl cluster cad run \
+  --cluster-id 1a2b3c4d5e6f7g8h9i0j \
+  --investigation describe-nodes \
+  --environment production \
+  --reason "OHSS-12345" \
+  --params MASTER=true
 ` + "```" + `
 
 Note:
@@ -105,6 +117,8 @@ osdctl cluster reports list -C <cluster-id> -l 1
 	runCmd.Flags().StringVarP(&opts.environment, "environment", "e", "", "Environment in which the target cluster runs. Allowed values: \"stage\" or \"production\"")
 	runCmd.Flags().BoolVarP(&opts.isDryRun, "dry-run", "d", false, "Dry-Run: Run the investigation with the dry-run flag. This will not create a report.")
 	runCmd.Flags().StringVar(&opts.elevationReason, "reason", "", "Provide a reason for running a manual investigation, used for backplane. Eg: 'OHSS-XXXX', or '#ITN-2024-XXXXX.")
+	runCmd.Flags().StringArrayVarP(&opts.params, "params", "p", nil,
+		"Investigation-specific parameters as KEY=VALUE (can be specified multiple times)")
 
 	_ = runCmd.MarkFlagRequired("cluster-id")
 	_ = runCmd.MarkFlagRequired("investigation")
@@ -198,6 +212,13 @@ func (o *cadRunOptions) validate() error {
 		return fmt.Errorf("elevation reason is required")
 	}
 
+	for _, p := range o.params {
+		parts := strings.SplitN(p, "=", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return fmt.Errorf("invalid param %q: must be in KEY=VALUE format", p)
+		}
+	}
+
 	return nil
 }
 
@@ -209,6 +230,28 @@ func (o *cadRunOptions) getCADClusterConfig() (clusterID, namespace string) {
 }
 
 func (o *cadRunOptions) pipelineRunTemplate(cadNamespace string) *unstructured.Unstructured {
+	pipelineParams := []map[string]interface{}{
+		{
+			"name":  "cluster-id",
+			"value": o.clusterID,
+		},
+		{
+			"name":  "investigation",
+			"value": o.investigation,
+		},
+		{
+			"name":  "dry-run",
+			"value": o.isDryRun,
+		},
+	}
+
+	if len(o.params) > 0 {
+		pipelineParams = append(pipelineParams, map[string]interface{}{
+			"name":  "investigation-params",
+			"value": strings.Join(o.params, ","),
+		})
+	}
+
 	u := unstructured.Unstructured{}
 	u.Object = map[string]interface{}{
 		"apiVersion": "tekton.dev/v1beta1",
@@ -218,23 +261,8 @@ func (o *cadRunOptions) pipelineRunTemplate(cadNamespace string) *unstructured.U
 			"namespace":    cadNamespace,
 		},
 		"spec": map[string]interface{}{
-			"params": []map[string]interface{}{
-				{
-					"name":  "cluster-id",
-					"value": o.clusterID,
-				},
-				{
-					"name":  "investigation",
-					"value": o.investigation,
-				},
-				{
-					"name":  "dry-run",
-					"value": o.isDryRun,
-				},
-			},
-			"pipelineRef": map[string]interface{}{
-				"name": "cad-manual-investigation-pipeline",
-			},
+			"params":             pipelineParams,
+			"pipelineRef":        map[string]interface{}{"name": "cad-manual-investigation-pipeline"},
 			"serviceAccountName": "cad-sa",
 			"timeout":            "30m",
 		},

--- a/cmd/cluster/cad/run_test.go
+++ b/cmd/cluster/cad/run_test.go
@@ -8,6 +8,62 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestValidateParams(t *testing.T) {
+	base := cadRunOptions{
+		clusterID:       "test-cluster",
+		investigation:   "chgm",
+		environment:     "production",
+		elevationReason: "OHSS-12345",
+	}
+
+	tests := []struct {
+		name    string
+		params  []string
+		wantErr string
+	}{
+		{
+			name:   "valid params",
+			params: []string{"KEY=value", "MASTER=true"},
+		},
+		{
+			name:   "no params",
+			params: nil,
+		},
+		{
+			name:    "missing value",
+			params:  []string{"foo"},
+			wantErr: `invalid param "foo": must be in KEY=VALUE format`,
+		},
+		{
+			name:    "empty key",
+			params:  []string{"=bar"},
+			wantErr: `invalid param "=bar": must be in KEY=VALUE format`,
+		},
+		{
+			name:    "empty value",
+			params:  []string{"KEY="},
+			wantErr: `invalid param "KEY=": must be in KEY=VALUE format`,
+		},
+		{
+			name:   "value containing equals sign",
+			params: []string{"KEY=val=ue"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := base
+			opts.params = tt.params
+			err := opts.validate()
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestGetCADClusterConfig(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/docs/README.md
+++ b/docs/README.md
@@ -1353,7 +1353,8 @@ Prerequisites:
 
 Available Investigations:
   chgm, cmbb, can-not-retrieve-updates, ai, cpd, etcd-quota-low,
-  insightsoperatordown, machine-health-check, must-gather, upgrade-config
+  insightsoperatordown, machine-health-check, must-gather, upgrade-config,
+  restart-controlplane, describe-nodes
 
 Examples:
 ```bash
@@ -1371,6 +1372,14 @@ osdctl cluster cad run \
   --environment production \
   --reason "OHSS-12345" \
   --dry-run
+
+# Run describe-nodes on master nodes only
+osdctl cluster cad run \
+  --cluster-id 1a2b3c4d5e6f7g8h9i0j \
+  --investigation describe-nodes \
+  --environment production \
+  --reason "OHSS-12345" \
+  --params MASTER=true
 ```
 
 Note:
@@ -1399,6 +1408,7 @@ osdctl cluster cad run [flags]
   -i, --investigation string             Investigation name
       --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
   -o, --output string                    Valid formats are ['', 'json', 'yaml', 'env']
+  -p, --params stringArray               Investigation-specific parameters as KEY=VALUE (can be specified multiple times)
       --reason string                    Provide a reason for running a manual investigation, used for backplane. Eg: 'OHSS-XXXX', or '#ITN-2024-XXXXX.
       --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                    The address and port of the Kubernetes API server

--- a/docs/osdctl_cluster_cad_run.md
+++ b/docs/osdctl_cluster_cad_run.md
@@ -15,7 +15,8 @@ Prerequisites:
 
 Available Investigations:
   chgm, cmbb, can-not-retrieve-updates, ai, cpd, etcd-quota-low,
-  insightsoperatordown, machine-health-check, must-gather, upgrade-config
+  insightsoperatordown, machine-health-check, must-gather, upgrade-config,
+  restart-controlplane, describe-nodes
 
 Examples:
 ```bash
@@ -33,6 +34,14 @@ osdctl cluster cad run \
   --environment production \
   --reason "OHSS-12345" \
   --dry-run
+
+# Run describe-nodes on master nodes only
+osdctl cluster cad run \
+  --cluster-id 1a2b3c4d5e6f7g8h9i0j \
+  --investigation describe-nodes \
+  --environment production \
+  --reason "OHSS-12345" \
+  --params MASTER=true
 ```
 
 Note:
@@ -55,6 +64,7 @@ osdctl cluster cad run [flags]
   -e, --environment string     Environment in which the target cluster runs. Allowed values: "stage" or "production"
   -h, --help                   help for run
   -i, --investigation string   Investigation name
+  -p, --params stringArray     Investigation-specific parameters as KEY=VALUE (can be specified multiple times)
       --reason string          Provide a reason for running a manual investigation, used for backplane. Eg: 'OHSS-XXXX', or '#ITN-2024-XXXXX.
 ```
 


### PR DESCRIPTION
Followup to https://github.com/openshift/configuration-anomaly-detection/pull/780

Adds the new describe-nodes investigation and a --params/-p flag to osdctl cluster cad run, allowing users to pass investigation-specific KEY=VALUE parameters. When provided, params are joined as a comma-separated string and forwarded as the investigation-params Tekton pipeline parameter.
Changes in cmd/cluster/cad/run.go:
- Add describe-nodes to validInvestigations
- Add params []string field to cadRunOptions
- Register --params/-p flag (StringArrayVarP, optional)
- Conditionally append investigation-params pipeline param in pipelineRunTemplate()
- Update command help text with describe-nodes and --params example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added investigations: describe-nodes and restart-controlplane
  * Added repeatable --params / -p flag to pass investigation-specific KEY=VALUE pairs

* **User Experience**
  * CLI now validates params and reports malformed KEY=VALUE entries

* **Documentation**
  * Updated docs and examples to show new investigations and how to use --params
<!-- end of auto-generated comment: release notes by coderabbit.ai -->