### PR TITLE
Add instructions to install with Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Currently, it mainly supports related work for AWS, especially [aws-account-oper
 
 ## Installation
 
+### MacOS
+
+```
+$ brew install osdctl
+```
+
 ### Build from source
 
 #### Requirements


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added macOS installation instructions for `osdctl` via Homebrew.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->