### PR TITLE
fix: document required flags in examples and clean up error output

### DIFF
--- a/cmd/account/cli.go
+++ b/cmd/account/cli.go
@@ -106,7 +106,7 @@ func (o *cliOptions) run() error {
 		}
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		if err := enc.Encode(out); err != nil {
+		if err := enc.Encode(out); err != nil { //nolint:gosec // G117 false positive — intentionally outputting AWS credentials
 			return err
 		}
 	default:

--- a/cmd/account/rotate-secret.go
+++ b/cmd/account/rotate-secret.go
@@ -29,9 +29,17 @@ import (
 func newCmdRotateSecret(streams genericclioptions.IOStreams, client *k8s.LazyClient) *cobra.Command {
 	ops := newRotateSecretOptions(streams, client)
 	rotateSecretCmd := &cobra.Command{
-		Use:               "rotate-secret <aws-account-cr-name>",
+		Use:               "rotate-secret ${AWS_ACCOUNT_CR_NAME}",
 		Short:             "Rotate IAM credentials secret",
-		Long:              "When logged into a hive shard, this rotates IAM credential secrets for a given `account` CR.",
+		Long: "When logged into a hive shard, this rotates IAM credential secrets for a given `account` CR.",
+		Example: `  # Rotate IAM credentials for an account CR
+  osdctl account rotate-secret ${AWS_ACCOUNT_CR_NAME} --cluster-id ${CLUSTER_ID} --reason "${REASON}"
+
+  # Rotate including CCS admin credentials
+  osdctl account rotate-secret ${AWS_ACCOUNT_CR_NAME} --cluster-id ${CLUSTER_ID} --reason "${REASON}" --ccs
+
+  # Dry-run to preview without making changes
+  osdctl account rotate-secret ${AWS_ACCOUNT_CR_NAME} --cluster-id ${CLUSTER_ID} --reason "${REASON}" --dry-run`,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(ops.complete(cmd, args))

--- a/cmd/account/rotate-secret.go
+++ b/cmd/account/rotate-secret.go
@@ -29,9 +29,9 @@ import (
 func newCmdRotateSecret(streams genericclioptions.IOStreams, client *k8s.LazyClient) *cobra.Command {
 	ops := newRotateSecretOptions(streams, client)
 	rotateSecretCmd := &cobra.Command{
-		Use:               "rotate-secret ${AWS_ACCOUNT_CR_NAME}",
-		Short:             "Rotate IAM credentials secret",
-		Long: "When logged into a hive shard, this rotates IAM credential secrets for a given `account` CR.",
+		Use:   "rotate-secret ${AWS_ACCOUNT_CR_NAME}",
+		Short: "Rotate IAM credentials secret",
+		Long:  "When logged into a hive shard, this rotates IAM credential secrets for a given `account` CR.",
 		Example: `  # Rotate IAM credentials for an account CR
   osdctl account rotate-secret ${AWS_ACCOUNT_CR_NAME} --cluster-id ${CLUSTER_ID} --reason "${REASON}"
 

--- a/cmd/alerts/list_alerts.go
+++ b/cmd/alerts/list_alerts.go
@@ -23,7 +23,7 @@ func NewCmdListAlerts() *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:   "list --cluster-id <cluster-id> --level [warning, critical, firing, pending, all]",
 		Short: "List all alerts or based on severity",
-		Long: `Checks the alerts for the cluster and print the list based on severity`,
+		Long:  `Checks the alerts for the cluster and print the list based on severity`,
 		Example: `  # List all alerts for a cluster
   osdctl alerts list --cluster-id ${CLUSTER_ID} --reason "${REASON}"
 

--- a/cmd/alerts/list_alerts.go
+++ b/cmd/alerts/list_alerts.go
@@ -24,8 +24,11 @@ func NewCmdListAlerts() *cobra.Command {
 		Use:   "list --cluster-id <cluster-id> --level [warning, critical, firing, pending, all]",
 		Short: "List all alerts or based on severity",
 		Long: `Checks the alerts for the cluster and print the list based on severity`,
-		Example: `  # List all firing alerts for a cluster
+		Example: `  # List all alerts for a cluster
   osdctl alerts list --cluster-id ${CLUSTER_ID} --reason "${REASON}"
+
+  # List only firing alerts
+  osdctl alerts list --cluster-id ${CLUSTER_ID} --level firing --reason "${REASON}"
 
   # List only critical alerts
   osdctl alerts list --cluster-id ${CLUSTER_ID} --level critical --reason "${REASON}"`,

--- a/cmd/alerts/list_alerts.go
+++ b/cmd/alerts/list_alerts.go
@@ -23,8 +23,12 @@ func NewCmdListAlerts() *cobra.Command {
 	newCmd := &cobra.Command{
 		Use:   "list --cluster-id <cluster-id> --level [warning, critical, firing, pending, all]",
 		Short: "List all alerts or based on severity",
-		Long:  `Checks the alerts for the cluster and print the list based on severity`,
+		Long: `Checks the alerts for the cluster and print the list based on severity`,
+		Example: `  # List all firing alerts for a cluster
+  osdctl alerts list --cluster-id ${CLUSTER_ID} --reason "${REASON}"
 
+  # List only critical alerts
+  osdctl alerts list --cluster-id ${CLUSTER_ID} --level critical --reason "${REASON}"`,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			ListAlerts(alertCmd)

--- a/cmd/alerts/silence/add_silence.go
+++ b/cmd/alerts/silence/add_silence.go
@@ -28,7 +28,15 @@ func NewCmdAddSilence() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add --cluster-id <cluster-identifier> [--all --duration --comment | --alertname --duration --comment]",
 		Short:             "Add new silence for alert",
-		Long:              `add new silence for specfic or all alert with comment and duration of alert`,
+		Long: `add new silence for specfic or all alert with comment and duration of alert`,
+		Example: `  # Silence a specific alert
+  osdctl alerts silence add --cluster-id ${CLUSTER_ID} --alertname "KubePodNotReady" --reason "${REASON}"
+
+  # Silence all alerts for a cluster
+  osdctl alerts silence add --cluster-id ${CLUSTER_ID} --all --reason "${REASON}"
+
+  # Silence an alert with custom duration and comment
+  osdctl alerts silence add --cluster-id ${CLUSTER_ID} --alertname "KubePodNotReady" --duration 2h --comment "Investigating pod issue" --reason "${REASON}"`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/alerts/silence/add_silence.go
+++ b/cmd/alerts/silence/add_silence.go
@@ -26,9 +26,9 @@ type addSilenceCmd struct {
 func NewCmdAddSilence() *cobra.Command {
 	addSilenceCmd := &addSilenceCmd{}
 	cmd := &cobra.Command{
-		Use:               "add --cluster-id <cluster-identifier> [--all --duration --comment | --alertname --duration --comment]",
-		Short:             "Add new silence for alert",
-		Long: `Add a new silence for a specific alert or for all alerts, including a comment and duration.`,
+		Use:   "add --cluster-id <cluster-identifier> [--all --duration --comment | --alertname --duration --comment]",
+		Short: "Add new silence for alert",
+		Long:  `Add a new silence for a specific alert or for all alerts, including a comment and duration.`,
 		Example: `  # Silence a specific alert
   osdctl alerts silence add --cluster-id ${CLUSTER_ID} --alertname "KubePodNotReady" --reason "${REASON}"
 

--- a/cmd/alerts/silence/add_silence.go
+++ b/cmd/alerts/silence/add_silence.go
@@ -28,7 +28,7 @@ func NewCmdAddSilence() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add --cluster-id <cluster-identifier> [--all --duration --comment | --alertname --duration --comment]",
 		Short:             "Add new silence for alert",
-		Long: `add new silence for specfic or all alert with comment and duration of alert`,
+		Long: `Add a new silence for a specific alert or for all alerts, including a comment and duration.`,
 		Example: `  # Silence a specific alert
   osdctl alerts silence add --cluster-id ${CLUSTER_ID} --alertname "KubePodNotReady" --reason "${REASON}"
 

--- a/cmd/alerts/silence/clear_silence.go
+++ b/cmd/alerts/silence/clear_silence.go
@@ -22,9 +22,9 @@ type silenceCmd struct {
 func NewCmdClearSilence() *cobra.Command {
 	silenceCmd := &silenceCmd{}
 	cmd := &cobra.Command{
-		Use:               "expire [--cluster-id <cluster-identifier>] [--all | --silence-id <silence-id>]",
-		Short:             "Expire Silence for alert",
-		Long: `Expire all silences, or expire a specific silence by its silence ID.`,
+		Use:   "expire [--cluster-id <cluster-identifier>] [--all | --silence-id <silence-id>]",
+		Short: "Expire Silence for alert",
+		Long:  `Expire all silences, or expire a specific silence by its silence ID.`,
 		Example: `  # Expire a specific silence by ID
   osdctl alerts silence expire --cluster-id ${CLUSTER_ID} --silence-id ${SILENCE_ID} --reason "${REASON}"
 

--- a/cmd/alerts/silence/clear_silence.go
+++ b/cmd/alerts/silence/clear_silence.go
@@ -24,7 +24,7 @@ func NewCmdClearSilence() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "expire [--cluster-id <cluster-identifier>] [--all | --silence-id <silence-id>]",
 		Short:             "Expire Silence for alert",
-		Long: `expire all silence or based on silenceid`,
+		Long: `Expire all silences, or expire a specific silence by its silence ID.`,
 		Example: `  # Expire a specific silence by ID
   osdctl alerts silence expire --cluster-id ${CLUSTER_ID} --silence-id ${SILENCE_ID} --reason "${REASON}"
 

--- a/cmd/alerts/silence/clear_silence.go
+++ b/cmd/alerts/silence/clear_silence.go
@@ -24,7 +24,12 @@ func NewCmdClearSilence() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "expire [--cluster-id <cluster-identifier>] [--all | --silence-id <silence-id>]",
 		Short:             "Expire Silence for alert",
-		Long:              `expire all silence or based on silenceid`,
+		Long: `expire all silence or based on silenceid`,
+		Example: `  # Expire a specific silence by ID
+  osdctl alerts silence expire --cluster-id ${CLUSTER_ID} --silence-id ${SILENCE_ID} --reason "${REASON}"
+
+  # Expire all silences for a cluster
+  osdctl alerts silence expire --cluster-id ${CLUSTER_ID} --all --reason "${REASON}"`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/alerts/silence/list_silence.go
+++ b/cmd/alerts/silence/list_silence.go
@@ -18,9 +18,9 @@ type listSilenceCmd struct {
 func NewCmdListSilence() *cobra.Command {
 	listSilenceCmd := &listSilenceCmd{}
 	cmd := &cobra.Command{
-		Use:               "list --cluster-id <cluster-identifier>",
-		Short:             "List all silences",
-		Long: `print the list of silences`,
+		Use:   "list --cluster-id <cluster-identifier>",
+		Short: "List all silences",
+		Long:  `print the list of silences`,
 		Example: `  # List all active silences for a cluster
   osdctl alerts silence list --cluster-id ${CLUSTER_ID} --reason "${REASON}"`,
 		Args:              cobra.NoArgs,

--- a/cmd/alerts/silence/list_silence.go
+++ b/cmd/alerts/silence/list_silence.go
@@ -20,7 +20,9 @@ func NewCmdListSilence() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "list --cluster-id <cluster-identifier>",
 		Short:             "List all silences",
-		Long:              `print the list of silences`,
+		Long: `print the list of silences`,
+		Example: `  # List all active silences for a cluster
+  osdctl alerts silence list --cluster-id ${CLUSTER_ID} --reason "${REASON}"`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/alerts/silence/silence_org.go
+++ b/cmd/alerts/silence/silence_org.go
@@ -21,9 +21,9 @@ type AddOrgSilenceCmd struct {
 func NewCmdAddOrgSilence() *cobra.Command {
 	AddOrgSilenceCmd := &AddOrgSilenceCmd{}
 	cmd := &cobra.Command{
-		Use:               "org <org-id> [--all --duration --comment | --alertname --duration --comment]",
-		Short:             "Add new silence for alert for org",
-		Long: `Add a new silence for specific alerts or all alerts with a comment and duration for an organization. OHSS required for org-wide silence.`,
+		Use:   "org <org-id> [--all --duration --comment | --alertname --duration --comment]",
+		Short: "Add new silence for alert for org",
+		Long:  `Add a new silence for specific alerts or all alerts with a comment and duration for an organization. OHSS required for org-wide silence.`,
 		Example: `  # Silence all alerts for an organization
   osdctl alerts silence org ${ORG_ID} --all --comment "${REASON}: org-wide silence"
 

--- a/cmd/alerts/silence/silence_org.go
+++ b/cmd/alerts/silence/silence_org.go
@@ -23,7 +23,12 @@ func NewCmdAddOrgSilence() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "org <org-id> [--all --duration --comment | --alertname --duration --comment]",
 		Short:             "Add new silence for alert for org",
-		Long:              `add new silence for specfic or all alerts with comment and duration of alert for an organization. OHSS required for org-wide silence`,
+		Long: `add new silence for specfic or all alerts with comment and duration of alert for an organization. OHSS required for org-wide silence`,
+		Example: `  # Silence all alerts for an organization
+  osdctl alerts silence org ${ORG_ID} --all --comment "${REASON}: org-wide silence"
+
+  # Silence a specific alert for an organization
+  osdctl alerts silence org ${ORG_ID} --alertname "KubePodNotReady" --comment "${REASON}: investigating pod issue"`,
 		Args:              cobra.ExactArgs(1),
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/alerts/silence/silence_org.go
+++ b/cmd/alerts/silence/silence_org.go
@@ -23,7 +23,7 @@ func NewCmdAddOrgSilence() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "org <org-id> [--all --duration --comment | --alertname --duration --comment]",
 		Short:             "Add new silence for alert for org",
-		Long: `add new silence for specfic or all alerts with comment and duration of alert for an organization. OHSS required for org-wide silence`,
+		Long: `Add a new silence for specific alerts or all alerts with a comment and duration for an organization. OHSS required for org-wide silence.`,
 		Example: `  # Silence all alerts for an organization
   osdctl alerts silence org ${ORG_ID} --all --comment "${REASON}: org-wide silence"
 

--- a/cmd/cloudtrail/errors.go
+++ b/cmd/cloudtrail/errors.go
@@ -64,16 +64,16 @@ By default, matches these error patterns:
 
 Use --error-types to filter for specific error patterns.`,
 		Example: `  # Check for permission errors in the last hour
-  osdctl cloudtrail errors -C <cluster-id> --since 1h
+  osdctl cloudtrail errors -C ${CLUSTER_ID} --since 1h
 
   # Check for specific error types only
-  osdctl cloudtrail errors -C <cluster-id> --error-types AccessDenied,Forbidden
+  osdctl cloudtrail errors -C ${CLUSTER_ID} --error-types AccessDenied,Forbidden
 
   # Output as JSON for scripting
-  osdctl cloudtrail errors -C <cluster-id> --json
+  osdctl cloudtrail errors -C ${CLUSTER_ID} --json
 
   # Include console links for each event
-  osdctl cloudtrail errors -C <cluster-id> --url`,
+  osdctl cloudtrail errors -C ${CLUSTER_ID} --url`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.run()
 		},

--- a/cmd/cloudtrail/permission-denied.go
+++ b/cmd/cloudtrail/permission-denied.go
@@ -26,6 +26,11 @@ func newCmdPermissionDenied() *cobra.Command {
 	permissionDeniedCmd := &cobra.Command{
 		Use:   "permission-denied-events",
 		Short: "Prints cloudtrail permission-denied events to console.",
+		Example: `  # Check for permission-denied events in the last 5 minutes
+  osdctl cloudtrail permission-denied-events --cluster-id ${CLUSTER_ID}
+
+  # Check for permission-denied events in the last hour with URLs
+  osdctl cloudtrail permission-denied-events --cluster-id ${CLUSTER_ID} --since 1h --url`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.run()
 		},

--- a/cmd/cluster/access/access.go
+++ b/cmd/cluster/access/access.go
@@ -55,7 +55,9 @@ func NewCmdAccess(streams genericclioptions.IOStreams, client *k8s.LazyClient) *
 	accessCmd := &cobra.Command{
 		Use:               "break-glass --cluster-id <cluster-identifier>",
 		Short:             "Emergency access to a cluster",
-		Long:              "Obtain emergency credentials to access the given cluster. You must be logged into the cluster's hive shard",
+		Long: "Obtain emergency credentials to access the given cluster. You must be logged into the cluster's hive shard",
+		Example: `  # Obtain emergency break-glass access to a cluster
+  osdctl cluster break-glass --cluster-id ${CLUSTER_ID} --reason "${REASON}"`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(_ *cobra.Command, _ []string) {

--- a/cmd/cluster/access/access.go
+++ b/cmd/cluster/access/access.go
@@ -53,9 +53,9 @@ var (
 func NewCmdAccess(streams genericclioptions.IOStreams, client *k8s.LazyClient) *cobra.Command {
 	ops := newClusterAccessOptions(streams)
 	accessCmd := &cobra.Command{
-		Use:               "break-glass --cluster-id <cluster-identifier>",
-		Short:             "Emergency access to a cluster",
-		Long: "Obtain emergency credentials to access the given cluster. You must be logged into the cluster's hive shard",
+		Use:   "break-glass --cluster-id <cluster-identifier>",
+		Short: "Emergency access to a cluster",
+		Long:  "Obtain emergency credentials to access the given cluster. You must be logged into the cluster's hive shard",
 		Example: `  # Obtain emergency break-glass access to a cluster
   osdctl cluster break-glass --cluster-id ${CLUSTER_ID} --reason "${REASON}"`,
 		Args:              cobra.NoArgs,

--- a/cmd/cluster/access/cleanup.go
+++ b/cmd/cluster/access/cleanup.go
@@ -25,7 +25,9 @@ func newCmdCleanup(client *k8s.LazyClient, streams genericclioptions.IOStreams) 
 	cleanupCmd := &cobra.Command{
 		Use:               "cleanup --cluster-id <cluster-identifier>",
 		Short:             "Drop emergency access to a cluster",
-		Long:              "Relinquish emergency access from the given cluster. If the cluster is PrivateLink, it deletes\nall jump pods in the cluster's namespace (because of this, you must be logged into the hive shard\nwhen dropping access for PrivateLink clusters). For non-PrivateLink clusters, the $KUBECONFIG\nenvironment variable is unset, if applicable.",
+		Long: "Relinquish emergency access from the given cluster. If the cluster is PrivateLink, it deletes\nall jump pods in the cluster's namespace (because of this, you must be logged into the hive shard\nwhen dropping access for PrivateLink clusters). For non-PrivateLink clusters, the $KUBECONFIG\nenvironment variable is unset, if applicable.",
+		Example: `  # Drop emergency access to a cluster
+  osdctl cluster break-glass cleanup --cluster-id ${CLUSTER_ID}`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/cluster/access/cleanup.go
+++ b/cmd/cluster/access/cleanup.go
@@ -23,9 +23,9 @@ import (
 func newCmdCleanup(client *k8s.LazyClient, streams genericclioptions.IOStreams) *cobra.Command {
 	ops := newCleanupAccessOptions(client, streams)
 	cleanupCmd := &cobra.Command{
-		Use:               "cleanup --cluster-id <cluster-identifier>",
-		Short:             "Drop emergency access to a cluster",
-		Long: "Relinquish emergency access from the given cluster. If the cluster is PrivateLink, it deletes\nall jump pods in the cluster's namespace (because of this, you must be logged into the hive shard\nwhen dropping access for PrivateLink clusters). For non-PrivateLink clusters, the $KUBECONFIG\nenvironment variable is unset, if applicable.",
+		Use:   "cleanup --cluster-id <cluster-identifier>",
+		Short: "Drop emergency access to a cluster",
+		Long:  "Relinquish emergency access from the given cluster. If the cluster is PrivateLink, it deletes\nall jump pods in the cluster's namespace (because of this, you must be logged into the hive shard\nwhen dropping access for PrivateLink clusters). For non-PrivateLink clusters, the $KUBECONFIG\nenvironment variable is unset, if applicable.",
 		Example: `  # Drop emergency access to a cluster
   osdctl cluster break-glass cleanup --cluster-id ${CLUSTER_ID}`,
 		Args:              cobra.NoArgs,

--- a/cmd/cluster/cad/run.go
+++ b/cmd/cluster/cad/run.go
@@ -72,32 +72,6 @@ Available Investigations:
   insightsoperatordown, machine-health-check, must-gather, upgrade-config,
   restart-controlplane, describe-nodes
 
-Examples:
-` + "```bash" + `
-# Run a change management investigation on a production cluster
-osdctl cluster cad run \
-  --cluster-id 1a2b3c4d5e6f7g8h9i0j \
-  --investigation chgm \
-  --environment production \
-  --reason "OHSS-12345"
-
-# Run a dry-run investigation (does not create a report)
-osdctl cluster cad run \
-  --cluster-id 1a2b3c4d5e6f7g8h9i0j \
-  --investigation chgm \
-  --environment production \
-  --reason "OHSS-12345" \
-  --dry-run
-
-# Run describe-nodes on master nodes only
-osdctl cluster cad run \
-  --cluster-id 1a2b3c4d5e6f7g8h9i0j \
-  --investigation describe-nodes \
-  --environment production \
-  --reason "OHSS-12345" \
-  --params MASTER=true
-` + "```" + `
-
 Note:
   After the investigation completes (may take several minutes), view results using:
 ` + "```bash" + `
@@ -105,6 +79,14 @@ osdctl cluster reports list -C <cluster-id> -l 1
 ` + "```" + `
 
   You must be connected to the target cluster's OCM environment to view its reports.`,
+		Example: `  # Run a change management investigation on a production cluster
+  osdctl cluster cad run --cluster-id ${CLUSTER_ID} --investigation chgm --environment production --reason "${REASON}"
+
+  # Run a dry-run investigation (does not create a report)
+  osdctl cluster cad run --cluster-id ${CLUSTER_ID} --investigation chgm --environment production --reason "${REASON}" --dry-run
+
+  # Run describe-nodes with parameters
+  osdctl cluster cad run --cluster-id ${CLUSTER_ID} --investigation describe-nodes --environment production --reason "${REASON}" --params MASTER=true`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/cluster/changevolumetype.go
+++ b/cmd/cluster/changevolumetype.go
@@ -63,13 +63,13 @@ replace all infra nodes with new ones using the target volume type.
 
 Pre-flight checks are performed automatically before making changes.`,
 		Example: `  # Change both control plane and infra volumes to gp3
-  osdctl cluster change-ebs-volume-type -C ${CLUSTER_ID} --type gp3 --reason "SREP-3811"
+  osdctl cluster change-ebs-volume-type -C ${CLUSTER_ID} --type gp3 --reason "${REASON}"
 
   # Change only control plane volumes to gp3
-  osdctl cluster change-ebs-volume-type -C ${CLUSTER_ID} --type gp3 --role control-plane --reason "SREP-3811"
+  osdctl cluster change-ebs-volume-type -C ${CLUSTER_ID} --type gp3 --role control-plane --reason "${REASON}"
 
   # Change only infra volumes to gp3
-  osdctl cluster change-ebs-volume-type -C ${CLUSTER_ID} --type gp3 --role infra --reason "SREP-3811"`,
+  osdctl cluster change-ebs-volume-type -C ${CLUSTER_ID} --type gp3 --role infra --reason "${REASON}"`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/cluster/checkbanneduser.go
+++ b/cmd/cluster/checkbanneduser.go
@@ -13,7 +13,7 @@ const BanCodeExportControlCompliance = "export_control_compliance"
 func newCmdCheckBannedUser() *cobra.Command {
 	clusterID := ""
 	cmd := &cobra.Command{
-		Use:               "check-banned-user --cluster-id <cluster-identifier>",
+		Use:   "check-banned-user --cluster-id <cluster-identifier>",
 		Short: "Checks if the cluster owner is a banned user.",
 		Example: `  # Check if the cluster owner is banned
   osdctl cluster check-banned-user --cluster-id ${CLUSTER_ID}`,

--- a/cmd/cluster/checkbanneduser.go
+++ b/cmd/cluster/checkbanneduser.go
@@ -14,7 +14,9 @@ func newCmdCheckBannedUser() *cobra.Command {
 	clusterID := ""
 	cmd := &cobra.Command{
 		Use:               "check-banned-user --cluster-id <cluster-identifier>",
-		Short:             "Checks if the cluster owner is a banned user.",
+		Short: "Checks if the cluster owner is a banned user.",
+		Example: `  # Check if the cluster owner is banned
+  osdctl cluster check-banned-user --cluster-id ${CLUSTER_ID}`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -132,7 +132,7 @@ type contextData struct {
 func newCmdContext() *cobra.Command {
 	options := &contextOptions{}
 	contextCmd := &cobra.Command{
-		Use:               "context --cluster-id <cluster-identifier>",
+		Use:   "context --cluster-id <cluster-identifier>",
 		Short: "Shows the context of a specified cluster",
 		Example: `  # Show cluster context
   osdctl cluster context --cluster-id ${CLUSTER_ID}

--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -133,7 +133,12 @@ func newCmdContext() *cobra.Command {
 	options := &contextOptions{}
 	contextCmd := &cobra.Command{
 		Use:               "context --cluster-id <cluster-identifier>",
-		Short:             "Shows the context of a specified cluster",
+		Short: "Shows the context of a specified cluster",
+		Example: `  # Show cluster context
+  osdctl cluster context --cluster-id ${CLUSTER_ID}
+
+  # Show cluster context with full checks
+  osdctl cluster context --cluster-id ${CLUSTER_ID} --full`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/cluster/detachstuckvolume.go
+++ b/cmd/cluster/detachstuckvolume.go
@@ -36,6 +36,8 @@ func newCmdDetachStuckVolume() *cobra.Command {
 	detachstuckvolumeCmd := &cobra.Command{
 		Use:               "detach-stuck-volume --cluster-id <cluster-identifier>",
 		Short:             "Detach openshift-monitoring namespace's volume from a cluster forcefully",
+		Example: `  # Detach stuck volumes in the openshift-monitoring namespace
+  osdctl cluster detach-stuck-volume --cluster-id ${CLUSTER_ID} --reason "${REASON}"`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/cluster/detachstuckvolume.go
+++ b/cmd/cluster/detachstuckvolume.go
@@ -34,8 +34,8 @@ type detachStuckVolumeOptions struct {
 func newCmdDetachStuckVolume() *cobra.Command {
 	ops := &detachStuckVolumeOptions{}
 	detachstuckvolumeCmd := &cobra.Command{
-		Use:               "detach-stuck-volume --cluster-id <cluster-identifier>",
-		Short:             "Detach openshift-monitoring namespace's volume from a cluster forcefully",
+		Use:   "detach-stuck-volume --cluster-id <cluster-identifier>",
+		Short: "Detach openshift-monitoring namespace's volume from a cluster forcefully",
 		Example: `  # Detach stuck volumes in the openshift-monitoring namespace
   osdctl cluster detach-stuck-volume --cluster-id ${CLUSTER_ID} --reason "${REASON}"`,
 		Args:              cobra.NoArgs,

--- a/cmd/cluster/etcd_health.go
+++ b/cmd/cluster/etcd_health.go
@@ -58,9 +58,9 @@ type etcdHealthCheckOptions struct {
 func newCmdEtcdHealthCheck() *cobra.Command {
 	opts := etcdHealthCheckOptions{}
 	cmd := &cobra.Command{
-		Use:               "etcd-health-check --cluster-id <cluster-id> --reason <reason for escalation>",
-		Short:             "Checks the etcd components and member health",
-		Long: `Checks etcd component health status for member replacement`,
+		Use:   "etcd-health-check --cluster-id <cluster-id> --reason <reason for escalation>",
+		Short: "Checks the etcd components and member health",
+		Long:  `Checks etcd component health status for member replacement`,
 		Example: `  # Check etcd health for a cluster
   osdctl cluster etcd-health-check --cluster-id ${CLUSTER_ID} --reason "${REASON}"`,
 		Args:              cobra.NoArgs,

--- a/cmd/cluster/etcd_health.go
+++ b/cmd/cluster/etcd_health.go
@@ -60,7 +60,9 @@ func newCmdEtcdHealthCheck() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "etcd-health-check --cluster-id <cluster-id> --reason <reason for escalation>",
 		Short:             "Checks the etcd components and member health",
-		Long:              `Checks etcd component health status for member replacement`,
+		Long: `Checks etcd component health status for member replacement`,
+		Example: `  # Check etcd health for a cluster
+  osdctl cluster etcd-health-check --cluster-id ${CLUSTER_ID} --reason "${REASON}"`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/cluster/etcd_replace.go
+++ b/cmd/cluster/etcd_replace.go
@@ -43,7 +43,9 @@ func newCmdEtcdMemberReplacement() *cobra.Command {
 	replaceCmd := &cobra.Command{
 		Use:               "etcd-member-replace --cluster-id <cluster-identifier>",
 		Short:             "Replaces an unhealthy etcd node",
-		Long:              `Replaces an unhealthy ectd node using the member id provided`,
+		Long: `Replaces an unhealthy ectd node using the member id provided`,
+		Example: `  # Replace an unhealthy etcd member
+  osdctl cluster etcd-member-replace --cluster-id ${CLUSTER_ID} --node ${NODE_NAME} --reason "${REASON}"`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/cluster/etcd_replace.go
+++ b/cmd/cluster/etcd_replace.go
@@ -43,7 +43,7 @@ func newCmdEtcdMemberReplacement() *cobra.Command {
 	replaceCmd := &cobra.Command{
 		Use:               "etcd-member-replace --cluster-id <cluster-identifier>",
 		Short:             "Replaces an unhealthy etcd node",
-		Long: `Replaces an unhealthy ectd node using the member id provided`,
+		Long: `Replaces an unhealthy etcd node using the member id provided`,
 		Example: `  # Replace an unhealthy etcd member
   osdctl cluster etcd-member-replace --cluster-id ${CLUSTER_ID} --node ${NODE_NAME} --reason "${REASON}"`,
 		Args:              cobra.NoArgs,

--- a/cmd/cluster/etcd_replace.go
+++ b/cmd/cluster/etcd_replace.go
@@ -41,9 +41,9 @@ const (
 func newCmdEtcdMemberReplacement() *cobra.Command {
 	opts := &etcdOptions{}
 	replaceCmd := &cobra.Command{
-		Use:               "etcd-member-replace --cluster-id <cluster-identifier>",
-		Short:             "Replaces an unhealthy etcd node",
-		Long: `Replaces an unhealthy etcd node using the member id provided`,
+		Use:   "etcd-member-replace --cluster-id <cluster-identifier>",
+		Short: "Replaces an unhealthy etcd node",
+		Long:  `Replaces an unhealthy etcd node using the member id provided`,
 		Example: `  # Replace an unhealthy etcd member
   osdctl cluster etcd-member-replace --cluster-id ${CLUSTER_ID} --node ${NODE_NAME} --reason "${REASON}"`,
 		Args:              cobra.NoArgs,

--- a/cmd/cluster/getenvvars.go
+++ b/cmd/cluster/getenvvars.go
@@ -36,7 +36,12 @@ func newCmdGetEnvVars() *cobra.Command {
 	opts := newGetEnvVarsOptions()
 	getEnvVarsCmd := &cobra.Command{
 		Use:               "get-env-vars --cluster-id <cluster-identifier>",
-		Short:             "Print a cluster's ID/management namespaces, optionally as env variables",
+		Short: "Print a cluster's ID/management namespaces, optionally as env variables",
+		Example: `  # Print cluster environment variables
+  osdctl cluster get-env-vars --cluster-id ${CLUSTER_ID}
+
+  # Print as exportable env variables
+  osdctl cluster get-env-vars --cluster-id ${CLUSTER_ID} --output env`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/cluster/getenvvars.go
+++ b/cmd/cluster/getenvvars.go
@@ -35,7 +35,7 @@ type formattedOutputCluster struct {
 func newCmdGetEnvVars() *cobra.Command {
 	opts := newGetEnvVarsOptions()
 	getEnvVarsCmd := &cobra.Command{
-		Use:               "get-env-vars --cluster-id <cluster-identifier>",
+		Use:   "get-env-vars --cluster-id <cluster-identifier>",
 		Short: "Print a cluster's ID/management namespaces, optionally as env variables",
 		Example: `  # Print cluster environment variables
   osdctl cluster get-env-vars --cluster-id ${CLUSTER_ID}

--- a/cmd/cluster/health.go
+++ b/cmd/cluster/health.go
@@ -30,7 +30,9 @@ func newCmdHealth() *cobra.Command {
 	ops := newHealthOptions()
 	healthCmd := &cobra.Command{
 		Use:               "health",
-		Short:             "Describes health of cluster nodes and provides other cluster vitals.",
+		Short: "Describes health of cluster nodes and provides other cluster vitals.",
+		Example: `  # Check cluster health
+  osdctl cluster health --cluster-id ${CLUSTER_ID}`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/cluster/health.go
+++ b/cmd/cluster/health.go
@@ -29,7 +29,7 @@ type healthOptions struct {
 func newCmdHealth() *cobra.Command {
 	ops := newHealthOptions()
 	healthCmd := &cobra.Command{
-		Use:               "health",
+		Use:   "health",
 		Short: "Describes health of cluster nodes and provides other cluster vitals.",
 		Example: `  # Check cluster health
   osdctl cluster health --cluster-id ${CLUSTER_ID}`,

--- a/cmd/cluster/hypershift_info.go
+++ b/cmd/cluster/hypershift_info.go
@@ -41,6 +41,11 @@ func NewCmdHypershiftInfo(streams genericclioptions.IOStreams) *cobra.Command {
 		Short: "Pull information about AWS objects from the cluster, the management cluster and the privatelink cluster",
 		Long: `This command aggregates AWS objects from the cluster, management cluster and privatelink for hypershift cluster.
 It attempts to render the relationships as graphviz if that output format is chosen or will simply print the output as tables.`,
+		Example: `  # Show hypershift cluster info as graphviz
+  osdctl cluster hypershift-info --cluster-id ${CLUSTER_ID}
+
+  # Show hypershift cluster info as table
+  osdctl cluster hypershift-info --cluster-id ${CLUSTER_ID} --output table`,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(ops.complete(cmd))

--- a/cmd/cluster/loggingcheck.go
+++ b/cmd/cluster/loggingcheck.go
@@ -28,7 +28,9 @@ func newCmdLoggingCheck(streams genericclioptions.IOStreams, globalOpts *globalf
 	ops := newloggingCheckOptions(streams, globalOpts)
 	loggingCheckCmd := &cobra.Command{
 		Use:               "logging-check --cluster-id <cluster-identifier>",
-		Short:             "Shows the logging support status of a specified cluster",
+		Short: "Shows the logging support status of a specified cluster",
+		Example: `  # Check logging support status for a cluster
+  osdctl cluster logging-check --cluster-id ${CLUSTER_ID}`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/cluster/loggingcheck.go
+++ b/cmd/cluster/loggingcheck.go
@@ -27,7 +27,7 @@ type loggingCheckOptions struct {
 func newCmdLoggingCheck(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	ops := newloggingCheckOptions(streams, globalOpts)
 	loggingCheckCmd := &cobra.Command{
-		Use:               "logging-check --cluster-id <cluster-identifier>",
+		Use:   "logging-check --cluster-id <cluster-identifier>",
 		Short: "Shows the logging support status of a specified cluster",
 		Example: `  # Check logging support status for a cluster
   osdctl cluster logging-check --cluster-id ${CLUSTER_ID}`,

--- a/cmd/cluster/reports/create.go
+++ b/cmd/cluster/reports/create.go
@@ -34,24 +34,12 @@ func newCmdCreate() *cobra.Command {
 This command creates a new report associated with a cluster. The report
 includes a summary (title) and data content. You can provide the data either
 directly as a string using --data, or from a file using --file. The data
-will be automatically base64-encoded before storage.
-
-Examples:
-  # Create a report with inline data
-  osdctl cluster reports create --cluster-id 1a2b3c4d \
-    --summary "Network diagnostic results" \
-    --data "All network checks passed successfully"
+will be automatically base64-encoded before storage.`,
+		Example: `  # Create a report with inline data
+  osdctl cluster reports create --cluster-id ${CLUSTER_ID} --summary "Network diagnostic results" --data "All network checks passed"
 
   # Create a report from a file
-  osdctl cluster reports create -C my-cluster \
-    --summary "Pod logs from incident" \
-    --file /tmp/pod-logs.txt
-
-  # Create a report and output as JSON
-  osdctl cluster reports create --cluster-id 1a2b3c4d \
-    --summary "Cluster health check" \
-    --data "CPU: 45%, Memory: 67%, Disk: 23%" \
-    --output json`,
+  osdctl cluster reports create --cluster-id ${CLUSTER_ID} --summary "Pod logs from incident" --file /tmp/pod-logs.txt`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/cluster/reports/get.go
+++ b/cmd/cluster/reports/get.go
@@ -28,17 +28,12 @@ func newCmdGet() *cobra.Command {
 		Long: `Retrieve and display a specific report by its ID.
 
 This command fetches a report by its report ID and displays the decoded
-report data. Use 'list' to find available report IDs.
+report data. Use 'list' to find available report IDs.`,
+		Example: `  # Get a specific report
+  osdctl cluster reports get --cluster-id ${CLUSTER_ID} --report-id ${REPORT_ID}
 
-Examples:
-  # Get a specific report and display its contents
-  osdctl cluster reports get --cluster-id 1a2b3c4d --report-id abc-123-def
-
-  # Get a report with JSON output (includes encoded data)
-  osdctl cluster reports get -C my-cluster -r report-456 --output json
-
-  # Get a report and pipe the output to a file
-  osdctl cluster reports get -C 1a2b3c4d -r abc-123 > report-output.txt`,
+  # Get a report with JSON output
+  osdctl cluster reports get --cluster-id ${CLUSTER_ID} --report-id ${REPORT_ID} --output json`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/cluster/reports/list.go
+++ b/cmd/cluster/reports/list.go
@@ -30,17 +30,12 @@ func newCmdList() *cobra.Command {
 
 This command retrieves and displays all reports associated with a cluster,
 showing the report ID, summary, and creation timestamp. You can optionally
-limit the number of reports returned to the most recent N reports.
-
-Examples:
-  # List all reports for a cluster (defaults to 10 most recent)
-  osdctl cluster reports list --cluster-id 1a2b3c4d
+limit the number of reports returned to the most recent N reports.`,
+		Example: `  # List reports for a cluster
+  osdctl cluster reports list --cluster-id ${CLUSTER_ID}
 
   # List the 5 most recent reports
-  osdctl cluster reports list --cluster-id 1a2b3c4d --last 5
-
-  # List reports with JSON output
-  osdctl cluster reports list --cluster-id my-cluster --output json`,
+  osdctl cluster reports list --cluster-id ${CLUSTER_ID} --last 5`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/cluster/resize/controlplane_node.go
+++ b/cmd/cluster/resize/controlplane_node.go
@@ -56,9 +56,8 @@ func newCmdResizeControlPlane() *cobra.Command {
   Requires previous login to the api server via "ocm backplane login".
   The user will be prompted to send a service log after initiating the resize. The resize process runs asynchronously,
   and this command exits immediately after sending the service log. Any issues with the resize will be reported via PagerDuty.`,
-		Example: `
-  # Resize all control plane instances to m5.4xlarge using control plane machine sets
-  osdctl cluster resize control-plane -c "${CLUSTER_ID}" --machine-type m5.4xlarge --reason "${OHSS}"`,
+		Example: `  # Resize all control plane instances to m5.4xlarge using control plane machine sets
+  osdctl cluster resize control-plane --cluster-id "${CLUSTER_ID}" --machine-type m5.4xlarge --reason "${REASON}"`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/cluster/resize/infra_node.go
+++ b/cmd/cluster/resize/infra_node.go
@@ -72,10 +72,10 @@ func newCmdResizeInfra() *cobra.Command {
     https://github.com/openshift/ops-sop/blob/master/v4/howto/resize-infras-workers.md
 `,
 		Example: `  # Automatically vertically scale infra nodes to the next size
-  osdctl cluster resize infra --cluster-id ${CLUSTER_ID} --reason "${REASON}" --justification "${JUSTIFICATION}" --ohss "${REASON}"
+  osdctl cluster resize infra --cluster-id ${CLUSTER_ID} --reason "${REASON}" --justification "${JUSTIFICATION}" --ohss "${OHSS}"
 
   # Resize infra nodes to a specific instance type
-  osdctl cluster resize infra --cluster-id ${CLUSTER_ID} --instance-type "r5.xlarge" --reason "${REASON}" --justification "${JUSTIFICATION}" --ohss "${REASON}"`,
+  osdctl cluster resize infra --cluster-id ${CLUSTER_ID} --instance-type "r5.xlarge" --reason "${REASON}" --justification "${JUSTIFICATION}" --ohss "${OHSS}"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.RunInfra(context.Background())
 		},

--- a/cmd/cluster/resize/infra_node.go
+++ b/cmd/cluster/resize/infra_node.go
@@ -71,13 +71,11 @@ func newCmdResizeInfra() *cobra.Command {
 
     https://github.com/openshift/ops-sop/blob/master/v4/howto/resize-infras-workers.md
 `,
-		Example: `
-  # Automatically vertically scale infra nodes to the next size
-  osdctl cluster resize infra --cluster-id ${CLUSTER_ID}
+		Example: `  # Automatically vertically scale infra nodes to the next size
+  osdctl cluster resize infra --cluster-id ${CLUSTER_ID} --reason "${REASON}" --justification "${JUSTIFICATION}" --ohss "${REASON}"
 
   # Resize infra nodes to a specific instance type
-  osdctl cluster resize infra --cluster-id ${CLUSTER_ID} --instance-type "r5.xlarge"
-`,
+  osdctl cluster resize infra --cluster-id ${CLUSTER_ID} --instance-type "r5.xlarge" --reason "${REASON}" --justification "${JUSTIFICATION}" --ohss "${REASON}"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return r.RunInfra(context.Background())
 		},

--- a/cmd/cluster/resize/requestserving_node.go
+++ b/cmd/cluster/resize/requestserving_node.go
@@ -55,13 +55,13 @@ func newCmdResizeRequestServingNodes() *cobra.Command {
 		Long:  `Resize a ROSA HCP cluster's request-serving nodes by applying a cluster-size-override annotation`,
 		Example: `
   # Resize a ROSA HCP cluster's request-serving nodes to the next size
-  osdctl cluster resize request-serving-nodes --cluster-id "${CLUSTER_ID}" --reason "${OHSS}"
+  osdctl cluster resize request-serving-nodes --cluster-id "${CLUSTER_ID}" --reason "${REASON}"
 
   # Resize a ROSA HCP cluster's request-serving nodes to a specific size
-  osdctl cluster resize request-serving-nodes --cluster-id "${CLUSTER_ID}" --size m54xl --reason "${OHSS}"
+  osdctl cluster resize request-serving-nodes --cluster-id "${CLUSTER_ID}" --size m54xl --reason "${REASON}"
 
   # Remove the cluster-size-override annotation to revert to default sizing behavior
-  osdctl cluster resize request-serving-nodes --cluster-id "${CLUSTER_ID}" --remove-override --reason "${OHSS}"
+  osdctl cluster resize request-serving-nodes --cluster-id "${CLUSTER_ID}" --remove-override --reason "${REASON}"
 `,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,

--- a/cmd/cluster/snapshot.go
+++ b/cmd/cluster/snapshot.go
@@ -96,13 +96,13 @@ This command captures the current state of key cluster resources including:
 The snapshot can be saved to a YAML file and later compared using 
 'osdctl cluster diff' to identify changes during feature testing.`,
 		Example: `  # Capture cluster snapshot to a file
-  osdctl cluster snapshot -C <cluster-id> -o before.yaml
+  osdctl cluster snapshot -C ${CLUSTER_ID} -o before.yaml
 
   # Capture snapshot with specific namespaces
-  osdctl cluster snapshot -C <cluster-id> -o snapshot.yaml --namespaces openshift-monitoring,openshift-operators
+  osdctl cluster snapshot -C ${CLUSTER_ID} -o snapshot.yaml --namespaces openshift-monitoring,openshift-operators
 
   # Capture additional resource types
-  osdctl cluster snapshot -C <cluster-id> -o snapshot.yaml --resources pods,deployments,services`,
+  osdctl cluster snapshot -C ${CLUSTER_ID} -o snapshot.yaml --resources pods,deployments,services`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.run()
 		},

--- a/cmd/cluster/ssh/key.go
+++ b/cmd/cluster/ssh/key.go
@@ -35,32 +35,14 @@ func NewCmdKey() *cobra.Command {
 		Use:   "key --reason $reason [--cluster-id $CLUSTER_ID]",
 		Short: "Retrieve a cluster's SSH key from Hive",
 		Long:  "Retrieve a cluster's SSH key from Hive. If a cluster-id is provided, then the key retrieved will be for that cluster. If no cluster-id is provided, then the key for the cluster backplane is currently logged into will be used instead. This command should only be used as a last resort, when all other means of accessing a node are lost.",
-		Example: `$ osdctl cluster ssh key --cluster-id $CLUSTER_ID --reason "OHSS-XXXX"
-INFO[0005] Backplane URL retrieved via OCM environment: https://api.backplane.openshift.com
------BEGIN RSA PRIVATE KEY-----
-...
------END RSA PRIVATE KEY-----
+		Example: `  # Retrieve SSH key for a specific cluster
+  osdctl cluster ssh key --cluster-id ${CLUSTER_ID} --reason "${REASON}"
 
-Providing a --cluster-id allows you to specify the cluster who's private ssh key you want to view, regardless if you're logged in or not.
+  # Retrieve SSH key for the currently logged-in cluster
+  osdctl cluster ssh key --reason "${REASON}"
 
-
-$ osdctl cluster ssh key --reason "OHSS-XXXX"
-INFO[0005] Backplane URL retrieved via OCM environment: https://api.backplane.openshift.com
------BEGIN RSA PRIVATE KEY-----
-...
------END RSA PRIVATE KEY-----
-
-Omitting --cluster-id will print the ssh key for the cluster you're currently logged into.
-
-
-$ osdctl cluster ssh key -y --reason "OHSS-XXXX" > /tmp/ssh.key
-INFO[0005] Backplane URL retrieved via OCM environment: https://api.backplane.openshift.com
-$ cat /tmp/ssh.key
------BEGIN RSA PRIVATE KEY-----
-...
------END RSA PRIVATE KEY-----
-
-Despite the logs from backplane, the ssh key is the only output channelled through stdout. This means you can safely redirect the output to a file for greater convienence.`,
+  # Save SSH key to a file
+  osdctl cluster ssh key -y --reason "${REASON}" > /tmp/ssh.key`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, args []string) error {
 			// Validate --hive-ocm-url if provided

--- a/cmd/cluster/support/delete.go
+++ b/cmd/cluster/support/delete.go
@@ -35,7 +35,12 @@ func newCmddelete(streams genericclioptions.IOStreams, globalOpts *globalflags.G
 	ops := newDeleteOptions(streams, globalOpts)
 	deleteCmd := &cobra.Command{
 		Use:               "delete --cluster-id <cluster-identifier>",
-		Short:             "Delete specified limited support reason for a given cluster",
+		Short: "Delete specified limited support reason for a given cluster",
+		Example: `  # Remove a specific limited support reason
+  osdctl cluster support delete --cluster-id ${CLUSTER_ID} --limited-support-reason-id ${REASON_ID}
+
+  # Remove all limited support reasons
+  osdctl cluster support delete --cluster-id ${CLUSTER_ID} --all`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/cluster/support/delete.go
+++ b/cmd/cluster/support/delete.go
@@ -34,7 +34,7 @@ func newCmddelete(streams genericclioptions.IOStreams, globalOpts *globalflags.G
 
 	ops := newDeleteOptions(streams, globalOpts)
 	deleteCmd := &cobra.Command{
-		Use:               "delete --cluster-id <cluster-identifier>",
+		Use:   "delete --cluster-id <cluster-identifier>",
 		Short: "Delete specified limited support reason for a given cluster",
 		Example: `  # Remove a specific limited support reason
   osdctl cluster support delete --cluster-id ${CLUSTER_ID} --limited-support-reason-id ${REASON_ID}

--- a/cmd/cluster/support/post.go
+++ b/cmd/cluster/support/post.go
@@ -68,14 +68,11 @@ func newCmdPost() *cobra.Command {
 		Short: "Send limited support reason to a given cluster",
 		Long: `Sends limited support reason to a given cluster, along with an internal service log detailing why the cluster was placed into limited support.
 The caller will be prompted to continue before sending the limited support reason.`,
-		Example: `# Post a limited support reason for a cluster misconfiguration
-osdctl cluster support post --cluster-id=1a2B3c4DefghIjkLMNOpQrSTUV5 --misconfiguration=cluster --problem="The cluster has a second failing ingress controller, which is not supported and can cause issues with SLA." \
---resolution="Remove the additional ingress controller 'my-custom-ingresscontroller'. 'oc get ingresscontroller -n openshift-ingress-operator' should yield only 'default'" \
---evidence="See OHSS-1234"
-
-Will result in the following limited-support text sent to the customer:
-The cluster has a second failing ingress controller, which is not supported and can cause issues with SLA. Remove the additional ingress controller 'my-custom-ingresscontroller'. 'oc get ingresscontroller -n openshift-ingress-operator' should yield only 'default'.
-`,
+		Example: `  # Post a limited support reason for a cluster misconfiguration
+  osdctl cluster support post --cluster-id ${CLUSTER_ID} --misconfiguration=cluster \
+    --problem="The cluster has a second failing ingress controller" \
+    --resolution="Remove the additional ingress controller" \
+    --evidence="See ${REASON}"`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/cluster/support/status.go
+++ b/cmd/cluster/support/status.go
@@ -24,7 +24,7 @@ type statusOptions struct {
 func newCmdstatus(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	ops := newStatusOptions(streams, globalOpts)
 	statusCmd := &cobra.Command{
-		Use:               "status --cluster-id <cluster-identifier>",
+		Use:   "status --cluster-id <cluster-identifier>",
 		Short: "Shows the support status of a specified cluster",
 		Example: `  # Check cluster support status
   osdctl cluster support status --cluster-id ${CLUSTER_ID}`,

--- a/cmd/cluster/support/status.go
+++ b/cmd/cluster/support/status.go
@@ -25,7 +25,9 @@ func newCmdstatus(streams genericclioptions.IOStreams, globalOpts *globalflags.G
 	ops := newStatusOptions(streams, globalOpts)
 	statusCmd := &cobra.Command{
 		Use:               "status --cluster-id <cluster-identifier>",
-		Short:             "Shows the support status of a specified cluster",
+		Short: "Shows the support status of a specified cluster",
+		Example: `  # Check cluster support status
+  osdctl cluster support status --cluster-id ${CLUSTER_ID}`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/cluster/transferowner.go
+++ b/cmd/cluster/transferowner.go
@@ -62,7 +62,12 @@ func newCmdTransferOwner(streams genericclioptions.IOStreams, globalOpts *global
 	ops := newTransferOwnerOptions(streams, globalOpts)
 	transferOwnerCmd := &cobra.Command{
 		Use:               "transfer-owner",
-		Short:             "Transfer cluster ownership to a new user (to be done by Region Lead)",
+		Short: "Transfer cluster ownership to a new user (to be done by Region Lead)",
+		Example: `  # Transfer cluster ownership
+  osdctl cluster transfer-owner --cluster-id ${CLUSTER_ID} --old-owner ${OLD_OWNER} --new-owner ${NEW_OWNER} --reason "${REASON}"
+
+  # Dry-run to preview the transfer without applying changes
+  osdctl cluster transfer-owner --cluster-id ${CLUSTER_ID} --old-owner ${OLD_OWNER} --new-owner ${NEW_OWNER} --reason "${REASON}" --dry-run`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/cluster/transferowner.go
+++ b/cmd/cluster/transferowner.go
@@ -61,7 +61,7 @@ type transferOwnerOptions struct {
 func newCmdTransferOwner(streams genericclioptions.IOStreams, globalOpts *globalflags.GlobalOptions) *cobra.Command {
 	ops := newTransferOwnerOptions(streams, globalOpts)
 	transferOwnerCmd := &cobra.Command{
-		Use:               "transfer-owner",
+		Use:   "transfer-owner",
 		Short: "Transfer cluster ownership to a new user (to be done by Region Lead)",
 		Example: `  # Transfer cluster ownership
   osdctl cluster transfer-owner --cluster-id ${CLUSTER_ID} --old-owner ${OLD_OWNER} --new-owner ${NEW_OWNER} --reason "${REASON}"

--- a/cmd/cluster/validatepullsecretext.go
+++ b/cmd/cluster/validatepullsecretext.go
@@ -63,13 +63,13 @@ type validatePullSecretExtOptions struct {
 
 const VPSExample string = `
 	# Compare OCM Access-Token, OCM Registry-Credentials, and OCM Account Email against cluster's pull secret
-	osdctl cluster validate-pull-secret-ext --cluster-id ${CLUSTER_ID} --reason "OSD-XYZ"
+	osdctl cluster validate-pull-secret-ext --cluster-id ${CLUSTER_ID} --reason "${REASON}"
 
 	# Exclude Access-Token, and Registry-Credential checks...
-	osdctl cluster validate-pull-secret-ext --cluster-id ${CLUSTER_ID} --reason "OSD-XYZ" --skip-access-token --skip-registry-creds
+	osdctl cluster validate-pull-secret-ext --cluster-id ${CLUSTER_ID} --reason "${REASON}" --skip-access-token --skip-registry-creds
 
 	# Skip sending service logs (useful for testing)
-	osdctl cluster validate-pull-secret-ext --cluster-id ${CLUSTER_ID} --reason "OSD-XYZ" --skip-service-logs
+	osdctl cluster validate-pull-secret-ext --cluster-id ${CLUSTER_ID} --reason "${REASON}" --skip-service-logs
 `
 
 func newCmdValidatePullSecretExt() *cobra.Command {

--- a/cmd/cluster/verifydns.go
+++ b/cmd/cluster/verifydns.go
@@ -44,7 +44,12 @@ func NewCmdVerifyDNS(streams genericclioptions.IOStreams) *cobra.Command {
 	verifyDNSCmd := &cobra.Command{
 		Use:               "verify-dns --cluster-id <cluster-id>",
 		Short:             "Verify DNS resolution for HCP cluster public endpoints",
-		Long:              verifyDNSLongDescription,
+		Long: verifyDNSLongDescription,
+		Example: `  # Verify DNS for an HCP cluster
+  osdctl cluster verify-dns --cluster-id ${CLUSTER_ID}
+
+  # Verify DNS with JSON output
+  osdctl cluster verify-dns --cluster-id ${CLUSTER_ID} --output json`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/cluster/verifydns.go
+++ b/cmd/cluster/verifydns.go
@@ -42,9 +42,9 @@ func NewCmdVerifyDNS(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	verifyDNSCmd := &cobra.Command{
-		Use:               "verify-dns --cluster-id <cluster-id>",
-		Short:             "Verify DNS resolution for HCP cluster public endpoints",
-		Long: verifyDNSLongDescription,
+		Use:   "verify-dns --cluster-id <cluster-id>",
+		Short: "Verify DNS resolution for HCP cluster public endpoints",
+		Long:  verifyDNSLongDescription,
 		Example: `  # Verify DNS for an HCP cluster
   osdctl cluster verify-dns --cluster-id ${CLUSTER_ID}
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -63,6 +63,8 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 		Long:              `CLI tool to provide OSD related utilities`,
 		DisableAutoGenTag: true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			cmd.SilenceUsage = true
+
 			if cmd.Flags().Lookup(aws.NoProxyFlag) != nil {
 				noAwsProxy, err := cmd.Flags().GetBool(aws.NoProxyFlag)
 				if err != nil {

--- a/cmd/cost/create.go
+++ b/cmd/cost/create.go
@@ -18,6 +18,8 @@ func newCmdCreate(streams genericclioptions.IOStreams) *cobra.Command {
 	createCmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a cost category for the given OU",
+		Example: `  # Create a cost category for an organizational unit
+  osdctl cost create --ou ${OU_ID}`,
 		Run: func(cmd *cobra.Command, args []string) {
 
 			awsClient, err := opsCost.initAWSClients()

--- a/cmd/cost/list.go
+++ b/cmd/cost/list.go
@@ -21,6 +21,11 @@ func newCmdList(streams genericclioptions.IOStreams, globalOpts *globalflags.Glo
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List the cost of each Account/OU under given OU",
+		Example: `  # List costs for an OU for the current month
+  osdctl cost list --ou ${OU_ID} --time MTD
+
+  # List costs for a date range
+  osdctl cost list --ou ${OU_ID} --start 2024-01-01 --end 2024-01-31`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(ops.checkArgs(cmd, args))
 			cmdutil.CheckErr(ops.runList())

--- a/cmd/cost/reconcile.go
+++ b/cmd/cost/reconcile.go
@@ -18,6 +18,8 @@ func newCmdReconcile(streams genericclioptions.IOStreams) *cobra.Command {
 	reconcileCmd := &cobra.Command{
 		Use:   "reconcile",
 		Short: "Checks if there's a cost category for every OU. If an OU is missing a cost category, creates the cost category",
+		Example: `  # Reconcile cost categories for an OU
+  osdctl cost reconcile --ou ${OU_ID}`,
 		Run: func(cmd *cobra.Command, args []string) {
 
 			awsClient, err := opsCost.initAWSClients()

--- a/cmd/dynatrace/dashboardCmd.go
+++ b/cmd/dynatrace/dashboardCmd.go
@@ -41,7 +41,9 @@ func newCmdDashboard() *cobra.Command {
 	urlCmd := &cobra.Command{
 		Use:               "dashboard --cluster-id CLUSTER_ID",
 		Aliases:           []string{"dash"},
-		Short:             "Get the Dynatrace Cluster Overview Dashboard for a given MC or HCP cluster",
+		Short: "Get the Dynatrace Cluster Overview Dashboard for a given MC or HCP cluster",
+		Example: `  # Open the Dynatrace dashboard for a cluster
+  osdctl dynatrace dashboard --cluster-id ${CLUSTER_ID}`,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			// We need the Dynatrace URL

--- a/cmd/dynatrace/dashboardCmd.go
+++ b/cmd/dynatrace/dashboardCmd.go
@@ -39,9 +39,9 @@ func openBrowser(url string) error {
 
 func newCmdDashboard() *cobra.Command {
 	urlCmd := &cobra.Command{
-		Use:               "dashboard --cluster-id CLUSTER_ID",
-		Aliases:           []string{"dash"},
-		Short: "Get the Dynatrace Cluster Overview Dashboard for a given MC or HCP cluster",
+		Use:     "dashboard --cluster-id CLUSTER_ID",
+		Aliases: []string{"dash"},
+		Short:   "Get the Dynatrace Cluster Overview Dashboard for a given MC or HCP cluster",
 		Example: `  # Open the Dynatrace dashboard for a cluster
   osdctl dynatrace dashboard --cluster-id ${CLUSTER_ID}`,
 		DisableAutoGenTag: true,

--- a/cmd/dynatrace/urlCmd.go
+++ b/cmd/dynatrace/urlCmd.go
@@ -11,7 +11,7 @@ func newCmdURL() *cobra.Command {
 	var clusterID string
 
 	urlCmd := &cobra.Command{
-		Use:               "url --cluster-id <cluster-identifier>",
+		Use:   "url --cluster-id <cluster-identifier>",
 		Short: "Get the Dynatrace Tenant URL for a given MC or HCP cluster",
 		Example: `  # Get the Dynatrace URL for a cluster
   osdctl dynatrace url --cluster-id ${CLUSTER_ID}`,

--- a/cmd/dynatrace/urlCmd.go
+++ b/cmd/dynatrace/urlCmd.go
@@ -12,7 +12,9 @@ func newCmdURL() *cobra.Command {
 
 	urlCmd := &cobra.Command{
 		Use:               "url --cluster-id <cluster-identifier>",
-		Short:             "Get the Dynatrace Tenant URL for a given MC or HCP cluster",
+		Short: "Get the Dynatrace Tenant URL for a given MC or HCP cluster",
+		Example: `  # Get the Dynatrace URL for a cluster
+  osdctl dynatrace url --cluster-id ${CLUSTER_ID}`,
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {
 

--- a/cmd/evidence/collect.go
+++ b/cmd/evidence/collect.go
@@ -155,16 +155,16 @@ This all-in-one command gathers:
 The collected evidence is saved to the specified output directory for
 inclusion in test reports and feature validation documentation.`,
 		Example: `  # Collect all evidence to a directory
-  osdctl evidence collect -C <cluster-id> --output ./evidence/
+  osdctl evidence collect -C ${CLUSTER_ID} --output ./evidence/
 
   # Collect evidence from the last 2 hours
-  osdctl evidence collect -C <cluster-id> --output ./evidence/ --since 2h
+  osdctl evidence collect -C ${CLUSTER_ID} --output ./evidence/ --since 2h
 
   # Collect evidence without CloudTrail (for non-AWS or limited access)
-  osdctl evidence collect -C <cluster-id> --output ./evidence/ --skip-cloudtrail
+  osdctl evidence collect -C ${CLUSTER_ID} --output ./evidence/ --skip-cloudtrail
 
   # Include Kubernetes events in collection
-  osdctl evidence collect -C <cluster-id> --output ./evidence/ --include-events`,
+  osdctl evidence collect -C ${CLUSTER_ID} --output ./evidence/ --include-events`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return opts.run()
 		},
@@ -569,7 +569,7 @@ func (o *collectOptions) collectKubernetesEvents(startTime time.Time) ([]EventIn
 func (o *collectOptions) collectCloudTrailData(startTime time.Time) (*CloudTrailData, error) {
 	// Note: Full CloudTrail error data collection is handled by 'osdctl cloudtrail errors'
 	// This function verifies AWS access is available
-	// For detailed CloudTrail analysis, use: osdctl cloudtrail errors -C <cluster-id> --since <duration>
+	// For detailed CloudTrail analysis, use: osdctl cloudtrail errors -C ${CLUSTER_ID} --since <duration>
 	_ = startTime
 
 	// Return nil to indicate CloudTrail was not collected (use dedicated command for details)

--- a/cmd/evidence/collect.go
+++ b/cmd/evidence/collect.go
@@ -607,18 +607,18 @@ func (o *collectOptions) saveSummary(evidence *EvidenceCollection, filename stri
 
 	sb.WriteString("EVIDENCE COLLECTION SUMMARY\n")
 	sb.WriteString("===========================\n\n")
-	sb.WriteString(fmt.Sprintf("Cluster: %s (%s)\n", evidence.Metadata.ClusterName, evidence.Metadata.ClusterID))
-	sb.WriteString(fmt.Sprintf("Platform: %s\n", evidence.Metadata.Platform))
-	sb.WriteString(fmt.Sprintf("Collection Time: %s\n", evidence.Metadata.CollectionTime.Format(time.RFC3339)))
-	sb.WriteString(fmt.Sprintf("Time Window Start: %s\n\n", evidence.Metadata.TimeWindowStart.Format(time.RFC3339)))
+	fmt.Fprintf(&sb, "Cluster: %s (%s)\n", evidence.Metadata.ClusterName, evidence.Metadata.ClusterID)
+	fmt.Fprintf(&sb, "Platform: %s\n", evidence.Metadata.Platform)
+	fmt.Fprintf(&sb, "Collection Time: %s\n", evidence.Metadata.CollectionTime.Format(time.RFC3339))
+	fmt.Fprintf(&sb, "Time Window Start: %s\n\n", evidence.Metadata.TimeWindowStart.Format(time.RFC3339))
 
 	if evidence.ClusterState != nil {
 		sb.WriteString("CLUSTER STATE\n")
 		sb.WriteString("-------------\n")
-		sb.WriteString(fmt.Sprintf("Nodes: %d\n", len(evidence.ClusterState.Nodes)))
-		sb.WriteString(fmt.Sprintf("Operators: %d\n", len(evidence.ClusterState.Operators)))
-		sb.WriteString(fmt.Sprintf("MachineConfigs: %d\n", len(evidence.ClusterState.MachineConfigs)))
-		sb.WriteString(fmt.Sprintf("Events: %d\n\n", len(evidence.ClusterState.Events)))
+		fmt.Fprintf(&sb, "Nodes: %d\n", len(evidence.ClusterState.Nodes))
+		fmt.Fprintf(&sb, "Operators: %d\n", len(evidence.ClusterState.Operators))
+		fmt.Fprintf(&sb, "MachineConfigs: %d\n", len(evidence.ClusterState.MachineConfigs))
+		fmt.Fprintf(&sb, "Events: %d\n\n", len(evidence.ClusterState.Events))
 
 		// Count degraded operators
 		degradedCount := 0
@@ -628,10 +628,10 @@ func (o *collectOptions) saveSummary(evidence *EvidenceCollection, filename stri
 			}
 		}
 		if degradedCount > 0 {
-			sb.WriteString(fmt.Sprintf("⚠️  Degraded Operators: %d\n", degradedCount))
+			fmt.Fprintf(&sb, "⚠️  Degraded Operators: %d\n", degradedCount)
 			for _, op := range evidence.ClusterState.Operators {
 				if op.Degraded {
-					sb.WriteString(fmt.Sprintf("   - %s\n", op.Name))
+					fmt.Fprintf(&sb, "   - %s\n", op.Name)
 				}
 			}
 			sb.WriteString("\n")
@@ -645,10 +645,10 @@ func (o *collectOptions) saveSummary(evidence *EvidenceCollection, filename stri
 			}
 		}
 		if notReadyCount > 0 {
-			sb.WriteString(fmt.Sprintf("⚠️  Not Ready Nodes: %d\n", notReadyCount))
+			fmt.Fprintf(&sb, "⚠️  Not Ready Nodes: %d\n", notReadyCount)
 			for _, node := range evidence.ClusterState.Nodes {
 				if node.Status != "Ready" {
-					sb.WriteString(fmt.Sprintf("   - %s\n", node.Name))
+					fmt.Fprintf(&sb, "   - %s\n", node.Name)
 				}
 			}
 			sb.WriteString("\n")
@@ -658,8 +658,8 @@ func (o *collectOptions) saveSummary(evidence *EvidenceCollection, filename stri
 	if evidence.CloudTrailData != nil {
 		sb.WriteString("CLOUDTRAIL DATA\n")
 		sb.WriteString("---------------\n")
-		sb.WriteString(fmt.Sprintf("Error Events: %d\n", len(evidence.CloudTrailData.ErrorEvents)))
-		sb.WriteString(fmt.Sprintf("Write Events: %d\n\n", len(evidence.CloudTrailData.WriteEvents)))
+		fmt.Fprintf(&sb, "Error Events: %d\n", len(evidence.CloudTrailData.ErrorEvents))
+		fmt.Fprintf(&sb, "Write Events: %d\n\n", len(evidence.CloudTrailData.WriteEvents))
 
 		if len(evidence.CloudTrailData.ErrorEvents) > 0 {
 			sb.WriteString("Recent Errors:\n")
@@ -669,7 +669,7 @@ func (o *collectOptions) saveSummary(evidence *EvidenceCollection, filename stri
 			}
 			for i := 0; i < maxErrors; i++ {
 				e := evidence.CloudTrailData.ErrorEvents[i]
-				sb.WriteString(fmt.Sprintf("   - %s: %s (%s)\n", e.EventTime, e.EventName, e.ErrorCode))
+				fmt.Fprintf(&sb, "   - %s: %s (%s)\n", e.EventTime, e.EventName, e.ErrorCode)
 			}
 			sb.WriteString("\n")
 		}

--- a/cmd/hcp/backup/backup.go
+++ b/cmd/hcp/backup/backup.go
@@ -21,9 +21,9 @@ func NewCmdBackup() *cobra.Command {
 		Use:   "backup --cluster-id <cluster-id> --reason <reason>",
 		Short: "Trigger a Velero backup for an HCP cluster",
 		Long:  longDescription,
-		Example: "  osdctl hcp backup --cluster-id 1abc2def3ghi --reason OHSS-12345\n" +
-			"  osdctl hcp backup --cluster-id 1abc2def3ghi --reason OHSS-12345 --label env=prod --label incident=OHSS-12345\n" +
-			"  osdctl hcp backup --cluster-id 1abc2def3ghi --reason OHSS-12345 --annotation owner=sre-team",
+		Example: "  osdctl hcp backup --cluster-id ${CLUSTER_ID} --reason ${REASON}\n" +
+			"  osdctl hcp backup --cluster-id ${CLUSTER_ID} --reason ${REASON} --label env=prod --label incident=${REASON}\n" +
+			"  osdctl hcp backup --cluster-id ${CLUSTER_ID} --reason ${REASON} --annotation owner=sre-team",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/hcp/get-cp-autoscaling-status/get_cp_autoscaling_status.go
+++ b/cmd/hcp/get-cp-autoscaling-status/get_cp_autoscaling_status.go
@@ -67,19 +67,19 @@ This command is useful for checking the autoscaling configuration status of host
 on a specific management cluster during day-to-day operations.`,
 		Example: `
   # Get autoscaling status for all hosted clusters on a management cluster
-  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id <cluster-id>
+  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id ${MGMT_CLUSTER_ID}
 
   # Get status with CSV output
-  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id <cluster-id> --output csv > status.csv
+  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id ${MGMT_CLUSTER_ID} --output csv > status.csv
 
   # Show only clusters ready for migration
-  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id <cluster-id> --show-only ready-for-migration
+  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id ${MGMT_CLUSTER_ID} --show-only ready-for-migration
 
   # Show only clusters that need annotation removal
-  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id <cluster-id> --show-only needs-removal
+  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id ${MGMT_CLUSTER_ID} --show-only needs-removal
 
   # Show only clusters safe to remove override
-  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id <cluster-id> --show-only safe-to-remove-override`,
+  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id ${MGMT_CLUSTER_ID} --show-only safe-to-remove-override`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/hcp/mustgather/mustGather.go
+++ b/cmd/hcp/mustgather/mustGather.go
@@ -43,7 +43,7 @@ func NewCmdMustGather() *cobra.Command {
 		Use:     "must-gather --cluster-id <cluster-identifier>",
 		Short:   "Create a must-gather for HCP cluster",
 		Long:    "Create a must-gather for an HCP cluster with optional gather targets",
-		Example: "osdctl hcp must-gather --cluster-id CLUSTER_ID --gather sc,mc,sc_acm --reason OHSS-1234",
+		Example: "  osdctl hcp must-gather --cluster-id ${CLUSTER_ID} --gather sc,mc,sc_acm --reason ${REASON}",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			return mg.Run()

--- a/cmd/hcp/status/status.go
+++ b/cmd/hcp/status/status.go
@@ -21,11 +21,8 @@ func NewCmdStatus() *cobra.Command {
 		Long: `Display a comprehensive health overview of a ROSA HCP cluster using
 data from the OCM live resources endpoint. Shows ManifestWork sync status,
 HostedCluster conditions, certificate status, and NodePool health.`,
-		Example: `  # Show status by cluster name
-  osdctl hcp status --cluster-id my-cluster
-
-  # Show status by cluster ID
-  osdctl hcp status --cluster-id 2o9r9r1q4tp0bulsfksdc8fesls54sql`,
+		Example: `  # Show HCP cluster status
+  osdctl hcp status --cluster-id ${CLUSTER_ID}`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/iampermissions/diff.go
+++ b/cmd/iampermissions/diff.go
@@ -33,7 +33,7 @@ func newCmdDiff() *cobra.Command {
 	}
 
 	policyCmd := &cobra.Command{
-		Use:               "diff",
+		Use:   "diff",
 		Short: "Diff IAM permissions for cluster operators between two versions",
 		Example: `  # Diff IAM permissions between two OCP versions
   osdctl iampermissions diff --base-version 4.14.0 --target-version 4.15.0`,

--- a/cmd/iampermissions/diff.go
+++ b/cmd/iampermissions/diff.go
@@ -34,7 +34,9 @@ func newCmdDiff() *cobra.Command {
 
 	policyCmd := &cobra.Command{
 		Use:               "diff",
-		Short:             "Diff IAM permissions for cluster operators between two versions",
+		Short: "Diff IAM permissions for cluster operators between two versions",
+		Example: `  # Diff IAM permissions between two OCP versions
+  osdctl iampermissions diff --base-version 4.14.0 --target-version 4.15.0`,
 		Args:              cobra.ExactArgs(0),
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/iampermissions/get.go
+++ b/cmd/iampermissions/get.go
@@ -26,7 +26,7 @@ func newCmdGet() *cobra.Command {
 	}
 
 	policyCmd := &cobra.Command{
-		Use:               "get",
+		Use:   "get",
 		Short: "Get OCP CredentialsRequests",
 		Example: `  # Get IAM permissions for a specific OCP version
   osdctl iampermissions get --release-version 4.15.0`,

--- a/cmd/iampermissions/get.go
+++ b/cmd/iampermissions/get.go
@@ -27,7 +27,9 @@ func newCmdGet() *cobra.Command {
 
 	policyCmd := &cobra.Command{
 		Use:               "get",
-		Short:             "Get OCP CredentialsRequests",
+		Short: "Get OCP CredentialsRequests",
+		Example: `  # Get IAM permissions for a specific OCP version
+  osdctl iampermissions get --release-version 4.15.0`,
 		Args:              cobra.ExactArgs(0),
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/iampermissions/save.go
+++ b/cmd/iampermissions/save.go
@@ -44,7 +44,7 @@ func newCmdSave() *cobra.Command {
 	}
 
 	saveCmd := &cobra.Command{
-		Use:               "save",
+		Use:   "save",
 		Short: "Save iam permissions for use in mcc",
 		Example: `  # Save IAM permissions to a directory
   osdctl iampermissions save --dir /tmp/policies --release-version 4.15.0`,

--- a/cmd/iampermissions/save.go
+++ b/cmd/iampermissions/save.go
@@ -45,7 +45,9 @@ func newCmdSave() *cobra.Command {
 
 	saveCmd := &cobra.Command{
 		Use:               "save",
-		Short:             "Save iam permissions for use in mcc",
+		Short: "Save iam permissions for use in mcc",
+		Example: `  # Save IAM permissions to a directory
+  osdctl iampermissions save --dir /tmp/policies --release-version 4.15.0`,
 		Args:              cobra.ExactArgs(0),
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, _ []string) {

--- a/cmd/org/aws-accounts.go
+++ b/cmd/org/aws-accounts.go
@@ -13,9 +13,9 @@ import (
 
 var (
 	awsAccountsCmd = &cobra.Command{
-		Use:           "aws-accounts",
-		Short:         "get organization AWS Accounts",
-		Args: cobra.ArbitraryArgs,
+		Use:   "aws-accounts",
+		Short: "get organization AWS Accounts",
+		Args:  cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(searchChildAwsAccounts(cmd))
 		},

--- a/cmd/org/aws-accounts.go
+++ b/cmd/org/aws-accounts.go
@@ -15,8 +15,7 @@ var (
 	awsAccountsCmd = &cobra.Command{
 		Use:           "aws-accounts",
 		Short:         "get organization AWS Accounts",
-		Args:          cobra.ArbitraryArgs,
-		SilenceErrors: true,
+		Args: cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(searchChildAwsAccounts(cmd))
 		},

--- a/cmd/org/clusters.go
+++ b/cmd/org/clusters.go
@@ -33,8 +33,7 @@ osdctl org clusters 123456789AbcDEfGHiJklMnopQR --all
 
 Retrieving all active clusters for a given AWS profile:
 osdctl org clusters --aws-profile my-aws-profile --aws-account-id 123456789`,
-		Args:          cobra.MaximumNArgs(1),
-		SilenceErrors: true,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			orgId := ""
 			if len(args) > 0 {

--- a/cmd/org/current.go
+++ b/cmd/org/current.go
@@ -13,9 +13,9 @@ import (
 
 var (
 	currentCmd = &cobra.Command{
-		Use:           "current",
-		Short:         "gets current organization",
-		Args: cobra.ArbitraryArgs,
+		Use:   "current",
+		Short: "gets current organization",
+		Args:  cobra.ArbitraryArgs,
 		Run: func(_ *cobra.Command, _ []string) {
 			ocmClient, err := utils.CreateConnection()
 			if err != nil {

--- a/cmd/org/current.go
+++ b/cmd/org/current.go
@@ -15,8 +15,7 @@ var (
 	currentCmd = &cobra.Command{
 		Use:           "current",
 		Short:         "gets current organization",
-		Args:          cobra.ArbitraryArgs,
-		SilenceErrors: true,
+		Args: cobra.ArbitraryArgs,
 		Run: func(_ *cobra.Command, _ []string) {
 			ocmClient, err := utils.CreateConnection()
 			if err != nil {

--- a/cmd/org/customers.go
+++ b/cmd/org/customers.go
@@ -14,9 +14,9 @@ import (
 
 var (
 	customersCmd = &cobra.Command{
-		Use:           "customers",
-		Short:         "get paying/non-paying organizations",
-		Args: cobra.ArbitraryArgs,
+		Use:   "customers",
+		Short: "get paying/non-paying organizations",
+		Args:  cobra.ArbitraryArgs,
 		Run: func(_ *cobra.Command, _ []string) {
 			ocmClient, err := utils.CreateConnection()
 			if err != nil {

--- a/cmd/org/customers.go
+++ b/cmd/org/customers.go
@@ -16,8 +16,7 @@ var (
 	customersCmd = &cobra.Command{
 		Use:           "customers",
 		Short:         "get paying/non-paying organizations",
-		Args:          cobra.ArbitraryArgs,
-		SilenceErrors: true,
+		Args: cobra.ArbitraryArgs,
 		Run: func(_ *cobra.Command, _ []string) {
 			ocmClient, err := utils.CreateConnection()
 			if err != nil {

--- a/cmd/org/describe.go
+++ b/cmd/org/describe.go
@@ -14,9 +14,9 @@ import (
 
 var (
 	describeCmd = &cobra.Command{
-		Use:           "describe",
-		Short:         "describe organization",
-		Args: cobra.ArbitraryArgs,
+		Use:   "describe",
+		Short: "describe organization",
+		Args:  cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			ocmClient, err := utils.CreateConnection()
 			if err != nil {

--- a/cmd/org/describe.go
+++ b/cmd/org/describe.go
@@ -16,8 +16,7 @@ var (
 	describeCmd = &cobra.Command{
 		Use:           "describe",
 		Short:         "describe organization",
-		Args:          cobra.ArbitraryArgs,
-		SilenceErrors: true,
+		Args: cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			ocmClient, err := utils.CreateConnection()
 			if err != nil {

--- a/cmd/org/get.go
+++ b/cmd/org/get.go
@@ -23,8 +23,7 @@ var (
 	getCmd = &cobra.Command{
 		Use:           "get",
 		Short:         "get organization by users",
-		Args:          cobra.ArbitraryArgs,
-		SilenceErrors: true,
+		Args: cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			ocmClient, err := utils.CreateConnection()
 			if err != nil {

--- a/cmd/org/get.go
+++ b/cmd/org/get.go
@@ -21,9 +21,9 @@ const (
 
 var (
 	getCmd = &cobra.Command{
-		Use:           "get",
-		Short:         "get organization by users",
-		Args: cobra.ArbitraryArgs,
+		Use:   "get",
+		Short: "get organization by users",
+		Args:  cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			ocmClient, err := utils.CreateConnection()
 			if err != nil {

--- a/cmd/org/labels.go
+++ b/cmd/org/labels.go
@@ -16,9 +16,9 @@ import (
 
 var (
 	labelsCmd = &cobra.Command{
-		Use:           "labels",
-		Short:         "get organization labels",
-		Args: cobra.ArbitraryArgs,
+		Use:   "labels",
+		Short: "get organization labels",
+		Args:  cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			ocmClient, err := utils.CreateConnection()
 			if err != nil {

--- a/cmd/org/labels.go
+++ b/cmd/org/labels.go
@@ -18,8 +18,7 @@ var (
 	labelsCmd = &cobra.Command{
 		Use:           "labels",
 		Short:         "get organization labels",
-		Args:          cobra.ArbitraryArgs,
-		SilenceErrors: true,
+		Args: cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			ocmClient, err := utils.CreateConnection()
 			if err != nil {

--- a/cmd/org/users.go
+++ b/cmd/org/users.go
@@ -17,8 +17,7 @@ var (
 	usersCmd = &cobra.Command{
 		Use:           "users",
 		Short:         "get organization users",
-		Args:          cobra.ArbitraryArgs,
-		SilenceErrors: true,
+		Args: cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(checkOrgId(args))
 			cmdutil.CheckErr(getUsers(args[0]))

--- a/cmd/org/users.go
+++ b/cmd/org/users.go
@@ -15,9 +15,9 @@ import (
 
 var (
 	usersCmd = &cobra.Command{
-		Use:           "users",
-		Short:         "get organization users",
-		Args: cobra.ArbitraryArgs,
+		Use:   "users",
+		Short: "get organization users",
+		Args:  cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(checkOrgId(args))
 			cmdutil.CheckErr(getUsers(args[0]))

--- a/cmd/promote/rhobs/rhobs.go
+++ b/cmd/promote/rhobs/rhobs.go
@@ -80,7 +80,7 @@ func resolveConfigRepoPath(provided string) (string, error) {
 		filepath.Join(os.Getenv("HOME"), "src", "rhobs-configuration-gitlab"),
 	}
 	for _, p := range candidates {
-		if _, err := os.Stat(filepath.Join(p, ".git")); err == nil {
+		if _, err := os.Stat(filepath.Join(p, ".git")); err == nil { //nolint:gosec // G703 false positive — paths are from hardcoded candidates, not user input
 			return p, nil
 		}
 	}
@@ -204,7 +204,7 @@ func updateProductionTargets(service *promote.Service, newHash string) (bool, er
 	}
 
 	if updated {
-		if err := os.WriteFile(filePath, []byte(strings.Join(lines, "\n")), 0600); err != nil {
+		if err := os.WriteFile(filePath, []byte(strings.Join(lines, "\n")), 0600); err != nil { //nolint:gosec // G703 false positive — filePath is from app-interface checkout, not user input
 			return false, fmt.Errorf("failed to write %s: %v", filePath, err)
 		}
 	}

--- a/cmd/required_flags_test.go
+++ b/cmd/required_flags_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func TestRequiredFlagsDocumentedInExamples(t *testing.T) {
+	streams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+	root := NewCmdRoot(streams)
+
+	var walk func(cmd *cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		if cmd.HasSubCommands() {
+			for _, sub := range cmd.Commands() {
+				walk(sub)
+			}
+			return
+		}
+
+		var names []string
+		shorthands := map[string]string{}
+		cmd.Flags().VisitAll(func(f *pflag.Flag) {
+			if ann, ok := f.Annotations[cobra.BashCompOneRequiredFlag]; ok && len(ann) > 0 && ann[0] == "true" {
+				names = append(names, f.Name)
+				if f.Shorthand != "" {
+					shorthands[f.Name] = f.Shorthand
+				}
+			}
+		})
+		if len(names) == 0 {
+			return
+		}
+
+		path := cmd.CommandPath()
+		if cmd.Example == "" {
+			t.Errorf("command %q has required flags %v but no Example field", path, names)
+			return
+		}
+		for _, name := range names {
+			if exampleContainsFlag(cmd.Example, name, shorthands[name]) {
+				continue
+			}
+			t.Errorf("command %q Example omits required flag --%s", path, name)
+		}
+	}
+	walk(root)
+}
+
+func exampleContainsFlag(example, name, shorthand string) bool {
+	if strings.Contains(example, fmt.Sprintf("--%s", name)) {
+		return true
+	}
+	if shorthand != "" && strings.Contains(example, fmt.Sprintf("-%s ", shorthand)) {
+		return true
+	}
+	return false
+}

--- a/cmd/rhobs/cellCmd.go
+++ b/cmd/rhobs/cellCmd.go
@@ -2,24 +2,30 @@ package rhobs
 
 import (
 	"fmt"
+	"os"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 func newCmdCell() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "cell",
-		Short:         "Get the RHOBS cell for a given cluster",
-		Args:          cobra.NoArgs,
-		SilenceErrors: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Use:   "cell",
+		Short: "Get the RHOBS cell for a given cluster",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
 			cmd.SilenceUsage = true
 
 			metricsRhobsFetcher, logsRhobsFetcher, err := CreateMetricsAndLogsRhobsFetchers(commonOptions.clusterId, commonOptions.hiveOcmUrl)
+			if err != nil {
+				log.Errorf("Error while computing RHOBS cells: %v", err)
+				os.Exit(1)
+			}
+
 			if metricsRhobsFetcher != nil {
 				if logsRhobsFetcher != nil && metricsRhobsFetcher.RhobsCell == logsRhobsFetcher.RhobsCell {
 					fmt.Println("Metrics & logs RHOBS cell:", metricsRhobsFetcher.RhobsCell)
-					return nil
+					return
 				}
 
 				fmt.Println("Metrics RHOBS cell:", metricsRhobsFetcher.RhobsCell)
@@ -28,8 +34,6 @@ func newCmdCell() *cobra.Command {
 			if logsRhobsFetcher != nil {
 				fmt.Println("Logs RHOBS cell   :", logsRhobsFetcher.RhobsCell)
 			}
-
-			return err
 		},
 	}
 

--- a/cmd/rhobs/logsCmd.go
+++ b/cmd/rhobs/logsCmd.go
@@ -48,8 +48,7 @@ func newCmdLogs() *cobra.Command {
 			"By default, logs from all the pods in the given namespace are returned but it is possible to specify " +
 			"a single pod as an argument or filter pods using their labels. Logs themselves can be also filtered " +
 			"to only keep the ones containing a given regexp (--contain-regex option) or a given log level (--level option).",
-		Args:          cobra.MaximumNArgs(1),
-		SilenceErrors: true,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if isOpeningGrafanaUrl && !isComputingGrafanaUrl {
 				return fmt.Errorf("--browser can only be set if --url is set")

--- a/cmd/rhobs/mcpCmd.go
+++ b/cmd/rhobs/mcpCmd.go
@@ -68,8 +68,8 @@ Prerequisites:
 
 func newCmdMcpServer() *cobra.Command {
 	return &cobra.Command{
-		Use:           "server",
-		Short:         "Start the RHOBS MCP server",
+		Use:          "server",
+		Short:        "Start the RHOBS MCP server",
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/rhobs/mcpCmd.go
+++ b/cmd/rhobs/mcpCmd.go
@@ -70,9 +70,8 @@ func newCmdMcpServer() *cobra.Command {
 	return &cobra.Command{
 		Use:           "server",
 		Short:         "Start the RHOBS MCP server",
-		Args:          cobra.NoArgs,
-		SilenceErrors: true,
-		SilenceUsage:  true,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.SetOutput(io.Discard)
 
@@ -105,9 +104,8 @@ Usage with Claude Code:
   claude --mcp-config "$(osdctl rhobs mcp config)"
 
 Or add to ~/.claude/mcp_settings.json manually.`,
-		Args:          cobra.NoArgs,
-		SilenceErrors: true,
-		SilenceUsage:  true,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			execPath, err := os.Executable()
 			if err != nil {

--- a/cmd/rhobs/metricsCmd.go
+++ b/cmd/rhobs/metricsCmd.go
@@ -29,8 +29,7 @@ func newCmdMetrics() *cobra.Command {
 			"but it is possible to specify a different evaluation time using the --time option or a time range using the --start-time, --end-time and --since options. " +
 			"Results can be filtered to only keep the ones matching the given cluster (--cluster-id option) with the --filter option " +
 			"even if it is more efficient to do that filtering at the prometheus expression level.",
-		Args:          cobra.MaximumNArgs(1),
-		SilenceErrors: true,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !isComputingGrafanaUrl {
 				if isOpeningGrafanaUrl {

--- a/cmd/rhobs/rootCmd.go
+++ b/cmd/rhobs/rootCmd.go
@@ -12,9 +12,9 @@ var commonOptions = struct {
 
 func NewCmdRhobs() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "rhobs",
-		Short:         "RHOBS.next related utilities",
-		Args: cobra.NoArgs,
+		Use:   "rhobs",
+		Short: "RHOBS.next related utilities",
+		Args:  cobra.NoArgs,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			for c := cmd; c != nil; c = c.Parent() {
 				if c.Name() == "mcp" {

--- a/cmd/rhobs/rootCmd.go
+++ b/cmd/rhobs/rootCmd.go
@@ -14,8 +14,7 @@ func NewCmdRhobs() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "rhobs",
 		Short:         "RHOBS.next related utilities",
-		Args:          cobra.NoArgs,
-		SilenceErrors: true,
+		Args: cobra.NoArgs,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			for c := cmd; c != nil; c = c.Parent() {
 				if c.Name() == "mcp" {

--- a/cmd/servicelog/list.go
+++ b/cmd/servicelog/list.go
@@ -23,18 +23,16 @@ func newListCmd() *cobra.Command {
 	opts := &listCmdOptions{}
 	cmd := &cobra.Command{
 		Use: "list --cluster-id <cluster-identifier> [flags] [options]",
-		Long: `Get service logs for a given cluster identifier.
-
-# To return just service logs created by SREs
-osdctl servicelog list --cluster-id=my-cluster-id
-
-# To return all service logs, including those by automated systems
-osdctl servicelog list --cluster-id=my-cluster-id --all-messages
-
-# To return all service logs, as well as internal service logs
-osdctl servicelog list --cluster-id=my-cluster-id --all-messages --internal
-`,
+		Long:  "Get service logs for a given cluster identifier.",
 		Short: "Get service logs for a given cluster identifier.",
+		Example: `  # List SRE-created service logs
+  osdctl servicelog list --cluster-id ${CLUSTER_ID}
+
+  # List all service logs including automated
+  osdctl servicelog list --cluster-id ${CLUSTER_ID} --all-messages
+
+  # List all service logs including internal
+  osdctl servicelog list --cluster-id ${CLUSTER_ID} --all-messages --internal`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listServiceLogs(opts.clusterID, opts)

--- a/cmd/servicelog/list.go
+++ b/cmd/servicelog/list.go
@@ -22,7 +22,7 @@ type listCmdOptions struct {
 func newListCmd() *cobra.Command {
 	opts := &listCmdOptions{}
 	cmd := &cobra.Command{
-		Use: "list --cluster-id <cluster-identifier> [flags] [options]",
+		Use:   "list --cluster-id <cluster-identifier> [flags] [options]",
 		Long:  "Get service logs for a given cluster identifier.",
 		Short: "Get service logs for a given cluster identifier.",
 		Example: `  # List SRE-created service logs
@@ -33,7 +33,7 @@ func newListCmd() *cobra.Command {
 
   # List all service logs including internal
   osdctl servicelog list --cluster-id ${CLUSTER_ID} --all-messages --internal`,
-		Args:  cobra.NoArgs,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return listServiceLogs(opts.clusterID, opts)
 		},

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -18,10 +18,10 @@ import (
 )
 
 var upgradeCmd = &cobra.Command{
-	Use:           "upgrade",
-	Short:         "Upgrade osdctl",
-	Long:          "Fetch latest osdctl from GitHub and replace the running binary",
-	RunE: upgrade,
+	Use:   "upgrade",
+	Short: "Upgrade osdctl",
+	Long:  "Fetch latest osdctl from GitHub and replace the running binary",
+	RunE:  upgrade,
 }
 
 func upgrade(cmd *cobra.Command, args []string) error {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -21,8 +21,7 @@ var upgradeCmd = &cobra.Command{
 	Use:           "upgrade",
 	Short:         "Upgrade osdctl",
 	Long:          "Fetch latest osdctl from GitHub and replace the running binary",
-	RunE:          upgrade,
-	SilenceErrors: true,
+	RunE: upgrade,
 }
 
 func upgrade(cmd *cobra.Command, args []string) error {

--- a/docs/README.md
+++ b/docs/README.md
@@ -986,7 +986,7 @@ osdctl alert silence [flags]
 
 ### osdctl alert silence add
 
-add new silence for specfic or all alert with comment and duration of alert
+Add a new silence for a specific alert or for all alerts, including a comment and duration.
 
 ```
 osdctl alert silence add --cluster-id <cluster-identifier> [--all --duration --comment | --alertname --duration --comment] [flags]
@@ -1016,7 +1016,7 @@ osdctl alert silence add --cluster-id <cluster-identifier> [--all --duration --c
 
 ### osdctl alert silence expire
 
-expire all silence or based on silenceid
+Expire all silences, or expire a specific silence by its silence ID.
 
 ```
 osdctl alert silence expire [--cluster-id <cluster-identifier>] [--all | --silence-id <silence-id>] [flags]
@@ -1070,7 +1070,7 @@ osdctl alert silence list --cluster-id <cluster-identifier> [flags]
 
 ### osdctl alert silence org
 
-add new silence for specfic or all alerts with comment and duration of alert for an organization. OHSS required for org-wide silence
+Add a new silence for specific alerts or all alerts with a comment and duration for an organization. OHSS required for org-wide silence.
 
 ```
 osdctl alert silence org <org-id> [--all --duration --comment | --alertname --duration --comment] [flags]
@@ -1605,7 +1605,7 @@ osdctl cluster etcd-health-check --cluster-id <cluster-id> --reason <reason for 
 
 ### osdctl cluster etcd-member-replace
 
-Replaces an unhealthy ectd node using the member id provided
+Replaces an unhealthy etcd node using the member id provided
 
 ```
 osdctl cluster etcd-member-replace --cluster-id <cluster-identifier> [flags]

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@
     - `list` - List out accounts for username
     - `unassign` - Unassign account to user
   - `reset <account name>` - Reset AWS Account CR
-  - `rotate-secret <aws-account-cr-name>` - Rotate IAM credentials secret
+  - `rotate-secret ${AWS_ACCOUNT_CR_NAME}` - Rotate IAM credentials secret
   - `servicequotas` - Interact with AWS service-quotas
     - `describe` - Describe AWS service-quotas
   - `set <account name>` - Set AWS Account CR status
@@ -774,7 +774,7 @@ osdctl account reset <account name> [flags]
 When logged into a hive shard, this rotates IAM credential secrets for a given `account` CR.
 
 ```
-osdctl account rotate-secret <aws-account-cr-name> [flags]
+osdctl account rotate-secret ${AWS_ACCOUNT_CR_NAME} [flags]
 ```
 
 #### Flags
@@ -1352,32 +1352,6 @@ Available Investigations:
   insightsoperatordown, machine-health-check, must-gather, upgrade-config,
   restart-controlplane, describe-nodes
 
-Examples:
-```bash
-# Run a change management investigation on a production cluster
-osdctl cluster cad run \
-  --cluster-id 1a2b3c4d5e6f7g8h9i0j \
-  --investigation chgm \
-  --environment production \
-  --reason "OHSS-12345"
-
-# Run a dry-run investigation (does not create a report)
-osdctl cluster cad run \
-  --cluster-id 1a2b3c4d5e6f7g8h9i0j \
-  --investigation chgm \
-  --environment production \
-  --reason "OHSS-12345" \
-  --dry-run
-
-# Run describe-nodes on master nodes only
-osdctl cluster cad run \
-  --cluster-id 1a2b3c4d5e6f7g8h9i0j \
-  --investigation describe-nodes \
-  --environment production \
-  --reason "OHSS-12345" \
-  --params MASTER=true
-```
-
 Note:
   After the investigation completes (may take several minutes), view results using:
 ```bash
@@ -1875,23 +1849,6 @@ includes a summary (title) and data content. You can provide the data either
 directly as a string using --data, or from a file using --file. The data
 will be automatically base64-encoded before storage.
 
-Examples:
-  # Create a report with inline data
-  osdctl cluster reports create --cluster-id 1a2b3c4d \
-    --summary "Network diagnostic results" \
-    --data "All network checks passed successfully"
-
-  # Create a report from a file
-  osdctl cluster reports create -C my-cluster \
-    --summary "Pod logs from incident" \
-    --file /tmp/pod-logs.txt
-
-  # Create a report and output as JSON
-  osdctl cluster reports create --cluster-id 1a2b3c4d \
-    --summary "Cluster health check" \
-    --data "CPU: 45%, Memory: 67%, Disk: 23%" \
-    --output json
-
 ```
 osdctl cluster reports create [flags]
 ```
@@ -1923,16 +1880,6 @@ Retrieve and display a specific report by its ID.
 This command fetches a report by its report ID and displays the decoded
 report data. Use 'list' to find available report IDs.
 
-Examples:
-  # Get a specific report and display its contents
-  osdctl cluster reports get --cluster-id 1a2b3c4d --report-id abc-123-def
-
-  # Get a report with JSON output (includes encoded data)
-  osdctl cluster reports get -C my-cluster -r report-456 --output json
-
-  # Get a report and pipe the output to a file
-  osdctl cluster reports get -C 1a2b3c4d -r abc-123 > report-output.txt
-
 ```
 osdctl cluster reports get [flags]
 ```
@@ -1962,16 +1909,6 @@ List all reports for a specific cluster.
 This command retrieves and displays all reports associated with a cluster,
 showing the report ID, summary, and creation timestamp. You can optionally
 limit the number of reports returned to the most recent N reports.
-
-Examples:
-  # List all reports for a cluster (defaults to 10 most recent)
-  osdctl cluster reports list --cluster-id 1a2b3c4d
-
-  # List the 5 most recent reports
-  osdctl cluster reports list --cluster-id 1a2b3c4d --last 5
-
-  # List reports with JSON output
-  osdctl cluster reports list --cluster-id my-cluster --output json
 
 ```
 osdctl cluster reports list [flags]
@@ -4410,16 +4347,6 @@ osdctl servicelog [flags]
 ### osdctl servicelog list
 
 Get service logs for a given cluster identifier.
-
-# To return just service logs created by SREs
-osdctl servicelog list --cluster-id=my-cluster-id
-
-# To return all service logs, including those by automated systems
-osdctl servicelog list --cluster-id=my-cluster-id --all-messages
-
-# To return all service logs, as well as internal service logs
-osdctl servicelog list --cluster-id=my-cluster-id --all-messages --internal
-
 
 ```
 osdctl servicelog list --cluster-id <cluster-identifier> [flags] [options]

--- a/docs/osdctl_account_rotate-secret.md
+++ b/docs/osdctl_account_rotate-secret.md
@@ -7,7 +7,20 @@ Rotate IAM credentials secret
 When logged into a hive shard, this rotates IAM credential secrets for a given `account` CR.
 
 ```
-osdctl account rotate-secret <aws-account-cr-name> [flags]
+osdctl account rotate-secret ${AWS_ACCOUNT_CR_NAME} [flags]
+```
+
+### Examples
+
+```
+  # Rotate IAM credentials for an account CR
+  osdctl account rotate-secret ${AWS_ACCOUNT_CR_NAME} --cluster-id ${CLUSTER_ID} --reason "${REASON}"
+
+  # Rotate including CCS admin credentials
+  osdctl account rotate-secret ${AWS_ACCOUNT_CR_NAME} --cluster-id ${CLUSTER_ID} --reason "${REASON}" --ccs
+
+  # Dry-run to preview without making changes
+  osdctl account rotate-secret ${AWS_ACCOUNT_CR_NAME} --cluster-id ${CLUSTER_ID} --reason "${REASON}" --dry-run
 ```
 
 ### Options

--- a/docs/osdctl_alert_list.md
+++ b/docs/osdctl_alert_list.md
@@ -10,6 +10,16 @@ Checks the alerts for the cluster and print the list based on severity
 osdctl alert list --cluster-id <cluster-id> --level [warning, critical, firing, pending, all] [flags]
 ```
 
+### Examples
+
+```
+  # List all firing alerts for a cluster
+  osdctl alerts list --cluster-id ${CLUSTER_ID} --reason "${REASON}"
+
+  # List only critical alerts
+  osdctl alerts list --cluster-id ${CLUSTER_ID} --level critical --reason "${REASON}"
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_alert_list.md
+++ b/docs/osdctl_alert_list.md
@@ -13,8 +13,11 @@ osdctl alert list --cluster-id <cluster-id> --level [warning, critical, firing, 
 ### Examples
 
 ```
-  # List all firing alerts for a cluster
+  # List all alerts for a cluster
   osdctl alerts list --cluster-id ${CLUSTER_ID} --reason "${REASON}"
+
+  # List only firing alerts
+  osdctl alerts list --cluster-id ${CLUSTER_ID} --level firing --reason "${REASON}"
 
   # List only critical alerts
   osdctl alerts list --cluster-id ${CLUSTER_ID} --level critical --reason "${REASON}"

--- a/docs/osdctl_alert_silence_add.md
+++ b/docs/osdctl_alert_silence_add.md
@@ -4,7 +4,7 @@ Add new silence for alert
 
 ### Synopsis
 
-add new silence for specfic or all alert with comment and duration of alert
+Add a new silence for a specific alert or for all alerts, including a comment and duration.
 
 ```
 osdctl alert silence add --cluster-id <cluster-identifier> [--all --duration --comment | --alertname --duration --comment] [flags]

--- a/docs/osdctl_alert_silence_add.md
+++ b/docs/osdctl_alert_silence_add.md
@@ -10,6 +10,19 @@ add new silence for specfic or all alert with comment and duration of alert
 osdctl alert silence add --cluster-id <cluster-identifier> [--all --duration --comment | --alertname --duration --comment] [flags]
 ```
 
+### Examples
+
+```
+  # Silence a specific alert
+  osdctl alerts silence add --cluster-id ${CLUSTER_ID} --alertname "KubePodNotReady" --reason "${REASON}"
+
+  # Silence all alerts for a cluster
+  osdctl alerts silence add --cluster-id ${CLUSTER_ID} --all --reason "${REASON}"
+
+  # Silence an alert with custom duration and comment
+  osdctl alerts silence add --cluster-id ${CLUSTER_ID} --alertname "KubePodNotReady" --duration 2h --comment "Investigating pod issue" --reason "${REASON}"
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_alert_silence_expire.md
+++ b/docs/osdctl_alert_silence_expire.md
@@ -4,7 +4,7 @@ Expire Silence for alert
 
 ### Synopsis
 
-expire all silence or based on silenceid
+Expire all silences, or expire a specific silence by its silence ID.
 
 ```
 osdctl alert silence expire [--cluster-id <cluster-identifier>] [--all | --silence-id <silence-id>] [flags]

--- a/docs/osdctl_alert_silence_expire.md
+++ b/docs/osdctl_alert_silence_expire.md
@@ -10,6 +10,16 @@ expire all silence or based on silenceid
 osdctl alert silence expire [--cluster-id <cluster-identifier>] [--all | --silence-id <silence-id>] [flags]
 ```
 
+### Examples
+
+```
+  # Expire a specific silence by ID
+  osdctl alerts silence expire --cluster-id ${CLUSTER_ID} --silence-id ${SILENCE_ID} --reason "${REASON}"
+
+  # Expire all silences for a cluster
+  osdctl alerts silence expire --cluster-id ${CLUSTER_ID} --all --reason "${REASON}"
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_alert_silence_list.md
+++ b/docs/osdctl_alert_silence_list.md
@@ -10,6 +10,13 @@ print the list of silences
 osdctl alert silence list --cluster-id <cluster-identifier> [flags]
 ```
 
+### Examples
+
+```
+  # List all active silences for a cluster
+  osdctl alerts silence list --cluster-id ${CLUSTER_ID} --reason "${REASON}"
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_alert_silence_org.md
+++ b/docs/osdctl_alert_silence_org.md
@@ -10,6 +10,16 @@ add new silence for specfic or all alerts with comment and duration of alert for
 osdctl alert silence org <org-id> [--all --duration --comment | --alertname --duration --comment] [flags]
 ```
 
+### Examples
+
+```
+  # Silence all alerts for an organization
+  osdctl alerts silence org ${ORG_ID} --all --comment "${REASON}: org-wide silence"
+
+  # Silence a specific alert for an organization
+  osdctl alerts silence org ${ORG_ID} --alertname "KubePodNotReady" --comment "${REASON}: investigating pod issue"
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_alert_silence_org.md
+++ b/docs/osdctl_alert_silence_org.md
@@ -4,7 +4,7 @@ Add new silence for alert for org
 
 ### Synopsis
 
-add new silence for specfic or all alerts with comment and duration of alert for an organization. OHSS required for org-wide silence
+Add a new silence for specific alerts or all alerts with a comment and duration for an organization. OHSS required for org-wide silence.
 
 ```
 osdctl alert silence org <org-id> [--all --duration --comment | --alertname --duration --comment] [flags]

--- a/docs/osdctl_cloudtrail_errors.md
+++ b/docs/osdctl_cloudtrail_errors.md
@@ -25,16 +25,16 @@ osdctl cloudtrail errors [flags]
 
 ```
   # Check for permission errors in the last hour
-  osdctl cloudtrail errors -C <cluster-id> --since 1h
+  osdctl cloudtrail errors -C ${CLUSTER_ID} --since 1h
 
   # Check for specific error types only
-  osdctl cloudtrail errors -C <cluster-id> --error-types AccessDenied,Forbidden
+  osdctl cloudtrail errors -C ${CLUSTER_ID} --error-types AccessDenied,Forbidden
 
   # Output as JSON for scripting
-  osdctl cloudtrail errors -C <cluster-id> --json
+  osdctl cloudtrail errors -C ${CLUSTER_ID} --json
 
   # Include console links for each event
-  osdctl cloudtrail errors -C <cluster-id> --url
+  osdctl cloudtrail errors -C ${CLUSTER_ID} --url
 ```
 
 ### Options

--- a/docs/osdctl_cloudtrail_permission-denied-events.md
+++ b/docs/osdctl_cloudtrail_permission-denied-events.md
@@ -6,6 +6,16 @@ Prints cloudtrail permission-denied events to console.
 osdctl cloudtrail permission-denied-events [flags]
 ```
 
+### Examples
+
+```
+  # Check for permission-denied events in the last 5 minutes
+  osdctl cloudtrail permission-denied-events --cluster-id ${CLUSTER_ID}
+
+  # Check for permission-denied events in the last hour with URLs
+  osdctl cloudtrail permission-denied-events --cluster-id ${CLUSTER_ID} --since 1h --url
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cluster_break-glass.md
+++ b/docs/osdctl_cluster_break-glass.md
@@ -10,6 +10,13 @@ Obtain emergency credentials to access the given cluster. You must be logged int
 osdctl cluster break-glass --cluster-id <cluster-identifier> [flags]
 ```
 
+### Examples
+
+```
+  # Obtain emergency break-glass access to a cluster
+  osdctl cluster break-glass --cluster-id ${CLUSTER_ID} --reason "${REASON}"
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cluster_break-glass_cleanup.md
+++ b/docs/osdctl_cluster_break-glass_cleanup.md
@@ -13,6 +13,13 @@ environment variable is unset, if applicable.
 osdctl cluster break-glass cleanup --cluster-id <cluster-identifier> [flags]
 ```
 
+### Examples
+
+```
+  # Drop emergency access to a cluster
+  osdctl cluster break-glass cleanup --cluster-id ${CLUSTER_ID}
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cluster_cad_run.md
+++ b/docs/osdctl_cluster_cad_run.md
@@ -18,32 +18,6 @@ Available Investigations:
   insightsoperatordown, machine-health-check, must-gather, upgrade-config,
   restart-controlplane, describe-nodes
 
-Examples:
-```bash
-# Run a change management investigation on a production cluster
-osdctl cluster cad run \
-  --cluster-id 1a2b3c4d5e6f7g8h9i0j \
-  --investigation chgm \
-  --environment production \
-  --reason "OHSS-12345"
-
-# Run a dry-run investigation (does not create a report)
-osdctl cluster cad run \
-  --cluster-id 1a2b3c4d5e6f7g8h9i0j \
-  --investigation chgm \
-  --environment production \
-  --reason "OHSS-12345" \
-  --dry-run
-
-# Run describe-nodes on master nodes only
-osdctl cluster cad run \
-  --cluster-id 1a2b3c4d5e6f7g8h9i0j \
-  --investigation describe-nodes \
-  --environment production \
-  --reason "OHSS-12345" \
-  --params MASTER=true
-```
-
 Note:
   After the investigation completes (may take several minutes), view results using:
 ```bash
@@ -54,6 +28,19 @@ osdctl cluster reports list -C <cluster-id> -l 1
 
 ```
 osdctl cluster cad run [flags]
+```
+
+### Examples
+
+```
+  # Run a change management investigation on a production cluster
+  osdctl cluster cad run --cluster-id ${CLUSTER_ID} --investigation chgm --environment production --reason "${REASON}"
+
+  # Run a dry-run investigation (does not create a report)
+  osdctl cluster cad run --cluster-id ${CLUSTER_ID} --investigation chgm --environment production --reason "${REASON}" --dry-run
+
+  # Run describe-nodes with parameters
+  osdctl cluster cad run --cluster-id ${CLUSTER_ID} --investigation describe-nodes --environment production --reason "${REASON}" --params MASTER=true
 ```
 
 ### Options

--- a/docs/osdctl_cluster_change-ebs-volume-type.md
+++ b/docs/osdctl_cluster_change-ebs-volume-type.md
@@ -21,13 +21,13 @@ osdctl cluster change-ebs-volume-type [flags]
 
 ```
   # Change both control plane and infra volumes to gp3
-  osdctl cluster change-ebs-volume-type -C ${CLUSTER_ID} --type gp3 --reason "SREP-3811"
+  osdctl cluster change-ebs-volume-type -C ${CLUSTER_ID} --type gp3 --reason "${REASON}"
 
   # Change only control plane volumes to gp3
-  osdctl cluster change-ebs-volume-type -C ${CLUSTER_ID} --type gp3 --role control-plane --reason "SREP-3811"
+  osdctl cluster change-ebs-volume-type -C ${CLUSTER_ID} --type gp3 --role control-plane --reason "${REASON}"
 
   # Change only infra volumes to gp3
-  osdctl cluster change-ebs-volume-type -C ${CLUSTER_ID} --type gp3 --role infra --reason "SREP-3811"
+  osdctl cluster change-ebs-volume-type -C ${CLUSTER_ID} --type gp3 --role infra --reason "${REASON}"
 ```
 
 ### Options

--- a/docs/osdctl_cluster_check-banned-user.md
+++ b/docs/osdctl_cluster_check-banned-user.md
@@ -6,6 +6,13 @@ Checks if the cluster owner is a banned user.
 osdctl cluster check-banned-user --cluster-id <cluster-identifier> [flags]
 ```
 
+### Examples
+
+```
+  # Check if the cluster owner is banned
+  osdctl cluster check-banned-user --cluster-id ${CLUSTER_ID}
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cluster_context.md
+++ b/docs/osdctl_cluster_context.md
@@ -6,6 +6,16 @@ Shows the context of a specified cluster
 osdctl cluster context --cluster-id <cluster-identifier> [flags]
 ```
 
+### Examples
+
+```
+  # Show cluster context
+  osdctl cluster context --cluster-id ${CLUSTER_ID}
+
+  # Show cluster context with full checks
+  osdctl cluster context --cluster-id ${CLUSTER_ID} --full
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cluster_detach-stuck-volume.md
+++ b/docs/osdctl_cluster_detach-stuck-volume.md
@@ -6,6 +6,13 @@ Detach openshift-monitoring namespace's volume from a cluster forcefully
 osdctl cluster detach-stuck-volume --cluster-id <cluster-identifier> [flags]
 ```
 
+### Examples
+
+```
+  # Detach stuck volumes in the openshift-monitoring namespace
+  osdctl cluster detach-stuck-volume --cluster-id ${CLUSTER_ID} --reason "${REASON}"
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cluster_etcd-health-check.md
+++ b/docs/osdctl_cluster_etcd-health-check.md
@@ -10,6 +10,13 @@ Checks etcd component health status for member replacement
 osdctl cluster etcd-health-check --cluster-id <cluster-id> --reason <reason for escalation> [flags]
 ```
 
+### Examples
+
+```
+  # Check etcd health for a cluster
+  osdctl cluster etcd-health-check --cluster-id ${CLUSTER_ID} --reason "${REASON}"
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cluster_etcd-member-replace.md
+++ b/docs/osdctl_cluster_etcd-member-replace.md
@@ -10,6 +10,13 @@ Replaces an unhealthy ectd node using the member id provided
 osdctl cluster etcd-member-replace --cluster-id <cluster-identifier> [flags]
 ```
 
+### Examples
+
+```
+  # Replace an unhealthy etcd member
+  osdctl cluster etcd-member-replace --cluster-id ${CLUSTER_ID} --node ${NODE_NAME} --reason "${REASON}"
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cluster_etcd-member-replace.md
+++ b/docs/osdctl_cluster_etcd-member-replace.md
@@ -4,7 +4,7 @@ Replaces an unhealthy etcd node
 
 ### Synopsis
 
-Replaces an unhealthy ectd node using the member id provided
+Replaces an unhealthy etcd node using the member id provided
 
 ```
 osdctl cluster etcd-member-replace --cluster-id <cluster-identifier> [flags]

--- a/docs/osdctl_cluster_get-env-vars.md
+++ b/docs/osdctl_cluster_get-env-vars.md
@@ -6,6 +6,16 @@ Print a cluster's ID/management namespaces, optionally as env variables
 osdctl cluster get-env-vars --cluster-id <cluster-identifier> [flags]
 ```
 
+### Examples
+
+```
+  # Print cluster environment variables
+  osdctl cluster get-env-vars --cluster-id ${CLUSTER_ID}
+
+  # Print as exportable env variables
+  osdctl cluster get-env-vars --cluster-id ${CLUSTER_ID} --output env
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cluster_health.md
+++ b/docs/osdctl_cluster_health.md
@@ -6,6 +6,13 @@ Describes health of cluster nodes and provides other cluster vitals.
 osdctl cluster health [flags]
 ```
 
+### Examples
+
+```
+  # Check cluster health
+  osdctl cluster health --cluster-id ${CLUSTER_ID}
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cluster_hypershift-info.md
+++ b/docs/osdctl_cluster_hypershift-info.md
@@ -11,6 +11,16 @@ It attempts to render the relationships as graphviz if that output format is cho
 osdctl cluster hypershift-info [flags]
 ```
 
+### Examples
+
+```
+  # Show hypershift cluster info as graphviz
+  osdctl cluster hypershift-info --cluster-id ${CLUSTER_ID}
+
+  # Show hypershift cluster info as table
+  osdctl cluster hypershift-info --cluster-id ${CLUSTER_ID} --output table
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cluster_logging-check.md
+++ b/docs/osdctl_cluster_logging-check.md
@@ -6,6 +6,13 @@ Shows the logging support status of a specified cluster
 osdctl cluster logging-check --cluster-id <cluster-identifier> [flags]
 ```
 
+### Examples
+
+```
+  # Check logging support status for a cluster
+  osdctl cluster logging-check --cluster-id ${CLUSTER_ID}
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cluster_reports_create.md
+++ b/docs/osdctl_cluster_reports_create.md
@@ -11,25 +11,18 @@ includes a summary (title) and data content. You can provide the data either
 directly as a string using --data, or from a file using --file. The data
 will be automatically base64-encoded before storage.
 
-Examples:
-  # Create a report with inline data
-  osdctl cluster reports create --cluster-id 1a2b3c4d \
-    --summary "Network diagnostic results" \
-    --data "All network checks passed successfully"
-
-  # Create a report from a file
-  osdctl cluster reports create -C my-cluster \
-    --summary "Pod logs from incident" \
-    --file /tmp/pod-logs.txt
-
-  # Create a report and output as JSON
-  osdctl cluster reports create --cluster-id 1a2b3c4d \
-    --summary "Cluster health check" \
-    --data "CPU: 45%, Memory: 67%, Disk: 23%" \
-    --output json
-
 ```
 osdctl cluster reports create [flags]
+```
+
+### Examples
+
+```
+  # Create a report with inline data
+  osdctl cluster reports create --cluster-id ${CLUSTER_ID} --summary "Network diagnostic results" --data "All network checks passed"
+
+  # Create a report from a file
+  osdctl cluster reports create --cluster-id ${CLUSTER_ID} --summary "Pod logs from incident" --file /tmp/pod-logs.txt
 ```
 
 ### Options

--- a/docs/osdctl_cluster_reports_get.md
+++ b/docs/osdctl_cluster_reports_get.md
@@ -9,18 +9,18 @@ Retrieve and display a specific report by its ID.
 This command fetches a report by its report ID and displays the decoded
 report data. Use 'list' to find available report IDs.
 
-Examples:
-  # Get a specific report and display its contents
-  osdctl cluster reports get --cluster-id 1a2b3c4d --report-id abc-123-def
-
-  # Get a report with JSON output (includes encoded data)
-  osdctl cluster reports get -C my-cluster -r report-456 --output json
-
-  # Get a report and pipe the output to a file
-  osdctl cluster reports get -C 1a2b3c4d -r abc-123 > report-output.txt
-
 ```
 osdctl cluster reports get [flags]
+```
+
+### Examples
+
+```
+  # Get a specific report
+  osdctl cluster reports get --cluster-id ${CLUSTER_ID} --report-id ${REPORT_ID}
+
+  # Get a report with JSON output
+  osdctl cluster reports get --cluster-id ${CLUSTER_ID} --report-id ${REPORT_ID} --output json
 ```
 
 ### Options

--- a/docs/osdctl_cluster_reports_list.md
+++ b/docs/osdctl_cluster_reports_list.md
@@ -10,18 +10,18 @@ This command retrieves and displays all reports associated with a cluster,
 showing the report ID, summary, and creation timestamp. You can optionally
 limit the number of reports returned to the most recent N reports.
 
-Examples:
-  # List all reports for a cluster (defaults to 10 most recent)
-  osdctl cluster reports list --cluster-id 1a2b3c4d
-
-  # List the 5 most recent reports
-  osdctl cluster reports list --cluster-id 1a2b3c4d --last 5
-
-  # List reports with JSON output
-  osdctl cluster reports list --cluster-id my-cluster --output json
-
 ```
 osdctl cluster reports list [flags]
+```
+
+### Examples
+
+```
+  # List reports for a cluster
+  osdctl cluster reports list --cluster-id ${CLUSTER_ID}
+
+  # List the 5 most recent reports
+  osdctl cluster reports list --cluster-id ${CLUSTER_ID} --last 5
 ```
 
 ### Options

--- a/docs/osdctl_cluster_resize_control-plane.md
+++ b/docs/osdctl_cluster_resize_control-plane.md
@@ -17,9 +17,8 @@ osdctl cluster resize control-plane [flags]
 ### Examples
 
 ```
-
   # Resize all control plane instances to m5.4xlarge using control plane machine sets
-  osdctl cluster resize control-plane -c "${CLUSTER_ID}" --machine-type m5.4xlarge --reason "${OHSS}"
+  osdctl cluster resize control-plane --cluster-id "${CLUSTER_ID}" --machine-type m5.4xlarge --reason "${REASON}"
 ```
 
 ### Options

--- a/docs/osdctl_cluster_resize_infra.md
+++ b/docs/osdctl_cluster_resize_infra.md
@@ -21,13 +21,11 @@ osdctl cluster resize infra [flags]
 ### Examples
 
 ```
-
   # Automatically vertically scale infra nodes to the next size
-  osdctl cluster resize infra --cluster-id ${CLUSTER_ID}
+  osdctl cluster resize infra --cluster-id ${CLUSTER_ID} --reason "${REASON}" --justification "${JUSTIFICATION}" --ohss "${REASON}"
 
   # Resize infra nodes to a specific instance type
-  osdctl cluster resize infra --cluster-id ${CLUSTER_ID} --instance-type "r5.xlarge"
-
+  osdctl cluster resize infra --cluster-id ${CLUSTER_ID} --instance-type "r5.xlarge" --reason "${REASON}" --justification "${JUSTIFICATION}" --ohss "${REASON}"
 ```
 
 ### Options

--- a/docs/osdctl_cluster_resize_infra.md
+++ b/docs/osdctl_cluster_resize_infra.md
@@ -22,10 +22,10 @@ osdctl cluster resize infra [flags]
 
 ```
   # Automatically vertically scale infra nodes to the next size
-  osdctl cluster resize infra --cluster-id ${CLUSTER_ID} --reason "${REASON}" --justification "${JUSTIFICATION}" --ohss "${REASON}"
+  osdctl cluster resize infra --cluster-id ${CLUSTER_ID} --reason "${REASON}" --justification "${JUSTIFICATION}" --ohss "${OHSS}"
 
   # Resize infra nodes to a specific instance type
-  osdctl cluster resize infra --cluster-id ${CLUSTER_ID} --instance-type "r5.xlarge" --reason "${REASON}" --justification "${JUSTIFICATION}" --ohss "${REASON}"
+  osdctl cluster resize infra --cluster-id ${CLUSTER_ID} --instance-type "r5.xlarge" --reason "${REASON}" --justification "${JUSTIFICATION}" --ohss "${OHSS}"
 ```
 
 ### Options

--- a/docs/osdctl_cluster_resize_request-serving-nodes.md
+++ b/docs/osdctl_cluster_resize_request-serving-nodes.md
@@ -15,13 +15,13 @@ osdctl cluster resize request-serving-nodes [flags]
 ```
 
   # Resize a ROSA HCP cluster's request-serving nodes to the next size
-  osdctl cluster resize request-serving-nodes --cluster-id "${CLUSTER_ID}" --reason "${OHSS}"
+  osdctl cluster resize request-serving-nodes --cluster-id "${CLUSTER_ID}" --reason "${REASON}"
 
   # Resize a ROSA HCP cluster's request-serving nodes to a specific size
-  osdctl cluster resize request-serving-nodes --cluster-id "${CLUSTER_ID}" --size m54xl --reason "${OHSS}"
+  osdctl cluster resize request-serving-nodes --cluster-id "${CLUSTER_ID}" --size m54xl --reason "${REASON}"
 
   # Remove the cluster-size-override annotation to revert to default sizing behavior
-  osdctl cluster resize request-serving-nodes --cluster-id "${CLUSTER_ID}" --remove-override --reason "${OHSS}"
+  osdctl cluster resize request-serving-nodes --cluster-id "${CLUSTER_ID}" --remove-override --reason "${REASON}"
 
 ```
 

--- a/docs/osdctl_cluster_snapshot.md
+++ b/docs/osdctl_cluster_snapshot.md
@@ -23,13 +23,13 @@ osdctl cluster snapshot [flags]
 
 ```
   # Capture cluster snapshot to a file
-  osdctl cluster snapshot -C <cluster-id> -o before.yaml
+  osdctl cluster snapshot -C ${CLUSTER_ID} -o before.yaml
 
   # Capture snapshot with specific namespaces
-  osdctl cluster snapshot -C <cluster-id> -o snapshot.yaml --namespaces openshift-monitoring,openshift-operators
+  osdctl cluster snapshot -C ${CLUSTER_ID} -o snapshot.yaml --namespaces openshift-monitoring,openshift-operators
 
   # Capture additional resource types
-  osdctl cluster snapshot -C <cluster-id> -o snapshot.yaml --resources pods,deployments,services
+  osdctl cluster snapshot -C ${CLUSTER_ID} -o snapshot.yaml --resources pods,deployments,services
 ```
 
 ### Options

--- a/docs/osdctl_cluster_ssh_key.md
+++ b/docs/osdctl_cluster_ssh_key.md
@@ -13,32 +13,14 @@ osdctl cluster ssh key --reason $reason [--cluster-id $CLUSTER_ID] [flags]
 ### Examples
 
 ```
-$ osdctl cluster ssh key --cluster-id $CLUSTER_ID --reason "OHSS-XXXX"
-INFO[0005] Backplane URL retrieved via OCM environment: https://api.backplane.openshift.com
------BEGIN RSA PRIVATE KEY-----
-...
------END RSA PRIVATE KEY-----
+  # Retrieve SSH key for a specific cluster
+  osdctl cluster ssh key --cluster-id ${CLUSTER_ID} --reason "${REASON}"
 
-Providing a --cluster-id allows you to specify the cluster who's private ssh key you want to view, regardless if you're logged in or not.
+  # Retrieve SSH key for the currently logged-in cluster
+  osdctl cluster ssh key --reason "${REASON}"
 
-
-$ osdctl cluster ssh key --reason "OHSS-XXXX"
-INFO[0005] Backplane URL retrieved via OCM environment: https://api.backplane.openshift.com
------BEGIN RSA PRIVATE KEY-----
-...
------END RSA PRIVATE KEY-----
-
-Omitting --cluster-id will print the ssh key for the cluster you're currently logged into.
-
-
-$ osdctl cluster ssh key -y --reason "OHSS-XXXX" > /tmp/ssh.key
-INFO[0005] Backplane URL retrieved via OCM environment: https://api.backplane.openshift.com
-$ cat /tmp/ssh.key
------BEGIN RSA PRIVATE KEY-----
-...
------END RSA PRIVATE KEY-----
-
-Despite the logs from backplane, the ssh key is the only output channelled through stdout. This means you can safely redirect the output to a file for greater convienence.
+  # Save SSH key to a file
+  osdctl cluster ssh key -y --reason "${REASON}" > /tmp/ssh.key
 ```
 
 ### Options

--- a/docs/osdctl_cluster_support_delete.md
+++ b/docs/osdctl_cluster_support_delete.md
@@ -6,6 +6,16 @@ Delete specified limited support reason for a given cluster
 osdctl cluster support delete --cluster-id <cluster-identifier> [flags]
 ```
 
+### Examples
+
+```
+  # Remove a specific limited support reason
+  osdctl cluster support delete --cluster-id ${CLUSTER_ID} --limited-support-reason-id ${REASON_ID}
+
+  # Remove all limited support reasons
+  osdctl cluster support delete --cluster-id ${CLUSTER_ID} --all
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cluster_support_post.md
+++ b/docs/osdctl_cluster_support_post.md
@@ -14,14 +14,11 @@ osdctl cluster support post --cluster-id <cluster-identifier> [flags]
 ### Examples
 
 ```
-# Post a limited support reason for a cluster misconfiguration
-osdctl cluster support post --cluster-id=1a2B3c4DefghIjkLMNOpQrSTUV5 --misconfiguration=cluster --problem="The cluster has a second failing ingress controller, which is not supported and can cause issues with SLA." \
---resolution="Remove the additional ingress controller 'my-custom-ingresscontroller'. 'oc get ingresscontroller -n openshift-ingress-operator' should yield only 'default'" \
---evidence="See OHSS-1234"
-
-Will result in the following limited-support text sent to the customer:
-The cluster has a second failing ingress controller, which is not supported and can cause issues with SLA. Remove the additional ingress controller 'my-custom-ingresscontroller'. 'oc get ingresscontroller -n openshift-ingress-operator' should yield only 'default'.
-
+  # Post a limited support reason for a cluster misconfiguration
+  osdctl cluster support post --cluster-id ${CLUSTER_ID} --misconfiguration=cluster \
+    --problem="The cluster has a second failing ingress controller" \
+    --resolution="Remove the additional ingress controller" \
+    --evidence="See ${REASON}"
 ```
 
 ### Options

--- a/docs/osdctl_cluster_support_status.md
+++ b/docs/osdctl_cluster_support_status.md
@@ -6,6 +6,13 @@ Shows the support status of a specified cluster
 osdctl cluster support status --cluster-id <cluster-identifier> [flags]
 ```
 
+### Examples
+
+```
+  # Check cluster support status
+  osdctl cluster support status --cluster-id ${CLUSTER_ID}
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cluster_transfer-owner.md
+++ b/docs/osdctl_cluster_transfer-owner.md
@@ -6,6 +6,16 @@ Transfer cluster ownership to a new user (to be done by Region Lead)
 osdctl cluster transfer-owner [flags]
 ```
 
+### Examples
+
+```
+  # Transfer cluster ownership
+  osdctl cluster transfer-owner --cluster-id ${CLUSTER_ID} --old-owner ${OLD_OWNER} --new-owner ${NEW_OWNER} --reason "${REASON}"
+
+  # Dry-run to preview the transfer without applying changes
+  osdctl cluster transfer-owner --cluster-id ${CLUSTER_ID} --old-owner ${OLD_OWNER} --new-owner ${NEW_OWNER} --reason "${REASON}" --dry-run
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cluster_validate-pull-secret-ext.md
+++ b/docs/osdctl_cluster_validate-pull-secret-ext.md
@@ -24,13 +24,13 @@ osdctl cluster validate-pull-secret-ext --cluster-id $CLUSTER_ID [flags]
 ```
 
 	# Compare OCM Access-Token, OCM Registry-Credentials, and OCM Account Email against cluster's pull secret
-	osdctl cluster validate-pull-secret-ext --cluster-id ${CLUSTER_ID} --reason "OSD-XYZ"
+	osdctl cluster validate-pull-secret-ext --cluster-id ${CLUSTER_ID} --reason "${REASON}"
 
 	# Exclude Access-Token, and Registry-Credential checks...
-	osdctl cluster validate-pull-secret-ext --cluster-id ${CLUSTER_ID} --reason "OSD-XYZ" --skip-access-token --skip-registry-creds
+	osdctl cluster validate-pull-secret-ext --cluster-id ${CLUSTER_ID} --reason "${REASON}" --skip-access-token --skip-registry-creds
 
 	# Skip sending service logs (useful for testing)
-	osdctl cluster validate-pull-secret-ext --cluster-id ${CLUSTER_ID} --reason "OSD-XYZ" --skip-service-logs
+	osdctl cluster validate-pull-secret-ext --cluster-id ${CLUSTER_ID} --reason "${REASON}" --skip-service-logs
 
 ```
 

--- a/docs/osdctl_cluster_verify-dns.md
+++ b/docs/osdctl_cluster_verify-dns.md
@@ -27,6 +27,16 @@ Output Formats:
 osdctl cluster verify-dns --cluster-id <cluster-id> [flags]
 ```
 
+### Examples
+
+```
+  # Verify DNS for an HCP cluster
+  osdctl cluster verify-dns --cluster-id ${CLUSTER_ID}
+
+  # Verify DNS with JSON output
+  osdctl cluster verify-dns --cluster-id ${CLUSTER_ID} --output json
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cost_create.md
+++ b/docs/osdctl_cost_create.md
@@ -6,6 +6,13 @@ Create a cost category for the given OU
 osdctl cost create [flags]
 ```
 
+### Examples
+
+```
+  # Create a cost category for an organizational unit
+  osdctl cost create --ou ${OU_ID}
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cost_list.md
+++ b/docs/osdctl_cost_list.md
@@ -6,6 +6,16 @@ List the cost of each Account/OU under given OU
 osdctl cost list [flags]
 ```
 
+### Examples
+
+```
+  # List costs for an OU for the current month
+  osdctl cost list --ou ${OU_ID} --time MTD
+
+  # List costs for a date range
+  osdctl cost list --ou ${OU_ID} --start 2024-01-01 --end 2024-01-31
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_cost_reconcile.md
+++ b/docs/osdctl_cost_reconcile.md
@@ -6,6 +6,13 @@ Checks if there's a cost category for every OU. If an OU is missing a cost categ
 osdctl cost reconcile [flags]
 ```
 
+### Examples
+
+```
+  # Reconcile cost categories for an OU
+  osdctl cost reconcile --ou ${OU_ID}
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_evidence_collect.md
+++ b/docs/osdctl_evidence_collect.md
@@ -23,16 +23,16 @@ osdctl evidence collect [flags]
 
 ```
   # Collect all evidence to a directory
-  osdctl evidence collect -C <cluster-id> --output ./evidence/
+  osdctl evidence collect -C ${CLUSTER_ID} --output ./evidence/
 
   # Collect evidence from the last 2 hours
-  osdctl evidence collect -C <cluster-id> --output ./evidence/ --since 2h
+  osdctl evidence collect -C ${CLUSTER_ID} --output ./evidence/ --since 2h
 
   # Collect evidence without CloudTrail (for non-AWS or limited access)
-  osdctl evidence collect -C <cluster-id> --output ./evidence/ --skip-cloudtrail
+  osdctl evidence collect -C ${CLUSTER_ID} --output ./evidence/ --skip-cloudtrail
 
   # Include Kubernetes events in collection
-  osdctl evidence collect -C <cluster-id> --output ./evidence/ --include-events
+  osdctl evidence collect -C ${CLUSTER_ID} --output ./evidence/ --include-events
 ```
 
 ### Options

--- a/docs/osdctl_hcp_backup.md
+++ b/docs/osdctl_hcp_backup.md
@@ -31,9 +31,9 @@ osdctl hcp backup --cluster-id <cluster-id> --reason <reason> [flags]
 ### Examples
 
 ```
-  osdctl hcp backup --cluster-id 1abc2def3ghi --reason OHSS-12345
-  osdctl hcp backup --cluster-id 1abc2def3ghi --reason OHSS-12345 --label env=prod --label incident=OHSS-12345
-  osdctl hcp backup --cluster-id 1abc2def3ghi --reason OHSS-12345 --annotation owner=sre-team
+  osdctl hcp backup --cluster-id ${CLUSTER_ID} --reason ${REASON}
+  osdctl hcp backup --cluster-id ${CLUSTER_ID} --reason ${REASON} --label env=prod --label incident=${REASON}
+  osdctl hcp backup --cluster-id ${CLUSTER_ID} --reason ${REASON} --annotation owner=sre-team
 ```
 
 ### Options

--- a/docs/osdctl_hcp_get-cp-autoscaling-status.md
+++ b/docs/osdctl_hcp_get-cp-autoscaling-status.md
@@ -18,19 +18,19 @@ osdctl hcp get-cp-autoscaling-status [flags]
 ```
 
   # Get autoscaling status for all hosted clusters on a management cluster
-  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id <cluster-id>
+  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id ${MGMT_CLUSTER_ID}
 
   # Get status with CSV output
-  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id <cluster-id> --output csv > status.csv
+  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id ${MGMT_CLUSTER_ID} --output csv > status.csv
 
   # Show only clusters ready for migration
-  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id <cluster-id> --show-only ready-for-migration
+  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id ${MGMT_CLUSTER_ID} --show-only ready-for-migration
 
   # Show only clusters that need annotation removal
-  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id <cluster-id> --show-only needs-removal
+  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id ${MGMT_CLUSTER_ID} --show-only needs-removal
 
   # Show only clusters safe to remove override
-  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id <cluster-id> --show-only safe-to-remove-override
+  osdctl hcp get-cp-autoscaling-status --mgmt-cluster-id ${MGMT_CLUSTER_ID} --show-only safe-to-remove-override
 ```
 
 ### Options

--- a/docs/osdctl_hcp_must-gather.md
+++ b/docs/osdctl_hcp_must-gather.md
@@ -13,7 +13,7 @@ osdctl hcp must-gather --cluster-id <cluster-identifier> [flags]
 ### Examples
 
 ```
-osdctl hcp must-gather --cluster-id CLUSTER_ID --gather sc,mc,sc_acm --reason OHSS-1234
+  osdctl hcp must-gather --cluster-id ${CLUSTER_ID} --gather sc,mc,sc_acm --reason ${REASON}
 ```
 
 ### Options

--- a/docs/osdctl_hcp_status.md
+++ b/docs/osdctl_hcp_status.md
@@ -15,11 +15,8 @@ osdctl hcp status [flags]
 ### Examples
 
 ```
-  # Show status by cluster name
-  osdctl hcp status --cluster-id my-cluster
-
-  # Show status by cluster ID
-  osdctl hcp status --cluster-id 2o9r9r1q4tp0bulsfksdc8fesls54sql
+  # Show HCP cluster status
+  osdctl hcp status --cluster-id ${CLUSTER_ID}
 ```
 
 ### Options

--- a/docs/osdctl_iampermissions_diff.md
+++ b/docs/osdctl_iampermissions_diff.md
@@ -6,6 +6,13 @@ Diff IAM permissions for cluster operators between two versions
 osdctl iampermissions diff [flags]
 ```
 
+### Examples
+
+```
+  # Diff IAM permissions between two OCP versions
+  osdctl iampermissions diff --base-version 4.14.0 --target-version 4.15.0
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_iampermissions_get.md
+++ b/docs/osdctl_iampermissions_get.md
@@ -6,6 +6,13 @@ Get OCP CredentialsRequests
 osdctl iampermissions get [flags]
 ```
 
+### Examples
+
+```
+  # Get IAM permissions for a specific OCP version
+  osdctl iampermissions get --release-version 4.15.0
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_iampermissions_save.md
+++ b/docs/osdctl_iampermissions_save.md
@@ -6,6 +6,13 @@ Save iam permissions for use in mcc
 osdctl iampermissions save [flags]
 ```
 
+### Examples
+
+```
+  # Save IAM permissions to a directory
+  osdctl iampermissions save --dir /tmp/policies --release-version 4.15.0
+```
+
 ### Options
 
 ```

--- a/docs/osdctl_servicelog_list.md
+++ b/docs/osdctl_servicelog_list.md
@@ -6,18 +6,21 @@ Get service logs for a given cluster identifier.
 
 Get service logs for a given cluster identifier.
 
-# To return just service logs created by SREs
-osdctl servicelog list --cluster-id=my-cluster-id
-
-# To return all service logs, including those by automated systems
-osdctl servicelog list --cluster-id=my-cluster-id --all-messages
-
-# To return all service logs, as well as internal service logs
-osdctl servicelog list --cluster-id=my-cluster-id --all-messages --internal
-
-
 ```
 osdctl servicelog list --cluster-id <cluster-identifier> [flags] [options]
+```
+
+### Examples
+
+```
+  # List SRE-created service logs
+  osdctl servicelog list --cluster-id ${CLUSTER_ID}
+
+  # List all service logs including automated
+  osdctl servicelog list --cluster-id ${CLUSTER_ID} --all-messages
+
+  # List all service logs including internal
+  osdctl servicelog list --cluster-id ${CLUSTER_ID} --all-messages --internal
 ```
 
 ### Options

--- a/main.go
+++ b/main.go
@@ -24,7 +24,9 @@ func main() {
 
 	resolved, err := command.ExecuteC()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Run '%s --help' for usage.\n", resolved.CommandPath())
+		if resolved != nil {
+			fmt.Fprintf(os.Stderr, "Run '%s --help' for usage.\n", resolved.CommandPath())
+		}
 		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -24,7 +24,10 @@ func main() {
 
 	resolved, err := command.ExecuteC()
 	if err != nil {
-		if resolved != nil {
+		if resolved != nil && resolved.SilenceErrors {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		}
+		if resolved != nil && resolved.SilenceUsage {
 			fmt.Fprintf(os.Stderr, "Run '%s --help' for usage.\n", resolved.CommandPath())
 		}
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -22,11 +22,9 @@ func main() {
 	cobra.EnableTraverseRunHooks = true
 	command := cmd.NewCmdRoot(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 
-	if err := command.Execute(); err != nil {
-		_, err := fmt.Fprintf(os.Stderr, "%v\n", err)
-		if err != nil {
-			fmt.Println("Error while printing to stderr: ", err.Error())
-		}
+	resolved, err := command.ExecuteC()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Run '%s --help' for usage.\n", resolved.CommandPath())
 		os.Exit(1)
 	}
 }

--- a/pkg/utils/ocm_test.go
+++ b/pkg/utils/ocm_test.go
@@ -88,7 +88,7 @@ func TestGetOcmConfigFromFilePath(t *testing.T) {
 					ClientID:     "test-client-id",
 					ClientSecret: "test-client-secret",
 				}
-				data, err := json.Marshal(config)
+				data, err := json.Marshal(config) //nolint:gosec // G117 false positive — test fixture with fake credentials
 				if err != nil {
 					t.Fatalf("failed to marshal config: %v", err)
 				}
@@ -255,7 +255,7 @@ func TestGetOCMSdkConnBuilderFromFilePath(t *testing.T) {
 					ClientID:     "test-client-id",
 					ClientSecret: "test-client-secret",
 				}
-				data, err := json.Marshal(config)
+				data, err := json.Marshal(config) //nolint:gosec // G117 false positive — test fixture with fake credentials
 				if err != nil {
 					t.Fatalf("failed to marshal config: %v", err)
 				}
@@ -445,7 +445,7 @@ func TestGetOCMConfigFromEnv(t *testing.T) {
 					RefreshToken: "test-refresh",
 					URL:          "https://api.openshift.com",
 				}
-				data, err := json.Marshal(config)
+				data, err := json.Marshal(config) //nolint:gosec // G117 false positive — test fixture with fake credentials
 				if err != nil {
 					t.Fatalf("failed to marshal config: %v", err)
 				}


### PR DESCRIPTION
## Summary

- **Suppress usage dump on errors**: Added `SilenceUsage` in `PersistentPreRun` so missing-flag and `RunE` errors show only the error + a help hint, not a wall of usage text. Unknown commands/flags still show usage.
- **Fix double error printing**: Changed `main.go` to use `ExecuteC()` and replaced the redundant error print with `Run '<command> --help' for usage.`
- **Add Example fields**: Added or fixed `Example` fields on 37 commands that had required flags (e.g. `--reason`, `--cluster-id`) but no examples, or had examples that omitted required flags.
- **Standardize placeholders**: Replaced hard-coded ticket numbers (`OHSS-1234`, `SREP-3811`, `OSD-XYZ`) and angle-bracket placeholders (`<cluster-id>`) with `${VARIABLE}` style across all examples.
- **Regression test**: New `TestRequiredFlagsDocumentedInExamples` walks the entire command tree and validates every `MarkFlagRequired` flag appears in its command's `Example` field.

### Before / After

```
# Before — error buried in usage dump, printed twice:
Error: required flag(s) "justification", "ohss", "reason" not set
Usage: osdctl cluster resize infra [flags]
... 30 lines of flags and help ...
required flag(s) "justification", "ohss", "reason" not set

# After — clean error with help hint:
Error: required flag(s) "justification", "ohss", "reason" not set
Run 'osdctl cluster resize infra --help' for usage.
```

## Secondary Lint Fixes

Pre-existing lint issues fixed to get `make lint` passing clean:

- `cmd/evidence/collect.go`: replaced `WriteString(fmt.Sprintf(...))` with `fmt.Fprintf(...)` (staticcheck QF1012, 15 instances)
- `cmd/account/cli.go`: suppressed gosec G117 false positive on intentional credential output
- `cmd/promote/rhobs/rhobs.go`: suppressed gosec G703 false positive on hardcoded path candidates (2 instances)
- `pkg/utils/ocm_test.go`: suppressed gosec G117 false positive on test fixtures with fake credentials (3 instances)

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./cmd/...` — all existing tests pass
- [x] `make lint` — 0 issues
- [x] `make verify-docs` — docs regenerated and up to date
- [x] New `TestRequiredFlagsDocumentedInExamples` passes
- [ ] Manual: run a command without a required flag — confirm clean error output
- [ ] Manual: run a command with `--help` — confirm full help text still appears
- [ ] Manual: run a command with an unknown flag — confirm usage still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI help and many docs with consistent placeholders, corrected wording/typos, and expanded Examples for numerous commands.

* **Tests**
  * Added a test to ensure required flags are documented in command examples.

* **Improvements**
  * Improved command error/help output behavior and refined evidence-collection summary formatting for clearer CLI feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->