### PR TITLE
Fix nil pointer panic in Jira issue printing

### DIFF
--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -806,7 +806,23 @@ func printJIRASupportExceptions(issues []jira.Issue, w io.Writer) {
 	fmt.Fprintln(w, delimiter+name)
 
 	for _, i := range issues {
-		fmt.Fprintf(w, "[%s](%s/%s): %+v [Status: %s]\n", i.Key, i.Fields.Type.Name, i.Fields.Priority.Name, i.Fields.Summary, i.Fields.Status.Name)
+		summary := "Unknown"
+		typeName := "Unknown"
+		priorityName := "Unknown"
+		statusName := "Unknown"
+		if i.Fields != nil {
+			summary = i.Fields.Summary
+			if i.Fields.Type.Name != "" {
+				typeName = i.Fields.Type.Name
+			}
+			if i.Fields.Priority != nil {
+				priorityName = i.Fields.Priority.Name
+			}
+			if i.Fields.Status != nil {
+				statusName = i.Fields.Status.Name
+			}
+		}
+		fmt.Fprintf(w, "[%s](%s/%s): %+v [Status: %s]\n", i.Key, typeName, priorityName, summary, statusName)
 		fmt.Fprintf(w, "- Link: %s/browse/%s\n\n", JiraBaseURL, i.Key)
 	}
 

--- a/pkg/utils/print.go
+++ b/pkg/utils/print.go
@@ -91,8 +91,20 @@ func PrintJiraIssues(issues []jira.Issue) {
 	fmt.Println(delimiter + name)
 
 	for _, i := range issues {
-		fmt.Printf("[%s|%s/browse/%s](%s/%s): %+v\n", i.Key, JiraBaseURL, i.Key, i.Fields.Type.Name, i.Fields.Priority.Name, i.Fields.Summary)
-		fmt.Printf("- Created: %s\tStatus: %s\n", time.Time(i.Fields.Created).Format("2006-01-02 15:04"), i.Fields.Status.Name)
+		typeName := "Unknown"
+		if i.Fields.Type.Name != "" {
+			typeName = i.Fields.Type.Name
+		}
+		priorityName := "Unknown"
+		if i.Fields.Priority != nil {
+			priorityName = i.Fields.Priority.Name
+		}
+		statusName := "Unknown"
+		if i.Fields.Status != nil {
+			statusName = i.Fields.Status.Name
+		}
+		fmt.Printf("[%s|%s/browse/%s](%s/%s): %+v\n", i.Key, JiraBaseURL, i.Key, typeName, priorityName, i.Fields.Summary)
+		fmt.Printf("- Created: %s\tStatus: %s\n", time.Time(i.Fields.Created).Format("2006-01-02 15:04"), statusName)
 	}
 
 	if len(issues) == 0 {

--- a/pkg/utils/print.go
+++ b/pkg/utils/print.go
@@ -91,20 +91,26 @@ func PrintJiraIssues(issues []jira.Issue) {
 	fmt.Println(delimiter + name)
 
 	for _, i := range issues {
+		summary := "Unknown"
+		created := "Unknown"
 		typeName := "Unknown"
-		if i.Fields.Type.Name != "" {
-			typeName = i.Fields.Type.Name
-		}
 		priorityName := "Unknown"
-		if i.Fields.Priority != nil {
-			priorityName = i.Fields.Priority.Name
-		}
 		statusName := "Unknown"
-		if i.Fields.Status != nil {
-			statusName = i.Fields.Status.Name
+		if i.Fields != nil {
+			summary = i.Fields.Summary
+			created = time.Time(i.Fields.Created).Format("2006-01-02 15:04")
+			if i.Fields.Type.Name != "" {
+				typeName = i.Fields.Type.Name
+			}
+			if i.Fields.Priority != nil {
+				priorityName = i.Fields.Priority.Name
+			}
+			if i.Fields.Status != nil {
+				statusName = i.Fields.Status.Name
+			}
 		}
-		fmt.Printf("[%s|%s/browse/%s](%s/%s): %+v\n", i.Key, JiraBaseURL, i.Key, typeName, priorityName, i.Fields.Summary)
-		fmt.Printf("- Created: %s\tStatus: %s\n", time.Time(i.Fields.Created).Format("2006-01-02 15:04"), statusName)
+		fmt.Printf("[%s|%s/browse/%s](%s/%s): %+v\n", i.Key, JiraBaseURL, i.Key, typeName, priorityName, summary)
+		fmt.Printf("- Created: %s\tStatus: %s\n", created, statusName)
 	}
 
 	if len(issues) == 0 {


### PR DESCRIPTION
## Summary
- Fix nil pointer dereference in `PrintJiraIssues` (`pkg/utils/print.go`) when a Jira issue has nil `Priority` or `Status` fields
- Fix same issue in `printJIRASupportExceptions` (`cmd/cluster/context.go`)

## Root Cause
`i.Fields.Priority` and `i.Fields.Status` are pointer types in the go-jira library and can be nil when the Jira issue doesn't have those fields set. The code dereferenced them without nil checks.

## Stack Trace
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x20 pc=0x1044d647c]

goroutine 1 [running]:
github.com/openshift/osdctl/pkg/utils.PrintJiraIssues({0x65274b7054a0, 0x3, 0x0?})
    github.com/openshift/osdctl/pkg/utils/print.go:94 +0x12c
github.com/openshift/osdctl/cmd/cluster.(*contextOptions).printLongOutput(...)
    github.com/openshift/osdctl/cmd/cluster/context.go:260 +0x1c8
github.com/openshift/osdctl/cmd/cluster.(*contextOptions).run(...)
    github.com/openshift/osdctl/cmd/cluster/context.go:240 +0x1ec
```

## Test plan
- [ ] `osdctl cluster context` with a cluster that has OHSS issues with nil Priority/Status fields
- [ ] Verify no panic, fields display as "Unknown" instead

/tide squash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Jira issue display would fail when certain fields (type, priority, or status) were missing or unavailable. Missing fields now display as "Unknown" instead of causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->