### PR TITLE
Update the instructions to install from the Homebrew SRE tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Currently, it mainly supports related work for AWS, especially [aws-account-oper
 
 ### MacOS
 
-```
-$ brew install osdctl
+```brew
+brew tap openshift-online/sre-tools
+brew install openshift-online/sre-tools/osdctl
 ```
 
 ### Build from source


### PR DESCRIPTION
As the tool is meant for internal use, I've migrated it to a dedicated SRE tap. Until the formula is removed from homebrew-core (I will submit a request), in order to avoid collisions, the install command requires the full namespace regardless of whether the tap is "tapped". I will update the instructions again once the formula is no longer in homebrew-core.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the macOS installation steps to use the recommended Homebrew tap and install path for `osdctl`.
  * Clarified the setup instructions so users can install the tool from the correct repository source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->