### PR TITLE
SREP-4720: fix stale jira custom fields

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -24,9 +24,9 @@ type fieldQuery struct {
 const (
 	JiraHandoverAnnouncementProjectName = "SRE Platform HandOver Announcements"
 	JiraBaseURL                         = "https://redhat.atlassian.net"
-	ProductCustomField                  = "customfield_12319040"
-	CustomerNameCustomField             = "customfield_12310160"
-	ClusterIDCustomField                = "customfield_12316349"
+	ProductCustomField                  = "customfield_10868"
+	CustomerNameCustomField             = "customfield_10746"
+	ClusterIDCustomField                = "customfield_10852"
 )
 
 var clusterKeyRE = regexp.MustCompile(`^(\w|-)+$`)


### PR DESCRIPTION
After the migration to Atlassian Cloud, the Jira custom field IDs used in osdctl and backplane-cli are stale and no longer resolve to the correct fields. All three custom field constants in osdctl (pkg/utils/utils.go) point to non-existent field IDs:

-     ClusterIDCustomField: customfield_12316349 should be customfield_10852

-     ProductCustomField: customfield_12319040 should be customfield_10868

-     CustomerNameCustomField: customfield_12310160 should be customfield_10746

This fixes the fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Jira custom field identifiers for product, customer name, and cluster information. These configuration adjustments ensure the system correctly synchronizes data with Jira issue tracking and maintains accurate product and customer matching in downstream workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->