### PR TITLE
ROSAENG-14108 & ROSAENG-14110: new '--url' and '--browser' options for the 'osdctl rhobs metrics' and the 'osdctl rhobs logs' commands

### DIFF
--- a/cmd/rhobs/logsCmd.go
+++ b/cmd/rhobs/logsCmd.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -15,6 +16,8 @@ import (
 var allowedLogLevels = []string{"default", "trace", "info", "warn", "error"}
 
 func newCmdLogs() *cobra.Command {
+	var isComputingGrafanaUrl bool
+	var isOpeningGrafanaUrl bool
 	var lokiExpr string
 	var namespace string
 	var labelSelectorStr string
@@ -45,9 +48,13 @@ func newCmdLogs() *cobra.Command {
 			"By default, logs from all the pods in the given namespace are returned but it is possible to specify " +
 			"a single pod as an argument or filter pods using their labels. Logs themselves can be also filtered " +
 			"to only keep the ones containing a given regexp (--contain-regex option) or a given log level (--level option).",
-		Args:          cobra.RangeArgs(0, 1),
+		Args:          cobra.MaximumNArgs(1),
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if isOpeningGrafanaUrl && !isComputingGrafanaUrl {
+				return fmt.Errorf("--browser can only be set if --url is set")
+			}
+
 			if cmd.Flags().Changed("query") {
 				if len(args) > 0 {
 					return errors.New("pod argument cannot be used with --query flag")
@@ -159,12 +166,18 @@ func newCmdLogs() *cobra.Command {
 			defaultStartTime := nowTime.Add(-5 * time.Minute)
 
 			if cmd.Flags().Changed("since") {
+				if duration <= 0 {
+					return fmt.Errorf("--since must be greater than 0")
+				}
 				startTime = nowTime.Add(-duration)
 			} else if !cmd.Flags().Changed("start-time") && !cmd.Flags().Changed("since-time") {
 				startTime = defaultStartTime
 			}
 			if !cmd.Flags().Changed("end-time") {
 				endTime = nowTime
+			}
+			if startTime.After(endTime) {
+				return fmt.Errorf("value passed to --start-time must be before the value passed to --end-time")
 			}
 
 			isGoingForward := false
@@ -211,17 +224,35 @@ func newCmdLogs() *cobra.Command {
 				lokiExpr += fmt.Sprintf(` | openshift_cluster_id = "%s"`, rhobsFetcher.clusterExternalId)
 			}
 
-			if isFollowing {
-				err = rhobsFetcher.StreamLogs(lokiExpr, outputFormat, isPrintingTimestamp, printedFields)
+			if isComputingGrafanaUrl {
+				grafanaUrl, err := rhobsFetcher.GetGrafanaLogsUrl(lokiExpr, startTime, endTime, isGoingForward)
+				if err != nil {
+					return fmt.Errorf("failed to compute Grafana URL: %v", err)
+				}
+				if isOpeningGrafanaUrl {
+					err = browser.OpenURL(grafanaUrl)
+					if err != nil {
+						return fmt.Errorf("failed to open Grafana URL in browser: %v", err)
+					}
+				} else {
+					fmt.Println(grafanaUrl)
+				}
 			} else {
-				err = rhobsFetcher.PrintLogs(lokiExpr, startTime, endTime, logsCount, isGoingForward, outputFormat, isPrintingTimestamp, printedFields)
-			}
-			if err != nil {
-				return fmt.Errorf("failed to print logs: %v", err)
+				if isFollowing {
+					err = rhobsFetcher.StreamLogs(lokiExpr, outputFormat, isPrintingTimestamp, printedFields)
+				} else {
+					err = rhobsFetcher.PrintLogs(lokiExpr, startTime, endTime, logsCount, isGoingForward, outputFormat, isPrintingTimestamp, printedFields)
+				}
+				if err != nil {
+					return fmt.Errorf("failed to print logs: %v", err)
+				}
 			}
 			return nil
 		},
 	}
+
+	cmd.Flags().BoolVarP(&isComputingGrafanaUrl, "url", "u", false, "Only compute and print the grafana URL")
+	cmd.Flags().BoolVarP(&isOpeningGrafanaUrl, "browser", "b", false, "Open in the default browser the URL computed with the --url option - only applicable if --url is set")
 
 	cmd.Flags().StringVarP(&lokiExpr, "query", "q", "", "LogQL expression - exclusive with many other flags")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Name of the namespace")
@@ -257,21 +288,25 @@ func newCmdLogs() *cobra.Command {
 		`"backward" returns the most recent & interesting logs first, while "forward" matches the behavior of "kubectl logs" by returning the oldest logs first `+
 		`(default to "backward" unless --follow is set in which case it is forced to "forward")`)
 
-	cmd.Flags().BoolVarP(&isFollowing, "follow", "f", false, "Specify if the logs should be streamed - exclusive with --start-time, --end-time, --since, --direction, --limit and --no-limit flags")
+	cmd.Flags().BoolVarP(&isFollowing, "follow", "f", false, "Specify if the logs should be streamed - exclusive with --url, --start-time, --end-time, --since, --direction, --limit and --no-limit flags")
 	cmd.MarkFlagsMutuallyExclusive("follow", "start-time")
 	cmd.MarkFlagsMutuallyExclusive("follow", "since-time")
 	cmd.MarkFlagsMutuallyExclusive("follow", "end-time")
 	cmd.MarkFlagsMutuallyExclusive("follow", "since")
 	cmd.MarkFlagsMutuallyExclusive("follow", "direction")
 
-	cmd.Flags().IntVar(&logsCount, "limit", 0, "Maximum number of logs to return - allowed range: [1 100000] (default to 10000 unless --follow is set in which case there is no limit)")
-	cmd.Flags().BoolVar(&isNotLimitingLogsCount, "no-limit", false, "Do not limit the number of logs to return - exclusive with --limit flag")
-	cmd.MarkFlagsMutuallyExclusive("limit", "no-limit", "follow")
+	cmd.Flags().IntVar(&logsCount, "limit", 0, "Maximum number of logs to return - allowed range: [1 100000] - exclusive with --no-limit, --url & --follow flags (default to 10000, no limit if --follow is set)")
+	cmd.Flags().BoolVar(&isNotLimitingLogsCount, "no-limit", false, "Do not limit the number of logs to return - exclusive with --limit, --url & --follow flags")
+	cmd.MarkFlagsMutuallyExclusive("limit", "no-limit", "url", "follow")
 
-	cmd.Flags().StringVarP(&outputFormatStr, "output", "o", string(LogsFormatText), `Format of the output - allowed values: "text", "csv" or "json"`)
-	cmd.Flags().BoolVar(&isPrintingTimestamp, "ts", false, `Print metadata timestamps - to be used when log messages do not have a timestamp - not possible with the "json" output format`)
+	cmd.Flags().StringVarP(&outputFormatStr, "output", "o", string(LogsFormatText), `Format of the output - allowed values: "text", "csv" or "json" - exclusive with --url`)
+	cmd.MarkFlagsMutuallyExclusive("output", "url")
+	cmd.Flags().BoolVar(&isPrintingTimestamp, "ts", false, `Print metadata timestamps - to be used when log messages do not have a timestamp - not possible with the "json" output format - exclusive with --url`)
+	cmd.MarkFlagsMutuallyExclusive("ts", "url")
 	cmd.Flags().StringSliceVar(&printedFields, "field", []string{"k8s_pod_name"}, `Fields to print with the log message - not possible with the "json" output format - `+
-		`flag can be repeated / values can also be aggregated with one flag using the comma as separator - possible values: "k8s_namespace_name", "k8s_pod_name", "k8s_container_name" - use the "json" output format to know about all possible fields`)
+		`flag can be repeated / values can also be aggregated with one flag using the comma as separator - possible values: "k8s_namespace_name", "k8s_pod_name", "k8s_container_name" - `+
+		`use the "json" output format to know about all possible fields - exclusive with --url`)
+	cmd.MarkFlagsMutuallyExclusive("field", "url")
 
 	return cmd
 }

--- a/cmd/rhobs/metricsCmd.go
+++ b/cmd/rhobs/metricsCmd.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
 func newCmdMetrics() *cobra.Command {
+	var isComputingGrafanaUrl bool
+	var isOpeningGrafanaUrl bool
 	var evalTime time.Time
 	var startTime time.Time
 	var endTime time.Time
@@ -17,20 +20,26 @@ func newCmdMetrics() *cobra.Command {
 	var isPrintingClusterResultsOnly bool
 
 	cmd := &cobra.Command{
-		Use:   "metrics PromQL-expression",
+		Use:   "metrics [PromQL-expression]",
 		Short: "Fetch metrics from RHOBS for a given cluster",
 		Long: "Fetch metrics from RHOBS for a given cluster. " +
 			"The cluster can be a hosted cluster (HCP), a management cluster (MC) or whatever cluster sending metrics to RHOBS. " +
-			"The prometheus expression provided as an argument can be either an instant query or a range query. " +
+			"The prometheus expression provided as an argument can be either an instant query or a range query; it is optional if the --url option is set. " +
 			"By default, the command will try to evaluate the expression as an instant query at the current time, " +
-			"but it is possible to specify a different evaluation time using the --time option or a time range using the --start-time, --end-time and --since options." +
+			"but it is possible to specify a different evaluation time using the --time option or a time range using the --start-time, --end-time and --since options. " +
 			"Results can be filtered to only keep the ones matching the given cluster (--cluster-id option) with the --filter option " +
 			"even if it is more efficient to do that filtering at the prometheus expression level.",
-		Args:          cobra.ExactArgs(1),
+		Args:          cobra.MaximumNArgs(1),
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return fmt.Errorf("exactly one Prometheus expression must be provided as an argument")
+			if !isComputingGrafanaUrl {
+				if isOpeningGrafanaUrl {
+					return fmt.Errorf("--browser can only be set if --url is set")
+				}
+
+				if len(args) != 1 {
+					return fmt.Errorf("a Prometheus expression must be provided when --url is not set")
+				}
 			}
 
 			nowTime := time.Now()
@@ -45,8 +54,8 @@ func newCmdMetrics() *cobra.Command {
 				startTime = defaultStartTime
 			}
 			if cmd.Flags().Changed("end-time") {
-				if !cmd.Flags().Changed("start-time") {
-					return fmt.Errorf("--end-time can only be set if --start-time is set")
+				if !cmd.Flags().Changed("start-time") && !cmd.Flags().Changed("url") {
+					return fmt.Errorf("--end-time can only be set if --start-time or --url is set")
 				}
 			} else {
 				endTime = nowTime
@@ -55,8 +64,8 @@ func newCmdMetrics() *cobra.Command {
 				return fmt.Errorf("value passed to --start-time must be before the value passed to --end-time")
 			}
 			if cmd.Flags().Changed("step") {
-				if !cmd.Flags().Changed("start-time") && !cmd.Flags().Changed("since") {
-					return fmt.Errorf("--step can only be set if --start-time or --since is set")
+				if !cmd.Flags().Changed("start-time") && !cmd.Flags().Changed("since") && !cmd.Flags().Changed("url") {
+					return fmt.Errorf("--step can only be set if --start-time, --since or --url is set")
 				}
 				if stepDuration <= 0 {
 					return fmt.Errorf("--step must be greater than 0")
@@ -75,30 +84,55 @@ func newCmdMetrics() *cobra.Command {
 				return err
 			}
 
-			if cmd.Flags().Changed("since") || cmd.Flags().Changed("start-time") {
-				err = rhobsFetcher.PrintRangeMetrics(cmd.Context(), args[0], NewMetricsTimeRange(startTime, endTime, stepDuration), outputFormat, isPrintingClusterResultsOnly)
+			if isComputingGrafanaUrl {
+				promExpr := ""
+				if len(args) == 1 {
+					promExpr = args[0]
+				}
+				grafanaUrl, err := rhobsFetcher.GetGrafanaMetricsUrl(promExpr, startTime, endTime)
+				if err != nil {
+					return fmt.Errorf("failed to compute Grafana URL: %v", err)
+				}
+				if isOpeningGrafanaUrl {
+					err = browser.OpenURL(grafanaUrl)
+					if err != nil {
+						return fmt.Errorf("failed to open Grafana URL in browser: %v", err)
+					}
+				} else {
+					fmt.Println(grafanaUrl)
+				}
 			} else {
-				err = rhobsFetcher.PrintInstantMetrics(cmd.Context(), args[0], evalTime, outputFormat, isPrintingClusterResultsOnly)
-			}
-			if err != nil {
-				return fmt.Errorf("failed to print metrics: %v", err)
+				if cmd.Flags().Changed("since") || cmd.Flags().Changed("start-time") {
+					err = rhobsFetcher.PrintRangeMetrics(cmd.Context(), args[0], NewMetricsTimeRange(startTime, endTime, stepDuration), outputFormat, isPrintingClusterResultsOnly)
+				} else {
+					err = rhobsFetcher.PrintInstantMetrics(cmd.Context(), args[0], evalTime, outputFormat, isPrintingClusterResultsOnly)
+				}
+				if err != nil {
+					return fmt.Errorf("failed to print metrics: %v", err)
+				}
 			}
 
 			return nil
 		},
 	}
 
-	cmd.Flags().TimeVar(&evalTime, "time", time.Time{}, []string{time.RFC3339}, "Time at which the PromQL expression must be evaluated (default to now)")
+	cmd.Flags().BoolVarP(&isComputingGrafanaUrl, "url", "u", false, "Only compute and print the grafana URL")
+	cmd.Flags().BoolVarP(&isOpeningGrafanaUrl, "browser", "b", false, "Open in the default browser the URL computed with the --url option - only applicable if --url is set")
+
+	cmd.Flags().TimeVar(&evalTime, "time", time.Time{}, []string{time.RFC3339}, "Time at which the PromQL expression must be evaluated - exclusive with --url (default to now)")
+	cmd.MarkFlagsMutuallyExclusive("time", "url")
 	cmd.Flags().TimeVar(&startTime, "start-time", time.Time{}, []string{time.RFC3339}, "Start time at which the PromQL expression must be evaluated - enable time range mode - exclusive with --time (default to 30 minutes ago)")
-	cmd.Flags().TimeVar(&endTime, "end-time", time.Time{}, []string{time.RFC3339}, "End time at which the PromQL expression must be evaluated - can only be set if --start-time set (default to now)")
+	cmd.Flags().TimeVar(&endTime, "end-time", time.Time{}, []string{time.RFC3339}, "End time at which the PromQL expression must be evaluated - can only be set if --start-time or --url is set (default to now)")
 	cmd.Flags().DurationVar(&duration, "since", 0, "Only return values newer than a relative duration (e.g. 1h, 30m) - enable time range mode - exclusive with --time, --start-time & --end-time")
 	cmd.Flags().DurationVar(&stepDuration, "step", 0, "Duration between data points (e.g. 30s, 2m) - can only be set if in time range mode (i.e. --start-time or --since is set)")
 	cmd.MarkFlagsMutuallyExclusive("time", "start-time", "since")
 	cmd.MarkFlagsMutuallyExclusive("time", "end-time", "since")
 
-	cmd.Flags().StringVarP(&outputFormatStr, "output", "o", string(MetricsFormatTable), `Format of the output - allowed values: "table", "csv" or "json"`)
+	cmd.Flags().StringVarP(&outputFormatStr, "output", "o", string(MetricsFormatTable), `Format of the output - allowed values: "table", "csv" or "json" - exclusive with --url`)
+	cmd.MarkFlagsMutuallyExclusive("output", "url")
 	cmd.Flags().BoolVarP(&isPrintingClusterResultsOnly, "filter", "f", false, "Only keep the results matching the given cluster - "+
-		"only effective if some of those results have a _id, _mc_id or mc_name label")
+		"only effective if some of those results have a _id, _mc_id or mc_name label - exclusive with --url")
+	cmd.MarkFlagsMutuallyExclusive("filter", "url")
 
 	return cmd
 }

--- a/cmd/rhobs/requests.go
+++ b/cmd/rhobs/requests.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -44,6 +45,7 @@ const (
 	rhobsCellLogsCmNs         = "openshift-logging"
 	rhobsCellLogsCmName       = "rhobs-logs-destination"
 	rhobsCellCmAnnotation     = "rhobs.openshift.io/forwarding-destination"
+	grafanaBaseExploreUrl     = "https://grafana.app-sre.devshift.net/explore?"
 )
 
 type MetricsFormat string
@@ -272,6 +274,146 @@ func CreateRhobsFetcher(clusterKey string, rhobsFetchUse RhobsFetchUsage, hiveOc
 		ocmEnvName:          ocmutils.GetCurrentOCMEnv(ocmConn),
 		RhobsCell:           rhobsCell,
 	}, nil
+}
+
+func (f *RhobsFetcher) getRhobsCellName() (string, error) {
+	re := regexp.MustCompile("https://([^.]+).*")
+	matches := re.FindStringSubmatch(f.RhobsCell)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("failed to extract RHOBS cell name from '%s'", f.RhobsCell)
+	}
+
+	return matches[1], nil
+}
+
+func (f *RhobsFetcher) getBaseGrafanaDataSource() (string, error) {
+	rhobsCellName, err := f.getRhobsCellName()
+	if err != nil {
+		return "", fmt.Errorf("failed to compute grafana datasource: %v", err)
+	}
+
+	return "rhobs-" + rhobsCellName + "-" + f.ocmEnvName + "-hcp-", nil
+}
+
+func (f *RhobsFetcher) getMetricsGrafanaDataSource() (string, error) {
+	baseDataSource, err := f.getBaseGrafanaDataSource()
+	if err != nil {
+		return "", err
+	}
+
+	return baseDataSource + "metrics", nil
+}
+
+func (f *RhobsFetcher) getLogsGrafanaDataSource() (string, error) {
+	baseDataSource, err := f.getBaseGrafanaDataSource()
+	if err != nil {
+		return "", err
+	}
+
+	return baseDataSource + "logs", nil
+}
+
+type grafanaMetricsExploreParams struct {
+	Panel struct {
+		DataSource string `json:"datasource"`
+		Queries    [1]struct {
+			RefId        string `json:"refId"`
+			Expr         string `json:"expr"`
+			Instant      bool   `json:"instant"`
+			Range        bool   `json:"range"`
+			EditorMode   string `json:"editorMode"`
+			LegendFormat string `json:"legendFormat"`
+		} `json:"queries"`
+		Range struct {
+			From string `json:"from"`
+			To   string `json:"to"`
+		} `json:"range"`
+	} `json:"aaa"`
+}
+
+type grafanaLogsExploreParams struct {
+	Panel struct {
+		DataSource string `json:"datasource"`
+		Queries    [1]struct {
+			RefId      string `json:"refId"`
+			Expr       string `json:"expr"`
+			QueryType  string `json:"queryType"`
+			EditorMode string `json:"editorMode"`
+			Direction  string `json:"direction"`
+		} `json:"queries"`
+		Range struct {
+			From string `json:"from"`
+			To   string `json:"to"`
+		} `json:"range"`
+	} `json:"aaa"`
+}
+
+func (f *RhobsFetcher) GetGrafanaMetricsUrl(promExpr string, startTime, endTime time.Time) (string, error) {
+	exploreParams := grafanaMetricsExploreParams{}
+
+	dataSource, err := f.getMetricsGrafanaDataSource()
+	if err != nil {
+		return "", err
+	}
+	exploreParams.Panel.DataSource = dataSource
+	exploreParams.Panel.Queries[0].RefId = "osdctl"
+	exploreParams.Panel.Queries[0].Expr = promExpr
+	exploreParams.Panel.Queries[0].Instant = true
+	exploreParams.Panel.Queries[0].Range = true
+	exploreParams.Panel.Queries[0].EditorMode = "code"
+	exploreParams.Panel.Queries[0].LegendFormat = "__auto"
+	exploreParams.Panel.Range.From = strconv.FormatInt(startTime.UnixMilli(), 10)
+	exploreParams.Panel.Range.To = strconv.FormatInt(endTime.UnixMilli(), 10)
+
+	exploreParamsBytes, err := json.Marshal(exploreParams)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal Grafana explore parameters: %v", err)
+	}
+
+	exploreParamsEncoded := url.Values{
+		"schemaVersion": {"1"},
+		"panes":         {string(exploreParamsBytes)},
+	}.Encode()
+
+	return grafanaBaseExploreUrl + exploreParamsEncoded, nil
+}
+
+func (f *RhobsFetcher) GetGrafanaLogsUrl(lokiExpr string, startTime, endTime time.Time, isGoingForward bool) (string, error) {
+	exploreParams := grafanaLogsExploreParams{}
+
+	dataSource, err := f.getLogsGrafanaDataSource()
+	if err != nil {
+		return "", err
+	}
+
+	var logsDir string
+
+	if isGoingForward {
+		logsDir = "forward"
+	} else {
+		logsDir = "backward"
+	}
+
+	exploreParams.Panel.DataSource = dataSource
+	exploreParams.Panel.Queries[0].RefId = "osdctl"
+	exploreParams.Panel.Queries[0].Expr = lokiExpr
+	exploreParams.Panel.Queries[0].QueryType = "range"
+	exploreParams.Panel.Queries[0].EditorMode = "code"
+	exploreParams.Panel.Queries[0].Direction = logsDir
+	exploreParams.Panel.Range.From = strconv.FormatInt(startTime.UnixMilli(), 10)
+	exploreParams.Panel.Range.To = strconv.FormatInt(endTime.UnixMilli(), 10)
+
+	exploreParamsBytes, err := json.Marshal(exploreParams)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal Grafana explore parameters: %v", err)
+	}
+
+	exploreParamsEncoded := url.Values{
+		"schemaVersion": {"1"},
+		"panes":         {string(exploreParamsBytes)},
+	}.Encode()
+
+	return grafanaBaseExploreUrl + exploreParamsEncoded, nil
 }
 
 func (f *RhobsFetcher) getTokenProvider() (ocmutils.AccessTokenProvider, error) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -141,7 +141,7 @@
   - `mcp` - RHOBS MCP server for AI agent integration
     - `config` - Print MCP client configuration JSON
     - `server` - Start the RHOBS MCP server
-  - `metrics PromQL-expression` - Fetch metrics from RHOBS for a given cluster
+  - `metrics [PromQL-expression]` - Fetch metrics from RHOBS for a given cluster
 - `servicelog` - OCM/Hive Service log
   - `list --cluster-id <cluster-identifier> [flags] [options]` - Get service logs for a given cluster identifier.
   - `post --cluster-id <cluster-identifier>` - Post a service log to a cluster or list of clusters
@@ -4238,30 +4238,32 @@ osdctl rhobs logs [pod] [flags]
 #### Flags
 
 ```
+  -b, --browser                         Open in the default browser the URL computed with the --url option - only applicable if --url is set
   -C, --cluster-id string               Name or Internal ID of the cluster (defaults to current cluster context)
       --contain stringArray             Text the log message must contain - flag can be repeated
       --contain-regex stringArray       Regular expression the log message must contain - flag can be repeated
   -c, --container string                Name of the container - print all containers logs if not specified
       --direction string                Direction of the logs to return - allowed values: "forward" or "backward" - "backward" returns the most recent & interesting logs first, while "forward" matches the behavior of "kubectl logs" by returning the oldest logs first (default to "backward" unless --follow is set in which case it is forced to "forward")
       --end-time time                   End time for the logs (default to now)
-      --field strings                   Fields to print with the log message - not possible with the "json" output format - flag can be repeated / values can also be aggregated with one flag using the comma as separator - possible values: "k8s_namespace_name", "k8s_pod_name", "k8s_container_name" - use the "json" output format to know about all possible fields (default [k8s_pod_name])
-  -f, --follow                          Specify if the logs should be streamed - exclusive with --start-time, --end-time, --since, --direction, --limit and --no-limit flags
+      --field strings                   Fields to print with the log message - not possible with the "json" output format - flag can be repeated / values can also be aggregated with one flag using the comma as separator - possible values: "k8s_namespace_name", "k8s_pod_name", "k8s_container_name" - use the "json" output format to know about all possible fields - exclusive with --url (default [k8s_pod_name])
+  -f, --follow                          Specify if the logs should be streamed - exclusive with --url, --start-time, --end-time, --since, --direction, --limit and --no-limit flags
   -h, --help                            help for logs
       --hive-ocm-url string             OCM environment URL for hive operations - aliases: "production", "staging", "integration" (default "production")
       --include-events                  Include events in the logs output - may add significant noise, use with caution
       --level strings                   Log level to retain - allowed values: "default", "trace", "info", "warn", "error" - flag can be repeated / values can also be aggregated with one flag using the comma as separator
-      --limit int                       Maximum number of logs to return - allowed range: [1 100000] (default to 10000 unless --follow is set in which case there is no limit)
+      --limit int                       Maximum number of logs to return - allowed range: [1 100000] - exclusive with --no-limit, --url & --follow flags (default to 10000, no limit if --follow is set)
   -n, --namespace string                Name of the namespace (default "default")
-      --no-limit                        Do not limit the number of logs to return - exclusive with --limit flag
+      --no-limit                        Do not limit the number of logs to return - exclusive with --limit, --url & --follow flags
       --not-contain stringArray         Text the log message must not contain - flag can be repeated
       --not-contain-regex stringArray   Regular expression the log message must not contain - flag can be repeated
-  -o, --output string                   Format of the output - allowed values: "text", "csv" or "json" (default "text")
+  -o, --output string                   Format of the output - allowed values: "text", "csv" or "json" - exclusive with --url (default "text")
   -q, --query string                    LogQL expression - exclusive with many other flags
   -l, --selector string                 Label selector for filtering pods - exclusive with the pod argument
       --since duration                  Only return logs newer than a relative duration (e.g. 1h, 30m) - exclusive with --start-time & --end-time
   -S, --skip-version-check              skip checking to see if this is the most recent release
       --start-time time                 Start time for the logs - alternate alias: --since-time (default to 5 minutes ago)
-      --ts                              Print metadata timestamps - to be used when log messages do not have a timestamp - not possible with the "json" output format
+      --ts                              Print metadata timestamps - to be used when log messages do not have a timestamp - not possible with the "json" output format - exclusive with --url
+  -u, --url                             Only compute and print the grafana URL
 ```
 
 ### osdctl rhobs mcp
@@ -4337,26 +4339,28 @@ osdctl rhobs mcp server [flags]
 
 ### osdctl rhobs metrics
 
-Fetch metrics from RHOBS for a given cluster. The cluster can be a hosted cluster (HCP), a management cluster (MC) or whatever cluster sending metrics to RHOBS. The prometheus expression provided as an argument can be either an instant query or a range query. By default, the command will try to evaluate the expression as an instant query at the current time, but it is possible to specify a different evaluation time using the --time option or a time range using the --start-time, --end-time and --since options.Results can be filtered to only keep the ones matching the given cluster (--cluster-id option) with the --filter option even if it is more efficient to do that filtering at the prometheus expression level.
+Fetch metrics from RHOBS for a given cluster. The cluster can be a hosted cluster (HCP), a management cluster (MC) or whatever cluster sending metrics to RHOBS. The prometheus expression provided as an argument can be either an instant query or a range query; it is optional if the --url option is set. By default, the command will try to evaluate the expression as an instant query at the current time, but it is possible to specify a different evaluation time using the --time option or a time range using the --start-time, --end-time and --since options. Results can be filtered to only keep the ones matching the given cluster (--cluster-id option) with the --filter option even if it is more efficient to do that filtering at the prometheus expression level.
 
 ```
-osdctl rhobs metrics PromQL-expression [flags]
+osdctl rhobs metrics [PromQL-expression] [flags]
 ```
 
 #### Flags
 
 ```
+  -b, --browser               Open in the default browser the URL computed with the --url option - only applicable if --url is set
   -C, --cluster-id string     Name or Internal ID of the cluster (defaults to current cluster context)
-      --end-time time         End time at which the PromQL expression must be evaluated - can only be set if --start-time set (default to now)
-  -f, --filter                Only keep the results matching the given cluster - only effective if some of those results have a _id, _mc_id or mc_name label
+      --end-time time         End time at which the PromQL expression must be evaluated - can only be set if --start-time or --url is set (default to now)
+  -f, --filter                Only keep the results matching the given cluster - only effective if some of those results have a _id, _mc_id or mc_name label - exclusive with --url
   -h, --help                  help for metrics
       --hive-ocm-url string   OCM environment URL for hive operations - aliases: "production", "staging", "integration" (default "production")
-  -o, --output string         Format of the output - allowed values: "table", "csv" or "json" (default "table")
+  -o, --output string         Format of the output - allowed values: "table", "csv" or "json" - exclusive with --url (default "table")
       --since duration        Only return values newer than a relative duration (e.g. 1h, 30m) - enable time range mode - exclusive with --time, --start-time & --end-time
   -S, --skip-version-check    skip checking to see if this is the most recent release
       --start-time time       Start time at which the PromQL expression must be evaluated - enable time range mode - exclusive with --time (default to 30 minutes ago)
       --step duration         Duration between data points (e.g. 30s, 2m) - can only be set if in time range mode (i.e. --start-time or --since is set)
-      --time time             Time at which the PromQL expression must be evaluated (default to now)
+      --time time             Time at which the PromQL expression must be evaluated - exclusive with --url (default to now)
+  -u, --url                   Only compute and print the grafana URL
 ```
 
 ### osdctl servicelog

--- a/docs/osdctl_rhobs_logs.md
+++ b/docs/osdctl_rhobs_logs.md
@@ -13,27 +13,29 @@ osdctl rhobs logs [pod] [flags]
 ### Options
 
 ```
+  -b, --browser                         Open in the default browser the URL computed with the --url option - only applicable if --url is set
       --contain stringArray             Text the log message must contain - flag can be repeated
       --contain-regex stringArray       Regular expression the log message must contain - flag can be repeated
   -c, --container string                Name of the container - print all containers logs if not specified
       --direction string                Direction of the logs to return - allowed values: "forward" or "backward" - "backward" returns the most recent & interesting logs first, while "forward" matches the behavior of "kubectl logs" by returning the oldest logs first (default to "backward" unless --follow is set in which case it is forced to "forward")
       --end-time time                   End time for the logs (default to now)
-      --field strings                   Fields to print with the log message - not possible with the "json" output format - flag can be repeated / values can also be aggregated with one flag using the comma as separator - possible values: "k8s_namespace_name", "k8s_pod_name", "k8s_container_name" - use the "json" output format to know about all possible fields (default [k8s_pod_name])
-  -f, --follow                          Specify if the logs should be streamed - exclusive with --start-time, --end-time, --since, --direction, --limit and --no-limit flags
+      --field strings                   Fields to print with the log message - not possible with the "json" output format - flag can be repeated / values can also be aggregated with one flag using the comma as separator - possible values: "k8s_namespace_name", "k8s_pod_name", "k8s_container_name" - use the "json" output format to know about all possible fields - exclusive with --url (default [k8s_pod_name])
+  -f, --follow                          Specify if the logs should be streamed - exclusive with --url, --start-time, --end-time, --since, --direction, --limit and --no-limit flags
   -h, --help                            help for logs
       --include-events                  Include events in the logs output - may add significant noise, use with caution
       --level strings                   Log level to retain - allowed values: "default", "trace", "info", "warn", "error" - flag can be repeated / values can also be aggregated with one flag using the comma as separator
-      --limit int                       Maximum number of logs to return - allowed range: [1 100000] (default to 10000 unless --follow is set in which case there is no limit)
+      --limit int                       Maximum number of logs to return - allowed range: [1 100000] - exclusive with --no-limit, --url & --follow flags (default to 10000, no limit if --follow is set)
   -n, --namespace string                Name of the namespace (default "default")
-      --no-limit                        Do not limit the number of logs to return - exclusive with --limit flag
+      --no-limit                        Do not limit the number of logs to return - exclusive with --limit, --url & --follow flags
       --not-contain stringArray         Text the log message must not contain - flag can be repeated
       --not-contain-regex stringArray   Regular expression the log message must not contain - flag can be repeated
-  -o, --output string                   Format of the output - allowed values: "text", "csv" or "json" (default "text")
+  -o, --output string                   Format of the output - allowed values: "text", "csv" or "json" - exclusive with --url (default "text")
   -q, --query string                    LogQL expression - exclusive with many other flags
   -l, --selector string                 Label selector for filtering pods - exclusive with the pod argument
       --since duration                  Only return logs newer than a relative duration (e.g. 1h, 30m) - exclusive with --start-time & --end-time
       --start-time time                 Start time for the logs - alternate alias: --since-time (default to 5 minutes ago)
-      --ts                              Print metadata timestamps - to be used when log messages do not have a timestamp - not possible with the "json" output format
+      --ts                              Print metadata timestamps - to be used when log messages do not have a timestamp - not possible with the "json" output format - exclusive with --url
+  -u, --url                             Only compute and print the grafana URL
 ```
 
 ### Options inherited from parent commands

--- a/docs/osdctl_rhobs_metrics.md
+++ b/docs/osdctl_rhobs_metrics.md
@@ -4,23 +4,25 @@ Fetch metrics from RHOBS for a given cluster
 
 ### Synopsis
 
-Fetch metrics from RHOBS for a given cluster. The cluster can be a hosted cluster (HCP), a management cluster (MC) or whatever cluster sending metrics to RHOBS. The prometheus expression provided as an argument can be either an instant query or a range query. By default, the command will try to evaluate the expression as an instant query at the current time, but it is possible to specify a different evaluation time using the --time option or a time range using the --start-time, --end-time and --since options.Results can be filtered to only keep the ones matching the given cluster (--cluster-id option) with the --filter option even if it is more efficient to do that filtering at the prometheus expression level.
+Fetch metrics from RHOBS for a given cluster. The cluster can be a hosted cluster (HCP), a management cluster (MC) or whatever cluster sending metrics to RHOBS. The prometheus expression provided as an argument can be either an instant query or a range query; it is optional if the --url option is set. By default, the command will try to evaluate the expression as an instant query at the current time, but it is possible to specify a different evaluation time using the --time option or a time range using the --start-time, --end-time and --since options. Results can be filtered to only keep the ones matching the given cluster (--cluster-id option) with the --filter option even if it is more efficient to do that filtering at the prometheus expression level.
 
 ```
-osdctl rhobs metrics PromQL-expression [flags]
+osdctl rhobs metrics [PromQL-expression] [flags]
 ```
 
 ### Options
 
 ```
-      --end-time time     End time at which the PromQL expression must be evaluated - can only be set if --start-time set (default to now)
-  -f, --filter            Only keep the results matching the given cluster - only effective if some of those results have a _id, _mc_id or mc_name label
+  -b, --browser           Open in the default browser the URL computed with the --url option - only applicable if --url is set
+      --end-time time     End time at which the PromQL expression must be evaluated - can only be set if --start-time or --url is set (default to now)
+  -f, --filter            Only keep the results matching the given cluster - only effective if some of those results have a _id, _mc_id or mc_name label - exclusive with --url
   -h, --help              help for metrics
-  -o, --output string     Format of the output - allowed values: "table", "csv" or "json" (default "table")
+  -o, --output string     Format of the output - allowed values: "table", "csv" or "json" - exclusive with --url (default "table")
       --since duration    Only return values newer than a relative duration (e.g. 1h, 30m) - enable time range mode - exclusive with --time, --start-time & --end-time
       --start-time time   Start time at which the PromQL expression must be evaluated - enable time range mode - exclusive with --time (default to 30 minutes ago)
       --step duration     Duration between data points (e.g. 30s, 2m) - can only be set if in time range mode (i.e. --start-time or --since is set)
-      --time time         Time at which the PromQL expression must be evaluated (default to now)
+      --time time         Time at which the PromQL expression must be evaluated - exclusive with --url (default to now)
+  -u, --url               Only compute and print the grafana URL
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Follow up of those PRs:
- https://github.com/openshift/osdctl/pull/876
- https://github.com/openshift/osdctl/pull/904

Adding a new `--url` and `--browser` options to view the results of the `osdctl rhobs metrics` and the `osdctl rhobs logs` commands in grafana.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --url flag to compute Grafana Explore links for logs and metrics
  * Added --browser flag to open generated links (only with --url)
  * Metrics PromQL argument is optional when using --url; time flags can be used with --url

* **Bug Fixes**
  * --since now rejects non‑positive durations

* **Documentation**
  * Updated CLI docs for logs/metrics: new flags, help text, and updated flag exclusivity rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->