### PR TITLE
[SREP-4895] Fallback to deleted_cluster endpoint to get cluster information.

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -67,6 +67,7 @@ func GetCluster(connection *sdk.Connection, key string) (cluster *cmv1.Cluster, 
 	// Prepare the resources that we will be using:
 	subsResource := connection.AccountsMgmt().V1().Subscriptions()
 	clustersResource := connection.ClustersMgmt().V1().Clusters()
+	deletedClustersResource := connection.ClustersMgmt().V1().DeletedClusters()
 
 	// Try to find a matching subscription:
 	subsSearch := fmt.Sprintf(
@@ -141,6 +142,29 @@ func GetCluster(connection *sdk.Connection, key string) (cluster *cmv1.Cluster, 
 	if clustersTotal > 1 {
 		err = fmt.Errorf(
 			"There are %d clusters with identifier or name '%s'",
+			clustersTotal, key,
+		)
+		return
+	}
+
+	// If we get here we might still be able to get some information from the deleted_clusters information:
+	deletedClustersResponse, err := deletedClustersResource.List().Search(clustersSearch).Size(1).Send()
+	if err != nil {
+		err = fmt.Errorf("can't retrieve deleted clusters for key '%s': '%v'", key, err)
+		return
+	}
+
+	// If there is exactly one cluster matching then return it:
+	clustersTotal = deletedClustersResponse.Total()
+	if clustersTotal == 1 {
+		cluster = deletedClustersResponse.Items().Slice()[0].Cluster()
+		return
+	}
+
+	// If there are multiple matching clusters then we should report it as an error:
+	if clustersTotal > 1 {
+		err = fmt.Errorf(
+			"there are %d deleted clusters with identifier or name '%s'",
 			clustersTotal, key,
 		)
 		return


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cluster lookup now also searches archived/deleted clusters when no active match is found.
  * Returns a single archived cluster result or reports multiple matches to avoid ambiguity.
  * Ensures users can find historical cluster records using the same search input as for active clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->