### PR TITLE
[SREP-4777] Switch to a multi-cluster image that is based on UBI.

### DIFF
--- a/cmd/hcp/mustgather/mustGather.go
+++ b/cmd/hcp/mustgather/mustGather.go
@@ -50,7 +50,8 @@ func NewCmdMustGather() *cobra.Command {
 		},
 	}
 
-	defaultAcmImage := "quay.io/stolostron/must-gather:2.11.4-SNAPSHOT-2024-12-02-15-19-44"
+	// The registry.redhat.io image requires authentication - see https://access.redhat.com/articles/RegistryAuthentication
+	defaultAcmImage := "registry.redhat.io/multicluster-engine/must-gather-rhel9:v2.9.4-1"
 	mustGatherCommand.Flags().StringVarP(&mg.clusterId, "cluster-id", "C", "", "Internal ID of the cluster to gather data from")
 	mustGatherCommand.Flags().StringVar(&mg.reason, "reason", "", "The reason for this command, which requires elevation (e.g., OHSS ticket or PD incident).")
 	mustGatherCommand.Flags().StringVar(&mg.gatherTargets, "gather", "hcp", "Comma-separated list of gather targets (available: sc, sc_acm, mc, hcp).")
@@ -194,10 +195,8 @@ func (mg *mustGather) Run() error {
 				hcName := cluster.DomainPrefix()
 				hcNamespace := strings.TrimSuffix(hcpNamespace, "-"+hcName)
 
-				// TODO(ACM-16170): replace this with an official ACM release image once it's available
-				acmHyperShiftImage := "quay.io/rokejungrh/must-gather:v2.13.0-33-linux"
 				gatherScript := fmt.Sprintf("/usr/bin/gather hosted-cluster-namespace=%s hosted-cluster-name=%s", hcNamespace, hcName)
-				if err := createMustGather(mcRestCfg, mcK8sCli, []string{"--dest-dir=" + destDir, "--image=" + acmHyperShiftImage, gatherScript}); err != nil {
+				if err := createMustGather(mcRestCfg, mcK8sCli, []string{"--dest-dir=" + destDir, "--image=" + mg.acmMustGatherImage, gatherScript}); err != nil {
 					fmt.Printf("collected HCP dynatrace logs but failed to gather %s: %v\n", gatherTarget, err.Error())
 				}
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3164,7 +3164,7 @@ osdctl hcp must-gather --cluster-id <cluster-identifier> [flags]
 #### Flags
 
 ```
-      --acm_image string                 Overrides the acm must-gather image being used for acm mc, sc as well as hcp must-gathers. (default "quay.io/stolostron/must-gather:2.11.4-SNAPSHOT-2024-12-02-15-19-44")
+      --acm_image string                 Overrides the acm must-gather image being used for acm mc, sc as well as hcp must-gathers. (default "registry.redhat.io/multicluster-engine/must-gather-rhel9:v2.9.4-1")
       --as string                        Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
       --cluster string                   The name of the kubeconfig cluster to use
   -C, --cluster-id string                Internal ID of the cluster to gather data from

--- a/docs/osdctl_hcp_must-gather.md
+++ b/docs/osdctl_hcp_must-gather.md
@@ -19,7 +19,7 @@ osdctl hcp must-gather --cluster-id CLUSTER_ID --gather sc,mc,sc_acm --reason OH
 ### Options
 
 ```
-      --acm_image string    Overrides the acm must-gather image being used for acm mc, sc as well as hcp must-gathers. (default "quay.io/stolostron/must-gather:2.11.4-SNAPSHOT-2024-12-02-15-19-44")
+      --acm_image string    Overrides the acm must-gather image being used for acm mc, sc as well as hcp must-gathers. (default "registry.redhat.io/multicluster-engine/must-gather-rhel9:v2.9.4-1")
   -C, --cluster-id string   Internal ID of the cluster to gather data from
       --gather string       Comma-separated list of gather targets (available: sc, sc_acm, mc, hcp). (default "hcp")
   -h, --help                help for must-gather


### PR DESCRIPTION
Replace old images with upstream images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the must-gather image for ACM functionality to use a RHEL9 image from registry.redhat.io (requires registry authentication).
  * The ACM image can now be configured via the `--acm_image` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->