### PR TITLE
SREP-4889: Add promote rhobs subcommand

### DIFF
--- a/cmd/promote/cmd.go
+++ b/cmd/promote/cmd.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift/osdctl/cmd/promote/blocked"
 	"github.com/openshift/osdctl/cmd/promote/dynatrace"
 	"github.com/openshift/osdctl/cmd/promote/managedscripts"
+	"github.com/openshift/osdctl/cmd/promote/rhobs"
 	"github.com/openshift/osdctl/cmd/promote/saas"
 	"github.com/spf13/cobra"
 )
@@ -23,6 +24,7 @@ func NewCmdPromote() *cobra.Command {
 	promoteCmd.AddCommand(dynatrace.NewCmdDynatrace())
 	promoteCmd.AddCommand(managedscripts.NewCmdManagedScripts())
 	promoteCmd.AddCommand(blocked.NewCmdBlock())
+	promoteCmd.AddCommand(rhobs.NewCmdRhobs())
 
 	return promoteCmd
 }

--- a/cmd/promote/rhobs/rhobs.go
+++ b/cmd/promote/rhobs/rhobs.go
@@ -1,0 +1,303 @@
+package rhobs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/openshift/osdctl/pkg/promote"
+	"github.com/spf13/cobra"
+
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+const (
+	rhobsSaasDirPath      = "data/services/rhobs/rhobs/cicd"
+	rhobsProdNamespaceRef = "rhobs-production"
+)
+
+// SRE-owned saas files for monitoring stack, collection, tenant rules,
+// dashboards, and synthetics. RHOBS infra saas files (alertmanager,
+// thanos, loki, gateway, cache, objstore, operator) are owned by the
+// RHOBS Platform Team and promoted separately.
+var sreOwnedServices = map[string]bool{
+	"saas-hcp-rules":                       true,
+	"saas-sc-rules":                        true,
+	"saas-hcp-loki-alerts":                 true,
+	"saas-hcp-loki-recording-rules":        true,
+	"saas-metric-collection-integration":   true,
+	"saas-metric-collection-stage":         true,
+	"saas-metric-collection-production":    true,
+	"saas-log-forwarder-integration":       true,
+	"saas-log-forwarder-stage":             true,
+	"saas-log-forwarder-production":        true,
+	"saas-log-event-collector-integration": true,
+	"saas-log-event-collector-stage":       true,
+	"saas-log-event-collector-production":  true,
+	"saas-log-token-refresher-integration": true,
+	"saas-log-token-refresher-stage":       true,
+	"saas-log-token-refresher-production":  true,
+	"saas-dashboards":                      true,
+	"saas-servicemonitors":                 true,
+	"saas-synthetics-agent":                true,
+	"saas-synthetics-api":                  true,
+	"saas-ocm-log-collection":              true,
+	"saas-ocm-metric-collection":           true,
+}
+
+type rhobsOptions struct {
+	list bool
+
+	appInterfaceProvidedPath string
+	configRepoPath           string
+	serviceId                string
+	gitHash                  string
+}
+
+func validateRhobsServiceFilePath(filePath string) string {
+	base := filepath.Base(filePath)
+	if !strings.HasPrefix(base, "saas-") || !strings.HasSuffix(base, ".yaml") {
+		return ""
+	}
+	serviceId := strings.TrimSuffix(base, ".yaml")
+	if !sreOwnedServices[serviceId] {
+		return ""
+	}
+	return filePath
+}
+
+func resolveConfigRepoPath(provided string) (string, error) {
+	if provided != "" {
+		if _, err := os.Stat(filepath.Join(provided, ".git")); err != nil {
+			return "", fmt.Errorf("invalid --configRepoDir %q: not a git repository", provided)
+		}
+		return provided, nil
+	}
+	candidates := []string{
+		filepath.Join(os.Getenv("HOME"), "src", "configuration"),
+		filepath.Join(os.Getenv("HOME"), "src", "rhobs-configuration"),
+		filepath.Join(os.Getenv("HOME"), "src", "rhobs-configuration-gitlab"),
+	}
+	for _, p := range candidates {
+		if _, err := os.Stat(filepath.Join(p, ".git")); err == nil {
+			return p, nil
+		}
+	}
+	return "", nil
+}
+
+type rhobsPromoteCallbacks struct {
+	promote.DefaultPromoteCallbacks
+
+	localRepoPath string
+	httpsURL      string
+}
+
+func (c *rhobsPromoteCallbacks) GetResourceTemplateRepoUrl(resourceTemplateNode *kyaml.RNode) (string, error) {
+	url, err := c.DefaultPromoteCallbacks.GetResourceTemplateRepoUrl(resourceTemplateNode)
+	if err != nil {
+		return "", err
+	}
+	c.httpsURL = url
+	if c.localRepoPath != "" {
+		return c.localRepoPath, nil
+	}
+	return url, nil
+}
+
+func (c *rhobsPromoteCallbacks) FilterTargets(targetNodes []*kyaml.RNode) ([]*kyaml.RNode, error) {
+	return promote.FilterTargetsContainingNamespaceRef(targetNodes, rhobsProdNamespaceRef)
+}
+
+func (c *rhobsPromoteCallbacks) ComputeCommitMessage(resourceTemplateRepo *promote.Repo, resourceTemplatePath, oldHash, newHash string) (*promote.CommitMessage, error) {
+	commitMessage, err := c.DefaultPromoteCallbacks.ComputeCommitMessage(resourceTemplateRepo, resourceTemplatePath, oldHash, newHash)
+	if err != nil {
+		return nil, err
+	}
+	if c.httpsURL != "" {
+		commitMessage.ChangesURL = fmt.Sprintf("%s/-/compare/%s...%s", c.httpsURL, oldHash, newHash)
+	}
+	return commitMessage, nil
+}
+
+func isPinnedSHA(ref string) bool {
+	if len(ref) != 40 {
+		return false
+	}
+	for _, c := range ref {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func shortHash(hash string) string {
+	if len(hash) > 12 {
+		return hash[:12]
+	}
+	return hash
+}
+
+func promoteAllServices(appInterfaceClone *promote.AppInterfaceClone, servicesRegistry *promote.ServicesRegistry, gitHash string) error {
+	branchName := fmt.Sprintf("promote-rhobs-%s", shortHash(gitHash))
+	if err := appInterfaceClone.CheckoutNewBranch(branchName); err != nil {
+		return err
+	}
+
+	var promotedIds []string
+	for _, id := range servicesRegistry.GetServicesIds() {
+		service, err := servicesRegistry.GetService(id)
+		if err != nil {
+			continue
+		}
+
+		updated, err := updateProductionTargets(service, gitHash)
+		if err != nil {
+			fmt.Printf("Skipping %s: %v\n", id, err)
+			continue
+		}
+		if !updated {
+			continue
+		}
+
+		commitMsg := fmt.Sprintf("Promote %s to %s", id, shortHash(gitHash))
+		if err := appInterfaceClone.Commit(commitMsg); err != nil {
+			return fmt.Errorf("failed to commit %s: %v", id, err)
+		}
+		promotedIds = append(promotedIds, id)
+		fmt.Printf("Promoted %s\n", id)
+	}
+
+	if len(promotedIds) == 0 {
+		return errors.New("no RHOBS services had production targets to promote")
+	}
+
+	fmt.Printf("\nPromoted %d service(s) on branch: %s\n", len(promotedIds), branchName)
+	fmt.Printf("Push the branch and create a MR from: %s\n", appInterfaceClone.GetPath())
+	return nil
+}
+
+func updateProductionTargets(service *promote.Service, newHash string) (bool, error) {
+	updated := false
+	err := service.GetResourceTemplatesSequenceNode().VisitElements(func(rtNode *kyaml.RNode) error {
+		targetsNode, err := kyaml.Lookup("targets").Filter(rtNode)
+		if err != nil || targetsNode == nil {
+			return nil
+		}
+		return targetsNode.VisitElements(func(targetNode *kyaml.RNode) error {
+			nsRef, _ := targetNode.GetString("namespace.$ref")
+			if !strings.Contains(nsRef, rhobsProdNamespaceRef) {
+				return nil
+			}
+			currentRef, err := targetNode.GetString("ref")
+			if err != nil || currentRef == "" {
+				return nil
+			}
+			if !isPinnedSHA(currentRef) || currentRef == newHash {
+				return nil
+			}
+			_, err = kyaml.SetField("ref", kyaml.NewStringRNode(newHash)).Filter(targetNode)
+			if err != nil {
+				return err
+			}
+			updated = true
+			return nil
+		})
+	})
+	if err != nil {
+		return false, err
+	}
+	if updated {
+		if err := service.Save(); err != nil {
+			return false, err
+		}
+	}
+	return updated, nil
+}
+
+func NewCmdRhobs() *cobra.Command {
+	ops := &rhobsOptions{}
+	rhobsCmd := &cobra.Command{
+		Use:               "rhobs",
+		Short:             "Promote RHOBS configuration to production",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		Example: `
+		# List all RHOBS services
+		osdctl promote rhobs --list
+
+		# Promote all RHOBS services to a specific git hash
+		osdctl promote rhobs --gitHash <git-hash>
+
+		# Promote a single RHOBS service
+		osdctl promote rhobs --serviceId saas-hcp-rules --gitHash <git-hash>`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			appInterfaceClone, err := promote.FindAppInterfaceClone(ops.appInterfaceProvidedPath)
+			if err != nil {
+				return err
+			}
+
+			servicesRegistry, err := promote.NewServicesRegistry(
+				appInterfaceClone,
+				validateRhobsServiceFilePath,
+				rhobsSaasDirPath,
+			)
+			if err != nil {
+				return err
+			}
+
+			if ops.list {
+				if ops.serviceId != "" || ops.gitHash != "" {
+					return errors.New("--list cannot be used with --serviceId or --gitHash")
+				}
+
+				fmt.Println("### Available RHOBS services ###")
+				for _, serviceId := range servicesRegistry.GetServicesIds() {
+					fmt.Println(serviceId)
+				}
+				return nil
+			}
+
+			cmd.SilenceUsage = true
+
+			localRepoPath, err := resolveConfigRepoPath(ops.configRepoPath)
+			if err != nil {
+				return err
+			}
+			if localRepoPath != "" {
+				fmt.Printf("Using local rhobs/configuration checkout: %s\n\n", localRepoPath)
+			}
+
+			if ops.serviceId != "" {
+				service, err := servicesRegistry.GetService(ops.serviceId)
+				if err != nil {
+					return err
+				}
+				return service.Promote(&rhobsPromoteCallbacks{
+					DefaultPromoteCallbacks: promote.DefaultPromoteCallbacks{Service: service},
+					localRepoPath:           localRepoPath,
+				}, ops.gitHash)
+			}
+
+			if ops.gitHash == "" {
+				return errors.New("--gitHash is required when promoting all services")
+			}
+			if !isPinnedSHA(ops.gitHash) {
+				return errors.New("--gitHash must be a 40-character lowercase commit SHA when promoting all services")
+			}
+
+			return promoteAllServices(appInterfaceClone, servicesRegistry, ops.gitHash)
+		},
+	}
+
+	rhobsCmd.Flags().BoolVarP(&ops.list, "list", "l", false, "List all RHOBS SaaS file names")
+	rhobsCmd.Flags().StringVarP(&ops.serviceId, "serviceId", "", "", "Name of the SaaS file (without extension)")
+	rhobsCmd.Flags().StringVarP(&ops.gitHash, "gitHash", "g", "", "Git hash of rhobs/configuration to promote to (required for bulk promotion; defaults to HEAD for --serviceId)")
+	rhobsCmd.Flags().StringVarP(&ops.appInterfaceProvidedPath, "appInterfaceDir", "", "", "Location of app-interface checkout")
+	rhobsCmd.Flags().StringVarP(&ops.configRepoPath, "configRepoDir", "", "", "Location of rhobs/configuration checkout (auto-detected from ~/src/)")
+
+	return rhobsCmd
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -138,6 +138,7 @@
   - `block` - Add a blocked version to a component in app.yaml
   - `dynatrace` - Utilities to promote dynatrace
   - `managedscripts` - Promote https://github.com/openshift/managed-scripts
+  - `rhobs` - Promote RHOBS configuration to production
   - `saas` - Utilities to promote SaaS services/operators
 - `rhobs` - RHOBS.next related utilities
   - `cell` - Get the RHOBS cell for a given cluster
@@ -4258,6 +4259,26 @@ osdctl promote managedscripts [flags]
       --appInterfaceDir string   location of app-interface checkout. Falls back to current working directory
   -g, --gitHash string           Git hash of the managed-scripts repo commit getting promoted
   -h, --help                     help for managedscripts
+  -S, --skip-version-check       skip checking to see if this is the most recent release
+```
+
+### osdctl promote rhobs
+
+Promote RHOBS configuration to production
+
+```
+osdctl promote rhobs [flags]
+```
+
+#### Flags
+
+```
+      --appInterfaceDir string   Location of app-interface checkout
+      --configRepoDir string     Location of rhobs/configuration checkout (auto-detected from ~/src/)
+  -g, --gitHash string           Git hash of rhobs/configuration to promote to (required for bulk promotion; defaults to HEAD for --serviceId)
+  -h, --help                     help for rhobs
+  -l, --list                     List all RHOBS SaaS file names
+      --serviceId string         Name of the SaaS file (without extension)
   -S, --skip-version-check       skip checking to see if this is the most recent release
 ```
 

--- a/docs/osdctl_promote.md
+++ b/docs/osdctl_promote.md
@@ -20,5 +20,6 @@ Utilities to promote services/operators
 * [osdctl promote block](osdctl_promote_block.md)	 - Add a blocked version to a component in app.yaml
 * [osdctl promote dynatrace](osdctl_promote_dynatrace.md)	 - Utilities to promote dynatrace
 * [osdctl promote managedscripts](osdctl_promote_managedscripts.md)	 - Promote https://github.com/openshift/managed-scripts
+* [osdctl promote rhobs](osdctl_promote_rhobs.md)	 - Promote RHOBS configuration to production
 * [osdctl promote saas](osdctl_promote_saas.md)	 - Utilities to promote SaaS services/operators
 

--- a/docs/osdctl_promote_rhobs.md
+++ b/docs/osdctl_promote_rhobs.md
@@ -1,0 +1,43 @@
+## osdctl promote rhobs
+
+Promote RHOBS configuration to production
+
+```
+osdctl promote rhobs [flags]
+```
+
+### Examples
+
+```
+
+		# List all RHOBS services
+		osdctl promote rhobs --list
+
+		# Promote all RHOBS services to a specific git hash
+		osdctl promote rhobs --gitHash <git-hash>
+
+		# Promote a single RHOBS service
+		osdctl promote rhobs --serviceId saas-hcp-rules --gitHash <git-hash>
+```
+
+### Options
+
+```
+      --appInterfaceDir string   Location of app-interface checkout
+      --configRepoDir string     Location of rhobs/configuration checkout (auto-detected from ~/src/)
+  -g, --gitHash string           Git hash of rhobs/configuration to promote to (required for bulk promotion; defaults to HEAD for --serviceId)
+  -h, --help                     help for rhobs
+  -l, --list                     List all RHOBS SaaS file names
+      --serviceId string         Name of the SaaS file (without extension)
+```
+
+### Options inherited from parent commands
+
+```
+  -S, --skip-version-check   skip checking to see if this is the most recent release
+```
+
+### SEE ALSO
+
+* [osdctl promote](osdctl_promote.md)	 - Utilities to promote services/operators
+


### PR DESCRIPTION
## Summary

- Adds `osdctl promote rhobs` subcommand to promote rhobs/configuration saas files in app-interface
- Follows the same pattern as `promote dynatrace` and `promote saas`
- Filters production targets by `rhobs-production` namespace refs
- Auto-detects local rhobs/configuration checkout to avoid HTTPS auth issues with GitLab
- Supports `--list`, `--serviceId` for single service, or default all-services promotion

## Usage

```bash
# List available RHOBS saas services
osdctl promote rhobs --list

# Promote a single service
osdctl promote rhobs --serviceId saas-hcp-rules --gitHash <sha>

# Promote all RHOBS services with pinned production targets
osdctl promote rhobs --gitHash <sha>

# Specify app-interface and config repo paths explicitly
osdctl promote rhobs --gitHash <sha> --appInterfaceDir ~/src/app-interface --configRepoDir ~/src/configuration
```

## Context

RHOBS is replacing Dynatrace for ROSA HCP observability. The rhobs/configuration repo contains tenant rules, monitoring stack templates, and alerting configs deployed via app-interface saas files. Production targets are pinned to SHAs while int/stage use `ref: main`. Previously, promotion required either a bash script (HCP rules only) or manual YAML editing.

## Test plan

- [ ] `osdctl promote rhobs --list` lists all 29 RHOBS saas services
- [ ] `osdctl promote rhobs --serviceId saas-hcp-rules --gitHash <sha>` updates only HCP rules production targets
- [ ] `osdctl promote rhobs --gitHash <sha>` updates all services with production targets
- [ ] Non-production targets (ref: main) are not modified
- [ ] GitLab compare URL in commit message is correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RHOBS promote command: list eligible services, promote a single service (--serviceId) or all allowlisted services to a specified git hash (--gitHash), auto-detect local RHOBS config, and create a promotion branch for bulk updates. Only pinned production refs are updated; per-service skips/errors shown and an error is raised if no updates occurred.
* **Documentation**
  * Added CLI docs and linked the new RHOBS promote command in promote documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->