### PR TITLE
SREP-4821: Skip SAPM-managed targets in rhobs promote

### DIFF
--- a/cmd/promote/rhobs/rhobs.go
+++ b/cmd/promote/rhobs/rhobs.go
@@ -180,6 +180,11 @@ func promoteAllServices(appInterfaceClone *promote.AppInterfaceClone, servicesRe
 	return nil
 }
 
+func targetHasSubscribe(targetNode *kyaml.RNode) bool {
+	promoNode, err := kyaml.Lookup("promotion", "subscribe").Filter(targetNode)
+	return err == nil && promoNode != nil
+}
+
 func updateProductionTargets(service *promote.Service, newHash string) (bool, error) {
 	updated := false
 	err := service.GetResourceTemplatesSequenceNode().VisitElements(func(rtNode *kyaml.RNode) error {
@@ -190,6 +195,9 @@ func updateProductionTargets(service *promote.Service, newHash string) (bool, er
 		return targetsNode.VisitElements(func(targetNode *kyaml.RNode) error {
 			nsRef, _ := targetNode.GetString("namespace.$ref")
 			if !strings.Contains(nsRef, rhobsProdNamespaceRef) {
+				return nil
+			}
+			if targetHasSubscribe(targetNode) {
 				return nil
 			}
 			currentRef, err := targetNode.GetString("ref")


### PR DESCRIPTION
## Summary

Skip targets with `promotion.subscribe` blocks when running `osdctl promote rhobs`. These targets are managed by SAPM progressive delivery and should not be manually promoted.

With SAPM waves in place (app-interface !188759, !188760, !188762), production targets in waves 2-5 auto-promote from the previous wave. Only wave 1 (canary) targets and non-wave services (hcp-rules, sc-rules, dashboards, etc.) should be manually promoted.

## Changes

- Add `targetHasSubscribe()` helper that checks for `promotion.subscribe` in a target node
- Skip targets with subscribe blocks in `updateProductionTargets()`

## Test plan

- [ ] Run `osdctl promote rhobs --list` (no change expected)
- [ ] Run `osdctl promote rhobs --gitHash <sha>` and verify only wave 1 + non-wave targets are updated
- [ ] Verify wave 2-5 targets are skipped (have subscribe blocks)

Jira: https://redhat.atlassian.net/browse/SREP-4821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated RHOBS target promotion logic to prevent ref field updates for targets with subscription content, ensuring more consistent promotion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->