### PR TITLE
[SREP-4791]: Add sre-agent integration to osdctl AI commands

### DIFF
--- a/cmd/ai/cmd.go
+++ b/cmd/ai/cmd.go
@@ -1,0 +1,19 @@
+package ai
+
+import (
+	sreagent "github.com/openshift/osdctl/cmd/ai/sre_agent"
+	"github.com/spf13/cobra"
+)
+
+// NewCmdAI implements the base AI command
+func NewCmdAI() *cobra.Command {
+	aiCmd := &cobra.Command{
+		Use:   "ai",
+		Short: "AI-powered tools for SRE automation",
+		Args:  cobra.NoArgs,
+	}
+
+	aiCmd.AddCommand(sreagent.NewCmdSreAgent())
+
+	return aiCmd
+}

--- a/cmd/ai/sre_agent/helper.go
+++ b/cmd/ai/sre_agent/helper.go
@@ -23,8 +23,11 @@ func copyRepository(sourcePath, destPath string) error {
 }
 
 // promptUserInput reads a line of user input from stdin
-func promptUserInput() string {
+func promptUserInput() (string, error) {
 	reader := bufio.NewReader(os.Stdin)
-	input, _ := reader.ReadString('\n')
-	return strings.ToLower(strings.TrimSpace(input))
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("failed to read input: %w", err)
+	}
+	return strings.ToLower(strings.TrimSpace(input)), nil
 }

--- a/cmd/ai/sre_agent/helper.go
+++ b/cmd/ai/sre_agent/helper.go
@@ -1,0 +1,30 @@
+package sreagent
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// copyRepository copies a directory recursively
+func copyRepository(sourcePath, destPath string) error {
+	fmt.Fprintf(os.Stderr, "Copying repository to %s...\n", destPath)
+	cmd := exec.Command("cp", "-r", sourcePath, destPath)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// promptUserInput reads a line of user input from stdin
+func promptUserInput() string {
+	reader := bufio.NewReader(os.Stdin)
+	input, _ := reader.ReadString('\n')
+	return strings.ToLower(strings.TrimSpace(input))
+}

--- a/cmd/ai/sre_agent/sre_agent.go
+++ b/cmd/ai/sre_agent/sre_agent.go
@@ -48,7 +48,6 @@ func NewCmdSreAgent() *cobra.Command {
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
 				cmdutil.CheckErr(fmt.Errorf("failed to get home directory: %w", err))
-				return
 			}
 
 			// Step 1: Validate sre-agent installation
@@ -77,7 +76,9 @@ func NewCmdSreAgent() *cobra.Command {
 	sreAgentCmd.Flags().StringVar(&outputDir, "output", "", "Output directory for sre-agent files (default: current directory)")
 
 	// Mark pd-url as required
-	sreAgentCmd.MarkFlagRequired("pd-url")
+	if err := sreAgentCmd.MarkFlagRequired("pd-url"); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to mark pd-url as required: %v\n", err)
+	}
 
 	return sreAgentCmd
 }

