### PR TITLE
SREP-4821: Use string replacement for rhobs promote

### DIFF
--- a/cmd/promote/rhobs/rhobs.go
+++ b/cmd/promote/rhobs/rhobs.go
@@ -206,7 +206,7 @@ func updateProductionTargets(service *promote.Service, newHash string) (bool, er
 	}
 
 	if updated {
-		if err := os.WriteFile(filePath, []byte(strings.Join(lines, "\n")), 0644); err != nil {
+		if err := os.WriteFile(filePath, []byte(strings.Join(lines, "\n")), 0600); err != nil {
 			return false, fmt.Errorf("failed to write %s: %v", filePath, err)
 		}
 	}

--- a/cmd/promote/rhobs/rhobs.go
+++ b/cmd/promote/rhobs/rhobs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/openshift/osdctl/pkg/promote"
@@ -180,50 +181,49 @@ func promoteAllServices(appInterfaceClone *promote.AppInterfaceClone, servicesRe
 	return nil
 }
 
-func targetHasSubscribe(targetNode *kyaml.RNode) bool {
-	promoNode, err := kyaml.Lookup("promotion", "subscribe").Filter(targetNode)
-	return err == nil && promoNode != nil
-}
+var shaRefPattern = regexp.MustCompile(`(\s+ref: )([0-9a-f]{40})`)
 
 func updateProductionTargets(service *promote.Service, newHash string) (bool, error) {
-	updated := false
-	err := service.GetResourceTemplatesSequenceNode().VisitElements(func(rtNode *kyaml.RNode) error {
-		targetsNode, err := kyaml.Lookup("targets").Filter(rtNode)
-		if err != nil || targetsNode == nil {
-			return nil
-		}
-		return targetsNode.VisitElements(func(targetNode *kyaml.RNode) error {
-			nsRef, _ := targetNode.GetString("namespace.$ref")
-			if !strings.Contains(nsRef, rhobsProdNamespaceRef) {
-				return nil
-			}
-			if targetHasSubscribe(targetNode) {
-				return nil
-			}
-			currentRef, err := targetNode.GetString("ref")
-			if err != nil || currentRef == "" {
-				return nil
-			}
-			if !isPinnedSHA(currentRef) || currentRef == newHash {
-				return nil
-			}
-			_, err = kyaml.SetField("ref", kyaml.NewStringRNode(newHash)).Filter(targetNode)
-			if err != nil {
-				return err
-			}
-			updated = true
-			return nil
-		})
-	})
+	filePath := service.GetFilePath()
+	content, err := os.ReadFile(filePath)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to read %s: %v", filePath, err)
 	}
+
+	lines := strings.Split(string(content), "\n")
+	updated := false
+
+	for i, line := range lines {
+		m := shaRefPattern.FindStringSubmatch(line)
+		if m == nil || m[2] == newHash {
+			continue
+		}
+		if targetBlockHasSubscribe(lines, i) {
+			continue
+		}
+		lines[i] = m[1] + newHash
+		updated = true
+	}
+
 	if updated {
-		if err := service.Save(); err != nil {
-			return false, err
+		if err := os.WriteFile(filePath, []byte(strings.Join(lines, "\n")), 0644); err != nil {
+			return false, fmt.Errorf("failed to write %s: %v", filePath, err)
 		}
 	}
 	return updated, nil
+}
+
+func targetBlockHasSubscribe(lines []string, refLineIdx int) bool {
+	for i := refLineIdx + 1; i < len(lines) && i < refLineIdx+15; i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "subscribe:" {
+			return true
+		}
+		if strings.HasPrefix(trimmed, "- name:") || strings.HasPrefix(lines[i], "- name:") {
+			break
+		}
+	}
+	return false
 }
 
 func NewCmdRhobs() *cobra.Command {


### PR DESCRIPTION
## Summary

Replace kyaml-based `updateProductionTargets` with string replacement to fix two issues:

1. **YAML corruption**: kyaml roundtrip strips promotion blocks, blank lines, and formatting from saas files when saving
2. **SAPM skip logic**: correctly skips targets with `subscribe:` blocks (SAPM-managed, waves 2+)

## Changes

- Rewrite `updateProductionTargets` to use regex-based string replacement instead of kyaml parse/modify/save
- Match pinned SHA refs via regex, replace in-place, write file directly
- Add `targetBlockHasSubscribe` helper that scans lines after `ref:` for a `subscribe:` block
- Remove `targetHasSubscribe` kyaml helper (from PR #899) and `isProductionTarget` namespace check (unnecessary since pinned SHAs only appear in production targets)

This now correctly promotes all service types: both `namespace.$ref` targets (hcp-rules, sc-rules) and `namespaceSelector` dynamic provider targets (metrics/logs collection).

## Test plan

- [x] `osdctl promote rhobs --gitHash <sha>` promotes 7 services (hcp-rules, sc-rules, 4 collection, servicemonitors)
- [x] hcp-rules/sc-rules: only wave 1 target (rhobsp01ue1) updated, waves 2-3 skipped
- [x] Collection files: only wave 1 targets (canary, tech-preview) updated, waves 2-5 skipped
- [x] YAML formatting and promotion blocks preserved (no blank line stripping)
- [x] Stage/integration targets (ref: main) not touched

Jira: https://redhat.atlassian.net/browse/SREP-4821


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved promotion command internals for more reliable and targeted production updates, reducing unnecessary revisions.
* **Bug Fix**
  * Avoids overwriting entries when a related subscription is present and skips no-op updates.
  * Surfaces file read/write failures more clearly so failed promotion updates are reported promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->