### PR TITLE
Skip Watchdog alert when silencing all alerts

### DIFF
--- a/cmd/alerts/silence/add_silence.go
+++ b/cmd/alerts/silence/add_silence.go
@@ -87,6 +87,11 @@ func AddSilence(cmd *addSilenceCmd) {
 func AddAllSilence(clusterID, duration, comment, username, clustername string, kubeconfig *rest.Config, clientset *kubernetes.Clientset) error {
 	alerts := fetchAllAlerts(kubeconfig, clientset)
 	for _, alert := range alerts {
+		if alert.Labels.Alertname == "Watchdog" {
+			fmt.Println("Skipping Watchdog alert")
+			continue
+		}
+
 		addCmd := []string{
 			"amtool",
 			"silence",


### PR DESCRIPTION
## Summary
- `osdctl alert silence add --all` now skips the Watchdog alert
- Silencing Watchdog causes Dead Man's Snitch to page, creating a false incident
- Related SOP discussion: https://github.com/openshift/ops-sop/pull/4039

## Test plan
- [ ] `osdctl alert silence add --all` skips Watchdog and prints message
- [ ] `osdctl alert silence add --alertname Watchdog` still works (explicit silence not blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Watchdog alerts are now excluded from being silenced when using the `--all` option in the silence command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->