### PR TITLE
SREP-715: Using the new --dump-guest-cluster-through-kube-service option of the hypershift CLI when dumping dataplane content for must-gathers

### DIFF
--- a/cmd/hcp/mustgather/mustGather.go
+++ b/cmd/hcp/mustgather/mustGather.go
@@ -50,7 +50,7 @@ func NewCmdMustGather() *cobra.Command {
 		},
 	}
 
-	defaultAcmImage := "quay.io/stolostron/must-gather:2.11.4-SNAPSHOT-2024-12-02-15-19-44"
+	defaultAcmImage := "quay.io/stolostron/must-gather:latest"
 	mustGatherCommand.Flags().StringVarP(&mg.clusterId, "cluster-id", "C", "", "Internal ID of the cluster to gather data from")
 	mustGatherCommand.Flags().StringVar(&mg.reason, "reason", "", "The reason for this command, which requires elevation (e.g., OHSS ticket or PD incident).")
 	mustGatherCommand.Flags().StringVar(&mg.gatherTargets, "gather", "hcp", "Comma-separated list of gather targets (available: sc, sc_acm, mc, hcp).")
@@ -194,10 +194,8 @@ func (mg *mustGather) Run() error {
 				hcName := cluster.DomainPrefix()
 				hcNamespace := strings.TrimSuffix(hcpNamespace, "-"+hcName)
 
-				// TODO(ACM-16170): replace this with an official ACM release image once it's available
-				acmHyperShiftImage := "quay.io/rokejungrh/must-gather:v2.13.0-33-linux"
 				gatherScript := fmt.Sprintf("/usr/bin/gather hosted-cluster-namespace=%s hosted-cluster-name=%s", hcNamespace, hcName)
-				if err := createMustGather(mcRestCfg, mcK8sCli, []string{"--dest-dir=" + destDir, "--image=" + acmHyperShiftImage, gatherScript}); err != nil {
+				if err := createMustGather(mcRestCfg, mcK8sCli, []string{"--dest-dir=" + destDir, "--image=" + mg.acmMustGatherImage, gatherScript}); err != nil {
 					fmt.Printf("collected HCP dynatrace logs but failed to gather %s: %v\n", gatherTarget, err.Error())
 				}
 


### PR DESCRIPTION
Related changes:
- On the docker image: https://github.com/stolostron/must-gather/pull/730
- On the `hypershift` CLI: https://github.com/openshift/hypershift/pull/6533

**What this PR does / why we need it:**

Port forwarding is not possible as debug handlers are disabled on MC clusters. As a result data plane content (including worker nodes logs) is currently failing to be dumped.

The new --dump-guest-cluster-through-kube-service can be used to by-pass that limitation by targeting the kube-apiserver service exposed by HCP namespaces.
Remark that it is only suitable to use that option when:

Within a MC cluster (i.e. in a pod which has access to the service)
The MC cluster has the debug handlers disabled

**Which issue(s) this PR fixes**
Contributes to [SREP-715](https://issues.redhat.com//browse/SREP-715)

**Disclaimer**

Remark that using the `quay.io/stolostron/must-gather:latest` image is only a temporary solution. Long term fix is to use the `registry.redhat.io/rhacm2/acm-must-gather-rhel9:v2.17` image which will at least hard code the code branch to use, sadly this "release" image does not exist yet and the proposed image is the only one with an acceptable lifetime.

Long term fix is tracked there:
https://redhat.atlassian.net/browse/SREP-4777

[SREP-715]: https://redhat.atlassian.net/browse/SREP-715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the container image used for must-gather diagnostics to use the latest image by default. The hosted/HyperShift must-gather now follows the configured must-gather image, ensuring consistent diagnostic image selection across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->