### PR TITLE
Allow osdctl rhobs logs to accept HCP cluster IDs

### DIFF
--- a/cmd/rhobs/mcp_tools.go
+++ b/cmd/rhobs/mcp_tools.go
@@ -51,13 +51,13 @@ func registerMcpTools(s *mcp.Server) {
 		Name: "rhobs_logs",
 		Description: "Query RHOBS Loki logs for ROSA HCP infrastructure. " +
 			"Covers HCP hosted clusters, Management Clusters (MC), and Service Clusters (SC). " +
-			"Requires an MC cluster ID since logs are collected at the MC level. " +
+			"Accepts any cluster ID; HCP IDs are automatically resolved to their parent MC. " +
 			"The correct RHOBS cell is resolved automatically.",
 		Annotations: readOnlyAnnotations,
 		InputSchema: json.RawMessage(`{
 			"type": "object",
 			"properties": {
-				"cluster_id":     {"type": "string", "description": "MC cluster ID or name (logs are collected at the MC level for HCP)"},
+				"cluster_id":     {"type": "string", "description": "Cluster ID or name (HCP, MC, or SC). HCP IDs auto-resolve to their parent MC."},
 				"namespace":      {"type": "string", "description": "Kubernetes namespace. Required unless query is set."},
 				"query":          {"type": "string", "description": "Raw LogQL expression (overrides namespace)"},
 				"contain_regex":  {"type": "string", "description": "Server-side regex filter (e.g., (?i)(error|timeout))"},

--- a/cmd/rhobs/requests.go
+++ b/cmd/rhobs/requests.go
@@ -238,15 +238,12 @@ func CreateRhobsFetcher(clusterKey string, rhobsFetchUse RhobsFetchUsage, hiveOc
 	isMC := false
 
 	if isHcp {
-		if rhobsFetchUse == RhobsFetchForLogs {
-			return nil, fmt.Errorf("cluster '%s' is a HCP cluster - try with its parent MC cluster", cluster.ID())
-		}
 		managementCluster, err := ocmutils.GetManagementCluster(cluster.ID())
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve management cluster for cluster '%s': %v", cluster.ID(), err)
 		}
 		monitoredClusterId = managementCluster.ID()
-		log.Infof("Cluster %s is managed by MC cluster %s - using the MC cluster to retrieve the RHOBS cell for logs\n", cluster.ID(), monitoredClusterId)
+		log.Infof("Cluster %s is managed by MC cluster %s - using the MC cluster for RHOBS cell resolution\n", cluster.ID(), monitoredClusterId)
 	} else {
 		monitoredClusterId = cluster.ID()
 		isMC, err = ocmutils.IsManagementCluster(cluster.ID())


### PR DESCRIPTION
Previously `osdctl rhobs logs` rejected HCP cluster IDs with an error telling users to find the parent MC ID. This was a UX regression from `osdctl dt logs` which accepted any cluster ID.

Now HCP IDs are auto-resolved to their parent MC (same as `osdctl rhobs metrics` already did). The HCP external ID is still used for the `openshift_cluster_id` log filter so logs are correctly scoped to the HCP.

All three `osdctl rhobs` subcommands (metrics, logs, cell) now accept any cluster ID (HCP, MC, or SC).

## Usage examples

```bash
# Logs with HCP cluster ID (auto-resolves to parent MC) in the openshift-monitoring (MC namespace)
osdctl rhobs logs -C <hcp-cluster-id> -n openshift-monitoring --since 1h

# Logs with MC cluster ID (works as before)
osdctl rhobs logs -C <mc-cluster-id> -n openshift-monitoring --since 1h

# Logs for a specific pod (positional arg)
osdctl rhobs logs -C <cluster-id> prometheus-k8s-0 -n openshift-monitoring --since 1h

# Logs for a specific container
osdctl rhobs logs -C <cluster-id> -n <hcp-namespace> -c kube-apiserver --since 1h

# Text search
osdctl rhobs logs -C <cluster-id> -n <hcp-namespace> --contain OOMKilled --since 1h

# Regex filter (server-side, fast)
osdctl rhobs logs -C <cluster-id> -n <hcp-namespace> --contain-regex '(?i)(error|timeout)' --since 30m

# Error level only
osdctl rhobs logs -C <cluster-id> -n <hcp-namespace> --level error --since 1h
```

## Tested

- HCP cluster ID: auto-resolves to MC, filters by HCP external ID
- MC cluster ID: works as before
- Positional pod name: `prometheus-k8s-0` filters correctly
- Namespace, container, contain, regex, level flags: all work

Also updates the MCP tool description to reflect that any cluster ID is accepted.

Fixes: https://github.com/openshift/ops-sop/pull/3993

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `rhobs_logs` tool now accepts any cluster ID, with Hosted Control Plane (HCP) cluster IDs automatically resolved to their parent Management Cluster for log resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->