### PR TITLE
Default account cli output to env with export prefix

### DIFF
--- a/cmd/account/cli.go
+++ b/cmd/account/cli.go
@@ -1,7 +1,9 @@
 package account
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/openshift/osdctl/pkg/osdCloud"
@@ -27,7 +29,7 @@ func newCmdCli() *cobra.Command {
 	cliCmd.Flags().BoolVarP(&ops.verbose, "verbose", "", false, "Verbose output")
 	cliCmd.Flags().StringVarP(&ops.awsAccountID, "accountId", "i", "", "AWS Account ID")
 	cliCmd.Flags().StringVarP(&ops.awsProfile, "profile", "p", "", "AWS Profile")
-	cliCmd.Flags().StringVarP(&ops.output, "output", "o", "", "Output type")
+	cliCmd.Flags().StringVarP(&ops.output, "output", "o", "env", "Output type (env, json)")
 	cliCmd.Flags().StringVarP(&ops.region, "region", "r", "", "Region")
 
 	return cliCmd
@@ -87,26 +89,32 @@ func (o *cliOptions) run() error {
 		return err
 	}
 
-	// Output section
-	// Default to json
-	if o.output == "" || o.output == "json" {
-		fmt.Printf("{\n\"AccessKeyId\": %q, \n\"Expiration\": %q, \n\"SecretAccessKey\": %q, \n\"SessionToken\": %q, \n\"Region\": %q\n}",
-			*assumedRoleCreds.AccessKeyId,
-			*assumedRoleCreds.Expiration,
-			*assumedRoleCreds.SecretAccessKey,
-			*assumedRoleCreds.SessionToken,
-			o.region,
-		)
-	}
-
-	if o.output == "env" {
-		fmt.Printf("AWS_ACCESS_KEY_ID=%s\nAWS_SECRET_ACCESS_KEY=%s\nAWS_SESSION_TOKEN=%s\nAWS_DEFAULT_REGION=%s\nAWS_REGION=%s\n",
-			*assumedRoleCreds.AccessKeyId,
-			*assumedRoleCreds.SecretAccessKey,
-			*assumedRoleCreds.SessionToken,
-			o.region,
-			o.region,
-		)
+	switch o.output {
+	case "json":
+		out := struct {
+			AccessKeyId     string `json:"AccessKeyId"`
+			Expiration      string `json:"Expiration"`
+			SecretAccessKey string `json:"SecretAccessKey"`
+			SessionToken    string `json:"SessionToken"`
+			Region          string `json:"Region"`
+		}{
+			AccessKeyId:     *assumedRoleCreds.AccessKeyId,
+			Expiration:      assumedRoleCreds.Expiration.String(),
+			SecretAccessKey: *assumedRoleCreds.SecretAccessKey,
+			SessionToken:    *assumedRoleCreds.SessionToken,
+			Region:          o.region,
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(out); err != nil {
+			return err
+		}
+	default:
+		fmt.Printf("export AWS_ACCESS_KEY_ID=%s\n", *assumedRoleCreds.AccessKeyId)
+		fmt.Printf("export AWS_SECRET_ACCESS_KEY=%s\n", *assumedRoleCreds.SecretAccessKey)
+		fmt.Printf("export AWS_SESSION_TOKEN=%s\n", *assumedRoleCreds.SessionToken)
+		fmt.Printf("export AWS_DEFAULT_REGION=%s\n", o.region)
+		fmt.Printf("export AWS_REGION=%s\n", o.region)
 	}
 
 	return nil

--- a/docs/README.md
+++ b/docs/README.md
@@ -292,7 +292,7 @@ osdctl account cli [flags]
   -h, --help                             help for cli
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
-  -o, --output string                    Output type
+  -o, --output string                    Output type (env, json) (default "env")
   -p, --profile string                   AWS Profile
   -r, --region string                    Region
       --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")

--- a/docs/osdctl_account_cli.md
+++ b/docs/osdctl_account_cli.md
@@ -11,7 +11,7 @@ osdctl account cli [flags]
 ```
   -i, --accountId string   AWS Account ID
   -h, --help               help for cli
-  -o, --output string      Output type
+  -o, --output string      Output type (env, json) (default "env")
   -p, --profile string     AWS Profile
   -r, --region string      Region
       --verbose            Verbose output


### PR DESCRIPTION
Change the default output format from JSON to env so credentials can be loaded directly with eval $(osdctl account cli -i <id>). Each env var line is now prefixed with `export`. Also clean up the output formatting to use json.NewEncoder for JSON and individual fmt.Printf calls for env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON output option for AWS credentials via an output flag, including credential fields and expiration.

* **Changes**
  * Default output now prints shell export statements for AWS environment variables instead of JSON.

* **Documentation**
  * Updated CLI docs to list supported output types (env, json) and note the default is env.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->