### PR TITLE
Remove non-SRE services from rhobs promote

### DIFF
--- a/cmd/promote/rhobs/rhobs.go
+++ b/cmd/promote/rhobs/rhobs.go
@@ -40,8 +40,6 @@ var sreOwnedServices = map[string]bool{
 	"saas-log-token-refresher-integration": true,
 	"saas-log-token-refresher-stage":       true,
 	"saas-log-token-refresher-production":  true,
-	"saas-dashboards":                      true,
-	"saas-servicemonitors":                 true,
 	"saas-synthetics-agent":                true,
 	"saas-synthetics-api":                  true,
 	"saas-ocm-log-collection":              true,


### PR DESCRIPTION
Remove saas-servicemonitors and saas-dashboards from the SRE-owned services list. These reference different repos (github.com/rhobs/configuration and github.com/rhobs/monitoring) with separate SHA histories and are not promoted alongside the RHOBS tenant configuration on GitLab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service registry: Removed two existing services (`saas-dashboards`, `saas-servicemonitors`) and added three new log token refresh services (`saas-log-token-refresher-integration`, `saas-log-token-refresher-stage`, `saas-log-token-refresher-production`). This affects how certain services are handled in the deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->