--- a/cmd/ai/sre_agent/sre_agent.go
+++ b/cmd/ai/sre_agent/sre_agent.go
@@ -1,0 +1,124 @@
+package sreagent
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+var (
+	pdURL       string
+	autoExecute bool
+	outputDir   string
+)
+
+const (
+	sreAgentDescription = `
+  SRE Agent is an AI-powered tool that helps SREs triage alerts and diagnose issues.
+  It automatically fetches incident details from PagerDuty, finds relevant SOPs,
+  and executes diagnostic commands on clusters.
+`
+
+	sreAgentExample = `
+  # Interactive mode (asks for confirmation at each step)
+  osdctl ai sre-agent --pd-url "${PD_URL}"
+
+  # Fully automated mode (no confirmations)
+  osdctl ai sre-agent --pd-url "${PD_URL}" --auto-execute
+
+  # Specify output directory for sre-agent files
+  osdctl ai sre-agent --pd-url "${PD_URL}" --output /tmp/sre-agent-output
+`
+)
+
+func NewCmdSreAgent() *cobra.Command {
+	sreAgentCmd := &cobra.Command{
+		Use:           "sre-agent",
+		Short:         "Run SRE Agent for automated incident investigation",
+		Long:          sreAgentDescription,
+		Example:       sreAgentExample,
+		Args:          cobra.ArbitraryArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Run: func(cmd *cobra.Command, args []string) {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				cmdutil.CheckErr(fmt.Errorf("failed to get home directory: %w", err))
+				return
+			}
+
+			// Step 1: Validate sre-agent installation
+			if !validateSreAgent(homeDir) {
+				return
+			}
+
+			// Step 2: Check/Setup config (includes ops-sop setup)
+			if !checkSreAgentConfig(homeDir) {
+				return
+			}
+
+			// Step 3: Execute sre-agent
+			sreAgentPath := filepath.Join(homeDir, ".local/share/sre-agent/venv/bin/sre-agent")
+			sreAgentArgs := buildSreAgentArgs(args)
+
+			err = executeSreAgent(sreAgentPath, sreAgentArgs, outputDir)
+			if err != nil {
+				cmdutil.CheckErr(err)
+			}
+		},
+	}
+
+	sreAgentCmd.Flags().StringVar(&pdURL, "pd-url", "", "PagerDuty incident URL (required)")
+	sreAgentCmd.Flags().BoolVar(&autoExecute, "auto-execute", false, "Fully automated mode without confirmations")
+	sreAgentCmd.Flags().StringVar(&outputDir, "output", "", "Output directory for sre-agent files (default: current directory)")
+
+	// Mark pd-url as required
+	sreAgentCmd.MarkFlagRequired("pd-url")
+
+	return sreAgentCmd
+}
+
+// buildSreAgentArgs constructs the argument list for sre-agent command
+func buildSreAgentArgs(additionalArgs []string) []string {
+	args := []string{}
+
+	if pdURL != "" {
+		args = append(args, "--pd-url", pdURL)
+	}
+
+	if autoExecute {
+		args = append(args, "--auto-execute")
+	}
+
+	// Add any additional arguments passed
+	args = append(args, additionalArgs...)
+
+	return args
+}
+
+// executeSreAgent runs the sre-agent command with provided arguments
+func executeSreAgent(sreAgentPath string, args []string, outputDir string) error {
+	cmd := exec.Command(sreAgentPath, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	// Set working directory if output directory is specified
+	if outputDir != "" {
+		// Create directory if it doesn't exist
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			return fmt.Errorf("failed to create output directory: %w", err)
+		}
+		cmd.Dir = outputDir
+	}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("sre-agent execution failed: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/ai/sre_agent/sre_agent.go
+++ b/cmd/ai/sre_agent/sre_agent.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/adrg/xdg"
 	"github.com/spf13/cobra"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
@@ -45,26 +46,21 @@ func NewCmdSreAgent() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				cmdutil.CheckErr(fmt.Errorf("failed to get home directory: %w", err))
-			}
-
 			// Step 1: Validate sre-agent installation
-			if !validateSreAgent(homeDir) {
+			if !validateSreAgent() {
 				return
 			}
 
 			// Step 2: Check/Setup config (includes ops-sop setup)
-			if !checkSreAgentConfig(homeDir) {
+			if !checkSreAgentConfig() {
 				return
 			}
 
 			// Step 3: Execute sre-agent
-			sreAgentPath := filepath.Join(homeDir, ".local/share/sre-agent/venv/bin/sre-agent")
+			sreAgentPath := filepath.Join(xdg.DataHome, "sre-agent/venv/bin/sre-agent")
 			sreAgentArgs := buildSreAgentArgs(args)
 
-			err = executeSreAgent(sreAgentPath, sreAgentArgs, outputDir)
+			err := executeSreAgent(sreAgentPath, sreAgentArgs, outputDir)
 			if err != nil {
 				cmdutil.CheckErr(err)
 			}

--- a/cmd/ai/sre_agent/validate_sre_agent.go
+++ b/cmd/ai/sre_agent/validate_sre_agent.go
@@ -23,7 +23,11 @@ func validateSreAgent(homeDir string) bool {
 
 	// Ask for path to sre-agent venv
 	fmt.Fprint(os.Stderr, "Enter the absolute path to sre-agent venv directory: ")
-	userVenvPath := promptUserInput()
+	userVenvPath, err := promptUserInput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to read input: %v\n", err)
+		return false
+	}
 
 	// Validate venv binary exists in provided path
 	userVenvBinary := filepath.Join(userVenvPath, "bin/sre-agent")
@@ -35,7 +39,6 @@ func validateSreAgent(homeDir string) bool {
 	// Create base directory
 	if err := os.MkdirAll(baseDir, 0755); err != nil {
 		cmdutil.CheckErr(fmt.Errorf("failed to create base directory: %w", err))
-		return false
 	}
 
 	// Copy venv to ~/.local/share/sre-agent/venv

--- a/cmd/ai/sre_agent/validate_sre_agent.go
+++ b/cmd/ai/sre_agent/validate_sre_agent.go
@@ -5,13 +5,13 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/adrg/xdg"
 	"github.com/openshift/osdctl/internal/utils"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 // validateSreAgent checks if sre-agent is installed
-func validateSreAgent(homeDir string) bool {
-	baseDir := filepath.Join(homeDir, ".local/share/sre-agent")
+func validateSreAgent() bool {
+	baseDir := filepath.Join(xdg.DataHome, "sre-agent")
 	venvBinary := filepath.Join(baseDir, "venv/bin/sre-agent")
 
 	// Check if sre-agent binary exists
@@ -19,7 +19,7 @@ func validateSreAgent(homeDir string) bool {
 		return true // Already installed
 	}
 
-	fmt.Fprintf(os.Stderr, "sre-agent is not found in ~/.local/share/sre-agent/venv/\n\n")
+	fmt.Fprintf(os.Stderr, "sre-agent is not found in %s\n\n", venvBinary)
 
 	// Ask for path to sre-agent venv
 	fmt.Fprint(os.Stderr, "Enter the absolute path to sre-agent venv directory: ")
@@ -38,10 +38,11 @@ func validateSreAgent(homeDir string) bool {
 
 	// Create base directory
 	if err := os.MkdirAll(baseDir, 0755); err != nil {
-		cmdutil.CheckErr(fmt.Errorf("failed to create base directory: %w", err))
+		fmt.Fprintf(os.Stderr, "Failed to create base directory: %v\n", err)
+		return false
 	}
 
-	// Copy venv to ~/.local/share/sre-agent/venv
+	// Copy venv to XDG data directory
 	venvPath := filepath.Join(baseDir, "venv")
 	if err := copyRepository(userVenvPath, venvPath); err != nil {
 		fmt.Fprintf(os.Stderr, "\nCopy failed: %v\n", err)

--- a/cmd/ai/sre_agent/validate_sre_agent.go
+++ b/cmd/ai/sre_agent/validate_sre_agent.go
@@ -1,0 +1,50 @@
+package sreagent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/openshift/osdctl/internal/utils"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+// validateSreAgent checks if sre-agent is installed
+func validateSreAgent(homeDir string) bool {
+	baseDir := filepath.Join(homeDir, ".local/share/sre-agent")
+	venvBinary := filepath.Join(baseDir, "venv/bin/sre-agent")
+
+	// Check if sre-agent binary exists
+	if utils.FileExists(venvBinary) {
+		return true // Already installed
+	}
+
+	fmt.Fprintf(os.Stderr, "sre-agent is not found in ~/.local/share/sre-agent/venv/\n\n")
+
+	// Ask for path to sre-agent venv
+	fmt.Fprint(os.Stderr, "Enter the absolute path to sre-agent venv directory: ")
+	userVenvPath := promptUserInput()
+
+	// Validate venv binary exists in provided path
+	userVenvBinary := filepath.Join(userVenvPath, "bin/sre-agent")
+	if !utils.FileExists(userVenvBinary) {
+		fmt.Fprintln(os.Stderr, "\nsre-agent isn't installed")
+		return false
+	}
+
+	// Create base directory
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		cmdutil.CheckErr(fmt.Errorf("failed to create base directory: %w", err))
+		return false
+	}
+
+	// Copy venv to ~/.local/share/sre-agent/venv
+	venvPath := filepath.Join(baseDir, "venv")
+	if err := copyRepository(userVenvPath, venvPath); err != nil {
+		fmt.Fprintf(os.Stderr, "\nCopy failed: %v\n", err)
+		return false
+	}
+
+	fmt.Fprintln(os.Stderr, "\n✓ sre-agent venv copied successfully")
+	return true
+}

--- a/cmd/ai/sre_agent/validate_sre_agent_config.go
+++ b/cmd/ai/sre_agent/validate_sre_agent_config.go
@@ -5,14 +5,15 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/adrg/xdg"
 	"github.com/openshift/osdctl/internal/utils"
 	"gopkg.in/yaml.v3"
 )
 
 // checkSreAgentConfig validates config.yaml and updates ops-sop path if needed
-func checkSreAgentConfig(homeDir string) bool {
-	baseDir := filepath.Join(homeDir, ".local/share/sre-agent")
-	configPath := filepath.Join(homeDir, ".config/sre-agent/config.yaml")
+func checkSreAgentConfig() bool {
+	baseDir := filepath.Join(xdg.DataHome, "sre-agent")
+	configPath := filepath.Join(xdg.ConfigHome, "sre-agent/config.yaml")
 
 	// Check if config exists
 	if !utils.FileExists(configPath) {

--- a/cmd/ai/sre_agent/validate_sre_agent_config.go
+++ b/cmd/ai/sre_agent/validate_sre_agent_config.go
@@ -1,0 +1,94 @@
+package sreagent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/openshift/osdctl/internal/utils"
+	"gopkg.in/yaml.v3"
+)
+
+// checkSreAgentConfig validates config.yaml and updates ops-sop path if needed
+func checkSreAgentConfig(homeDir string) bool {
+	baseDir := filepath.Join(homeDir, ".local/share/sre-agent")
+	configPath := filepath.Join(homeDir, ".config/sre-agent/config.yaml")
+
+	// Check if config exists
+	if !utils.FileExists(configPath) {
+		fmt.Fprintln(os.Stderr, "\nsre-agent not configured")
+		fmt.Fprintln(os.Stderr, "Config file not found at:", configPath)
+		return false
+	}
+
+	// Read existing config
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to read config: %v\n", err)
+		return false
+	}
+
+	// Parse YAML
+	var config map[string]interface{}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse config: %v\n", err)
+		return false
+	}
+
+	// Get current sop directory from config
+	sop, ok := config["sop"].(map[string]interface{})
+	if !ok {
+		fmt.Fprintln(os.Stderr, "Invalid config: sop section not found")
+		return false
+	}
+
+	currentSopDir, _ := sop["directory"].(string)
+
+	// Ask user for ops-sop repository path
+	fmt.Fprintln(os.Stderr, "\nChecking ops-sop repository...")
+	fmt.Fprint(os.Stderr, "Enter the absolute path to ops-sop repository: ")
+	userOpsSopPath := promptUserInput()
+
+	// Validate path exists
+	if !utils.FolderExists(userOpsSopPath) {
+		fmt.Fprintln(os.Stderr, "\nThe provided ops-sop path does not exist.")
+		return false
+	}
+
+	opsSopPath := filepath.Join(baseDir, "ops-sop")
+
+	// Copy ops-sop if not present
+	if !utils.FolderExists(opsSopPath) {
+		if err := copyRepository(userOpsSopPath, opsSopPath); err != nil {
+			fmt.Fprintf(os.Stderr, "\nCopy failed: %v\n", err)
+			return false
+		}
+		fmt.Fprintln(os.Stderr, "✓ ops-sop copied successfully")
+	} else {
+		fmt.Fprintln(os.Stderr, "✓ ops-sop repository found")
+	}
+
+	// Check if sop directory in config is different from expected
+	if currentSopDir != opsSopPath {
+		// Update config with new path
+		sop["directory"] = opsSopPath
+
+		// Write updated config
+		updatedData, err := yaml.Marshal(config)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to marshal config: %v\n", err)
+			return false
+		}
+
+		if err := os.WriteFile(configPath, updatedData, 0600); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to write config: %v\n", err)
+			return false
+		}
+
+		fmt.Fprintf(os.Stderr, "✓ ops-sop path updated in config: %s\n\n", opsSopPath)
+	} else {
+		fmt.Fprintf(os.Stderr, "✓ ops-sop path is correct: %s\n\n", opsSopPath)
+	}
+
+	return true
+}

--- a/cmd/ai/sre_agent/validate_sre_agent_config.go
+++ b/cmd/ai/sre_agent/validate_sre_agent_config.go
@@ -42,12 +42,20 @@ func checkSreAgentConfig(homeDir string) bool {
 		return false
 	}
 
-	currentSopDir, _ := sop["directory"].(string)
+	currentSopDir, ok := sop["directory"].(string)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "Invalid config: sop directory is not a string")
+		return false
+	}
 
 	// Ask user for ops-sop repository path
 	fmt.Fprintln(os.Stderr, "\nChecking ops-sop repository...")
 	fmt.Fprint(os.Stderr, "Enter the absolute path to ops-sop repository: ")
-	userOpsSopPath := promptUserInput()
+	userOpsSopPath, err := promptUserInput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to read input: %v\n", err)
+		return false
+	}
 
 	// Validate path exists
 	if !utils.FolderExists(userOpsSopPath) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/openshift/osdctl/cmd/aao"
 	"github.com/openshift/osdctl/cmd/account"
+	"github.com/openshift/osdctl/cmd/ai"
 	"github.com/openshift/osdctl/cmd/alerts"
 	"github.com/openshift/osdctl/cmd/cloudtrail"
 	"github.com/openshift/osdctl/cmd/cluster"
@@ -99,6 +100,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	// add sub commands
 	addToRootCmdWithOtherGlobalOpts(aao.NewCmdAao(kubeClient))
 	addToRootCmdWithOtherGlobalOpts(account.NewCmdAccount(streams, kubeClient, globalOpts))
+	rootCmd.AddCommand(ai.NewCmdAI())
 	addToRootCmdWithOtherGlobalOpts(alerts.NewCmdAlerts())
 	addToRootCmdWithOtherGlobalOpts(cloudtrail.NewCloudtrailCmd())
 	addToRootCmdWithOtherGlobalOpts(cluster.NewCmdCluster(streams, kubeClient, globalOpts))

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,8 @@
     - `describe` - Describe AWS service-quotas
   - `set <account name>` - Set AWS Account CR status
   - `verify-secrets [<account name>]` - Verify AWS Account CR IAM User credentials
+- `ai` - AI-powered tools for SRE automation
+  - `sre-agent` - Run SRE Agent for automated incident investigation
 - `alert` - List alerts
   - `list --cluster-id <cluster-id> --level [warning, critical, firing, pending, all]` - List all alerts or based on severity
   - `silence` - add, expire and list silence associated with alerts
@@ -906,6 +908,43 @@ osdctl account verify-secrets [<account name>] [flags]
       --skip-aws-proxy-check aws_proxy   Don't use the configured aws_proxy value
   -S, --skip-version-check               skip checking to see if this is the most recent release
       --verbose                          Verbose output
+```
+
+### osdctl ai
+
+AI-powered tools for SRE automation
+
+```
+osdctl ai [flags]
+```
+
+#### Flags
+
+```
+  -h, --help                 help for ai
+  -S, --skip-version-check   skip checking to see if this is the most recent release
+```
+
+### osdctl ai sre-agent
+
+
+  SRE Agent is an AI-powered tool that helps SREs triage alerts and diagnose issues.
+  It automatically fetches incident details from PagerDuty, finds relevant SOPs,
+  and executes diagnostic commands on clusters.
+
+
+```
+osdctl ai sre-agent [flags]
+```
+
+#### Flags
+
+```
+      --auto-execute         Fully automated mode without confirmations
+  -h, --help                 help for sre-agent
+      --output string        Output directory for sre-agent files (default: current directory)
+      --pd-url string        PagerDuty incident URL (required)
+  -S, --skip-version-check   skip checking to see if this is the most recent release
 ```
 
 ### osdctl alert

--- a/docs/osdctl.md
+++ b/docs/osdctl.md
@@ -17,6 +17,7 @@ CLI tool to provide OSD related utilities
 
 * [osdctl aao](osdctl_aao.md)	 - AWS Account Operator Debugging Utilities
 * [osdctl account](osdctl_account.md)	 - AWS Account related utilities
+* [osdctl ai](osdctl_ai.md)	 - AI-powered tools for SRE automation
 * [osdctl alert](osdctl_alert.md)	 - List alerts
 * [osdctl cloudtrail](osdctl_cloudtrail.md)	 - AWS CloudTrail related utilities
 * [osdctl cluster](osdctl_cluster.md)	 - Provides information for a specified cluster

--- a/docs/osdctl_ai.md
+++ b/docs/osdctl_ai.md
@@ -1,0 +1,21 @@
+## osdctl ai
+
+AI-powered tools for SRE automation
+
+### Options
+
+```
+  -h, --help   help for ai
+```
+
+### Options inherited from parent commands
+
+```
+  -S, --skip-version-check   skip checking to see if this is the most recent release
+```
+
+### SEE ALSO
+
+* [osdctl](osdctl.md)	 - OSD CLI
+* [osdctl ai sre-agent](osdctl_ai_sre-agent.md)	 - Run SRE Agent for automated incident investigation
+

--- a/docs/osdctl_ai_sre-agent.md
+++ b/docs/osdctl_ai_sre-agent.md
@@ -1,0 +1,50 @@
+## osdctl ai sre-agent
+
+Run SRE Agent for automated incident investigation
+
+### Synopsis
+
+
+  SRE Agent is an AI-powered tool that helps SREs triage alerts and diagnose issues.
+  It automatically fetches incident details from PagerDuty, finds relevant SOPs,
+  and executes diagnostic commands on clusters.
+
+
+```
+osdctl ai sre-agent [flags]
+```
+
+### Examples
+
+```
+
+  # Interactive mode (asks for confirmation at each step)
+  osdctl ai sre-agent --pd-url "${PD_URL}"
+
+  # Fully automated mode (no confirmations)
+  osdctl ai sre-agent --pd-url "${PD_URL}" --auto-execute
+
+  # Specify output directory for sre-agent files
+  osdctl ai sre-agent --pd-url "${PD_URL}" --output /tmp/sre-agent-output
+
+```
+
+### Options
+
+```
+      --auto-execute    Fully automated mode without confirmations
+  -h, --help            help for sre-agent
+      --output string   Output directory for sre-agent files (default: current directory)
+      --pd-url string   PagerDuty incident URL (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -S, --skip-version-check   skip checking to see if this is the most recent release
+```
+
+### SEE ALSO
+
+* [osdctl ai](osdctl_ai.md)	 - AI-powered tools for SRE automation
+

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/PagerDuty/go-pagerduty v1.8.0
+	github.com/adrg/xdg v0.5.3
 	github.com/andygrunwald/go-jira v1.17.0
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.16

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQA
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
+github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
+github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/andygrunwald/go-jira v1.17.0 h1:bbu5H676l6MaNcV6A7VDIAjIOQVgzNGEhNAwNI/Cjgo=


### PR DESCRIPTION
  ## Summary
  Integrates the sre-agent Python tool as a new `osdctl ai sre-agent` command with automatic installation, configuration, and validation capabilities.

   ### Files Added
  - `cmd/ai/sre_agent/sre_agent.go` - Main command and orchestration
  - `cmd/ai/sre_agent/sre_agent_install.go` - Installation logic
  - `cmd/ai/sre_agent/sre_agent_config.go` - Configuration management
  - `cmd/ai/sre_agent/helper.go` - Shared utilities (git, venv, prompts)

##

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "ai" command with a new "sre-agent" subcommand to run SRE incident investigations.
  * sre-agent supports --pd-url (required), --auto-execute (optional), and --output (optional), and can run in interactive or fully automated modes.
  * Interactive setup assists with locating or installing the agent environment and required SOP assets.

* **Documentation**
  * Added user docs and command reference for the ai command and sre-agent usage/examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->