### PR TITLE
Make RHOBS MCP server start even when vault token is expired

### DIFF
--- a/cmd/rhobs/mcpCmd.go
+++ b/cmd/rhobs/mcpCmd.go
@@ -76,10 +76,12 @@ func newCmdMcpServer() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.SetOutput(io.Discard)
 
-			if err := checkVaultToken(cmd.Context()); err != nil {
-				fmt.Fprintln(os.Stderr, "WARNING:", err)
-				fmt.Fprintln(os.Stderr, "MCP server starting anyway. Tool calls will fail until vault is authenticated.")
-			}
+			go func(ctx context.Context) {
+				if err := checkVaultToken(ctx); err != nil {
+					fmt.Fprintln(os.Stderr, "WARNING:", err)
+					fmt.Fprintln(os.Stderr, "MCP server starting anyway. Tool calls will fail until vault is authenticated.")
+				}
+			}(cmd.Context())
 
 			server := mcp.NewServer(&mcp.Implementation{
 				Name:    "osdctl-rhobs",

--- a/cmd/rhobs/mcpCmd.go
+++ b/cmd/rhobs/mcpCmd.go
@@ -77,7 +77,8 @@ func newCmdMcpServer() *cobra.Command {
 			log.SetOutput(io.Discard)
 
 			if err := checkVaultToken(cmd.Context()); err != nil {
-				return err
+				fmt.Fprintln(os.Stderr, "WARNING:", err)
+				fmt.Fprintln(os.Stderr, "MCP server starting anyway. Tool calls will fail until vault is authenticated.")
 			}
 
 			server := mcp.NewServer(&mcp.Implementation{

--- a/cmd/rhobs/mcp_helpers.go
+++ b/cmd/rhobs/mcp_helpers.go
@@ -3,6 +3,7 @@ package rhobs
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -24,6 +25,12 @@ func quickVaultCheck() error {
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	if err := cmd.Run(); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return fmt.Errorf("vault CLI not found in PATH; install Vault and retry")
+		}
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("vault token lookup timed out; verify VAULT_ADDR and network connectivity")
+		}
 		return fmt.Errorf("vault token expired or missing. Run: VAULT_ADDR=https://vault.devshift.net vault login -method=oidc")
 	}
 	return nil

--- a/cmd/rhobs/mcp_helpers.go
+++ b/cmd/rhobs/mcp_helpers.go
@@ -1,9 +1,13 @@
 package rhobs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
 	"sync"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"golang.org/x/sync/singleflight"
@@ -11,6 +15,19 @@ import (
 
 var fetcherCache sync.Map
 var fetcherInit singleflight.Group
+
+func quickVaultCheck() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "vault", "token", "lookup")
+	cmd.Env = append(os.Environ(), "VAULT_ADDR=https://vault.devshift.net")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("vault token expired or missing. Run: VAULT_ADDR=https://vault.devshift.net vault login -method=oidc")
+	}
+	return nil
+}
 
 func getCachedFetcher(clusterId string, usage RhobsFetchUsage) (*RhobsFetcher, error) {
 	key := fmt.Sprintf("%s:%s", clusterId, usage)
@@ -21,6 +38,9 @@ func getCachedFetcher(clusterId string, usage RhobsFetchUsage) (*RhobsFetcher, e
 	v, err, _ := fetcherInit.Do(key, func() (interface{}, error) {
 		if cached, ok := fetcherCache.Load(key); ok {
 			return cached, nil
+		}
+		if err := quickVaultCheck(); err != nil {
+			return nil, err
 		}
 		fetcher, err := CreateRhobsFetcher(clusterId, usage, commonOptions.hiveOcmUrl)
 		if err != nil {


### PR DESCRIPTION
The MCP server currently exits with an error when vault is expired, causing Claude Code to show 'failed' in /mcp with no context and no way to reconnect (error -32000).

This changes the vault preflight from blocking to non-blocking: the server always starts and registers tools. When vault is expired, tool calls return a fast, clear error with login instructions instead of hanging.

Before: server fails to start, /mcp shows 'failed', reconnect gives cryptic -32000
After: server starts with 3 tools, tool calls return 'vault token expired, run: vault login'

Also adds a fast vault check (5s timeout) before fetcher creation so tool calls fail instantly rather than hanging on interactive vault login.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server startup no longer blocks waiting for Vault authentication; it continues booting and logs a warning if Vault is unavailable.
* **Bug Fixes**
  * Fetch/path initialization now enforces Vault token presence and returns a clear, user-facing error with guidance to authenticate (e.g., run Vault login) when missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->