### PR TITLE
Bump osd-network-verifier to v1.7.0 and add AWS GovCloud support

### DIFF
--- a/cmd/network/verification.go
+++ b/cmd/network/verification.go
@@ -193,7 +193,7 @@ func NewCmdValidateEgress() *cobra.Command {
 	validateEgressCmd.Flags().StringVar(&e.Region, "region", "", "(optional) AWS region, required for --pod-mode if not passing a --cluster-id")
 	validateEgressCmd.Flags().BoolVar(&e.Debug, "debug", false, "(optional) if provided, enable additional debug-level logging")
 	validateEgressCmd.Flags().BoolVarP(&e.AllSubnets, "all-subnets", "A", false, "(optional) an option for AWS Privatelink clusters to run osd-network-verifier against all subnets listed by ocm.")
-	validateEgressCmd.Flags().StringVar(&e.platformName, "platform", "", "(optional) override for cloud platform/product. E.g., 'aws-classic' (OSD/ROSA Classic), 'aws-hcp' (ROSA HCP), or 'aws-hcp-zeroegress'")
+	validateEgressCmd.Flags().StringVar(&e.platformName, "platform", "", "(optional) override for cloud platform/product. E.g., 'aws-classic' (OSD/ROSA Classic), 'aws-hcp' (ROSA HCP), 'aws-hcp-zeroegress', 'aws-govcloud-classic' (AWS GovCloud), or 'gcp-classic'")
 	validateEgressCmd.Flags().DurationVar(&e.EgressTimeout, "egress-timeout", onv.DefaultTimeout, "(optional) timeout for individual egress verification requests")
 	validateEgressCmd.Flags().BoolVar(&e.Version, "version", false, "When present, prints out the version of osd-network-verifier being used")
 	validateEgressCmd.Flags().StringVar(&e.Probe, "probe", "curl", "(optional) select the probe to be used for egress testing. Either 'curl' (default) or 'legacy'")
@@ -819,7 +819,7 @@ func (e *EgressVerification) setupPodModeVerification(ctx context.Context, platf
 // setupCloudProviderVerification sets up cloud provider-based verification and returns verifier and inputs
 func (e *EgressVerification) setupCloudProviderVerification(ctx context.Context, platform cloud.Platform) (networkVerifier, []*onv.ValidateEgressInput, error) {
 	switch platform {
-	case cloud.AWSHCP, cloud.AWSHCPZeroEgress, cloud.AWSClassic:
+	case cloud.AWSHCP, cloud.AWSHCPZeroEgress, cloud.AWSClassic, cloud.AWSGovCloudClassic:
 		cfg, err := e.setupForAws(ctx)
 		if err != nil {
 			return nil, nil, err

--- a/cmd/network/verification.go
+++ b/cmd/network/verification.go
@@ -789,7 +789,7 @@ func (e *EgressVerification) setupPodModeVerification(ctx context.Context, platf
 	}
 
 	// For AWS-based platforms in pod mode, ensure region is set for proper egress list generation
-	if platform == cloud.AWSClassic || platform == cloud.AWSHCP || platform == cloud.AWSHCPZeroEgress {
+	if platform == cloud.AWSClassic || platform == cloud.AWSHCP || platform == cloud.AWSHCPZeroEgress || platform == cloud.AWSGovCloudClassic {
 		var region string
 
 		// Try to detect region from OCM cluster info first

--- a/docs/README.md
+++ b/docs/README.md
@@ -3935,7 +3935,7 @@ osdctl network verify-egress [flags]
       --namespace string                 (optional) Kubernetes namespace to run verification pods in (default "openshift-network-diagnostics")
       --no-tls                           (optional) if provided, ignore all ssl certificate validations on client-side.
   -o, --output string                    Valid formats are ['', 'json', 'yaml', 'env']
-      --platform string                  (optional) override for cloud platform/product. E.g., 'aws-classic' (OSD/ROSA Classic), 'aws-hcp' (ROSA HCP), or 'aws-hcp-zeroegress'
+      --platform string                  (optional) override for cloud platform/product. E.g., 'aws-classic' (OSD/ROSA Classic), 'aws-hcp' (ROSA HCP), 'aws-hcp-zeroegress', 'aws-govcloud-classic' (AWS GovCloud), or 'gcp-classic'
       --pod-mode                         (optional) run verification using Kubernetes pods instead of cloud instances
       --probe string                     (optional) select the probe to be used for egress testing. Either 'curl' (default) or 'legacy' (default "curl")
       --region string                    (optional) AWS region, required for --pod-mode if not passing a --cluster-id

--- a/docs/osdctl_network_verify-egress.md
+++ b/docs/osdctl_network_verify-egress.md
@@ -91,7 +91,7 @@ osdctl network verify-egress [flags]
       --kubeconfig string         (optional) path to kubeconfig file for pod mode (uses default kubeconfig if not specified)
       --namespace string          (optional) Kubernetes namespace to run verification pods in (default "openshift-network-diagnostics")
       --no-tls                    (optional) if provided, ignore all ssl certificate validations on client-side.
-      --platform string           (optional) override for cloud platform/product. E.g., 'aws-classic' (OSD/ROSA Classic), 'aws-hcp' (ROSA HCP), or 'aws-hcp-zeroegress'
+      --platform string           (optional) override for cloud platform/product. E.g., 'aws-classic' (OSD/ROSA Classic), 'aws-hcp' (ROSA HCP), 'aws-hcp-zeroegress', 'aws-govcloud-classic' (AWS GovCloud), or 'gcp-classic'
       --pod-mode                  (optional) run verification using Kubernetes pods instead of cloud instances
       --probe string              (optional) select the probe to be used for egress testing. Either 'curl' (default) or 'legacy' (default "curl")
       --region string             (optional) AWS region, required for --pod-mode if not passing a --cluster-id

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/openshift/hive/apis v0.0.0-20250206153200-5a34ea42e678
 	github.com/openshift/hypershift/api v0.0.0-20250208145556-2753dcc8cfb7
 	github.com/openshift/ocm-container v1.0.1-0.20260310005051-28d4fda21872
-	github.com/openshift/osd-network-verifier v1.6.1
+	github.com/openshift/osd-network-verifier v1.7.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/shopspring/decimal v1.4.0
 	github.com/sirupsen/logrus v1.9.4

--- a/go.sum
+++ b/go.sum
@@ -492,8 +492,8 @@ github.com/openshift/hypershift/api v0.0.0-20250208145556-2753dcc8cfb7 h1:535PgO
 github.com/openshift/hypershift/api v0.0.0-20250208145556-2753dcc8cfb7/go.mod h1:fQFj8aH3buOKqmhMQ5igRVOT7iQdduxRE9H1LM/BiY0=
 github.com/openshift/ocm-container v1.0.1-0.20260310005051-28d4fda21872 h1:ctMZePpayeWKIrW7e+4B5/nW9PABo1xrwiVf8IR5eCQ=
 github.com/openshift/ocm-container v1.0.1-0.20260310005051-28d4fda21872/go.mod h1:9BnOM0uw0vl/liK1fLSDebncPDBTOEJv2E+mi70MFbQ=
-github.com/openshift/osd-network-verifier v1.6.1 h1:3Qtlo24bgKNxNdhoYXWjc/UvtCL1k5kULa6lPsO93gg=
-github.com/openshift/osd-network-verifier v1.6.1/go.mod h1:WBsoc9YeIdm3ZtWPad+j20qxkgBDrRK2Kiu4N/MeenE=
+github.com/openshift/osd-network-verifier v1.7.0 h1:uYIA1Tk9y350QaIJXm/luXIwN/Gp5/sBtceHaeGUWn8=
+github.com/openshift/osd-network-verifier v1.7.0/go.mod h1:WBsoc9YeIdm3ZtWPad+j20qxkgBDrRK2Kiu4N/MeenE=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=


### PR DESCRIPTION
- Bumps [github.com/openshift/osd-network-verifier](https://github.com/openshift/osd-network-verifier) from 1.6.1 to 1.7.0. Also adds
- Adds cloud.AWSGovCloudClassic platform handling to enable network verification for AWS GovCloud clusters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for aws-govcloud-classic and gcp-classic as platform options for verify-egress; GovCloud classic clusters now follow the AWS verification path for proper egress verification.

* **Documentation**
  * Updated verify-egress help and docs to list the new platform override values.

* **Chores**
  * Bumped osd-network-verifier dependency to v1.7.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->