### PR TITLE
Make report-id optional for cluster reports get

### DIFF
--- a/cmd/cluster/reports/get.go
+++ b/cmd/cluster/reports/get.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -28,9 +29,14 @@ func newCmdGet() *cobra.Command {
 		Long: `Retrieve and display a specific report by its ID.
 
 This command fetches a report by its report ID and displays the decoded
-report data. Use 'list' to find available report IDs.`,
+report data. Use 'list' to find available report IDs.
+
+If no report ID is provided, the latest report for the cluster is returned.`,
 		Example: `  # Get a specific report
   osdctl cluster reports get --cluster-id ${CLUSTER_ID} --report-id ${REPORT_ID}
+
+  # Get the latest report
+  osdctl cluster reports get --cluster-id ${CLUSTER_ID}
 
   # Get a report with JSON output
   osdctl cluster reports get --cluster-id ${CLUSTER_ID} --report-id ${REPORT_ID} --output json`,
@@ -48,10 +54,9 @@ report data. Use 'list' to find available report IDs.`,
 	}
 
 	getCmd.Flags().StringVarP(&opts.clusterID, "cluster-id", "C", "", "Cluster ID (internal or external)")
-	getCmd.Flags().StringVarP(&opts.reportID, "report-id", "r", "", "Report ID to retrieve")
+	getCmd.Flags().StringVarP(&opts.reportID, "report-id", "r", "", "Report ID to retrieve (defaults to the latest report if omitted)")
 	getCmd.Flags().StringVarP(&opts.output, "output", "o", "text", "Output format: text or json")
 	_ = getCmd.MarkFlagRequired("cluster-id")
-	_ = getCmd.MarkFlagRequired("report-id")
 
 	return getCmd
 }
@@ -68,9 +73,25 @@ func (o *getOptions) run(ocmClient *sdk.Connection) error {
 		return fmt.Errorf("failed to create backplane client: %w", err)
 	}
 
-	// Fetch the specific report
 	ctx := context.Background()
-	report, err := backplaneClient.GetReport(ctx, o.reportID)
+
+	reportID := o.reportID
+	if reportID == "" {
+		fmt.Fprintln(os.Stderr, "No report ID provided; searching for the latest report.")
+
+		latestID, err := latestReportID(ctx, backplaneClient)
+		if err != nil {
+			return err
+		}
+		if latestID == "" {
+			fmt.Fprintln(os.Stderr, "No reports found for cluster.")
+			return nil
+		}
+		reportID = latestID
+	}
+
+	// Fetch the specific report
+	report, err := backplaneClient.GetReport(ctx, reportID)
 	if err != nil {
 		return fmt.Errorf("failed to get report: %w", err)
 	}
@@ -93,4 +114,31 @@ func (o *getOptions) run(ocmClient *sdk.Connection) error {
 	fmt.Println(string(decodedData))
 
 	return nil
+}
+
+// latestReportID returns the report ID of the most recently created report for
+// the cluster. It returns an empty string if the cluster has no reports.
+func latestReportID(ctx context.Context, backplaneClient *backplane.Client) (string, error) {
+	reports, err := backplaneClient.ListReports(ctx, 0)
+	if err != nil {
+		return "", fmt.Errorf("failed to list reports: %w", err)
+	}
+
+	if reports == nil || len(reports.Reports) == 0 {
+		return "", nil
+	}
+
+	var latestID string
+	var latestTime time.Time
+	for _, report := range reports.Reports {
+		if report.ReportId == nil || report.CreatedAt == nil {
+			continue
+		}
+		if latestID == "" || report.CreatedAt.After(latestTime) {
+			latestID = *report.ReportId
+			latestTime = *report.CreatedAt
+		}
+	}
+
+	return latestID, nil
 }

--- a/cmd/cluster/reports/get_test.go
+++ b/cmd/cluster/reports/get_test.go
@@ -55,11 +55,11 @@ func TestGetOptions_Validation(t *testing.T) {
 			wantErr:   true,
 		},
 		{
-			name:      "missing report ID",
+			name:      "missing report ID is allowed",
 			clusterID: "test-cluster-123",
 			reportID:  "",
 			output:    "table",
-			wantErr:   true,
+			wantErr:   false,
 		},
 	}
 
@@ -71,8 +71,9 @@ func TestGetOptions_Validation(t *testing.T) {
 				output:    tt.output,
 			}
 
-			// Basic validation
-			hasError := opts.clusterID == "" || opts.reportID == ""
+			// Basic validation: only cluster-id is required; report-id is optional
+			// and defaults to the latest report when omitted.
+			hasError := opts.clusterID == ""
 			assert.Equal(t, tt.wantErr, hasError)
 
 			assert.Equal(t, tt.clusterID, opts.clusterID)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1916,6 +1916,8 @@ Retrieve and display a specific report by its ID.
 This command fetches a report by its report ID and displays the decoded
 report data. Use 'list' to find available report IDs.
 
+If no report ID is provided, the latest report for the cluster is returned.
+
 ```
 osdctl cluster reports get [flags]
 ```
@@ -1931,7 +1933,7 @@ osdctl cluster reports get [flags]
       --insecure-skip-tls-verify         If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string                Path to the kubeconfig file to use for CLI requests.
   -o, --output string                    Output format: text or json (default "text")
-  -r, --report-id string                 Report ID to retrieve
+  -r, --report-id string                 Report ID to retrieve (defaults to the latest report if omitted)
       --request-timeout string           The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                    The address and port of the Kubernetes API server
       --skip-aws-proxy-check aws_proxy   Don't use the configured aws_proxy value

--- a/docs/osdctl_cluster_reports_get.md
+++ b/docs/osdctl_cluster_reports_get.md
@@ -9,6 +9,8 @@ Retrieve and display a specific report by its ID.
 This command fetches a report by its report ID and displays the decoded
 report data. Use 'list' to find available report IDs.
 
+If no report ID is provided, the latest report for the cluster is returned.
+
 ```
 osdctl cluster reports get [flags]
 ```
@@ -18,6 +20,9 @@ osdctl cluster reports get [flags]
 ```
   # Get a specific report
   osdctl cluster reports get --cluster-id ${CLUSTER_ID} --report-id ${REPORT_ID}
+
+  # Get the latest report
+  osdctl cluster reports get --cluster-id ${CLUSTER_ID}
 
   # Get a report with JSON output
   osdctl cluster reports get --cluster-id ${CLUSTER_ID} --report-id ${REPORT_ID} --output json
@@ -29,7 +34,7 @@ osdctl cluster reports get [flags]
   -C, --cluster-id string   Cluster ID (internal or external)
   -h, --help                help for get
   -o, --output string       Output format: text or json (default "text")
-  -r, --report-id string    Report ID to retrieve
+  -r, --report-id string    Report ID to retrieve (defaults to the latest report if omitted)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
The `cluster reports get` subcommand previously required the `--report-id` flag. It is now optional: when omitted, the latest report for the cluster is fetched and returned.

When `--report-id` is not provided, a message is written to standard error indicating that the latest report will be searched for and returned. If the cluster has no reports, a corresponding message is written to standard error and the command exits without error.


Claude-Session: https://claude.ai/code/session_011kSv6MRg3ccFMw8rpy12YE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The cluster reports get command now returns the latest report automatically when `--report-id` is not provided.
  * Added clearer help text and an example showing how to fetch the newest report for a cluster.

* **Bug Fixes**
  * Improved handling when no reports are available, with clearer messaging.
  * The command now skips incomplete report entries and selects the most recently created valid report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->