### PR TITLE
 Fix FormattedLog to include all commits, use oneline short-hash format

### DIFF
--- a/cmd/promote/managedscripts/managed_scripts_test.go
+++ b/cmd/promote/managedscripts/managed_scripts_test.go
@@ -98,7 +98,7 @@ func (d *managedScriptsTestData) GetManagedScriptsRepoFormattedLog(hashIndexes .
 	var sb strings.Builder
 
 	for _, idx := range hashIndexes {
-		fmt.Fprintf(&sb, promote.CommitTemplate, d.managedScriptsRepoHashes[idx], idx)
+		fmt.Fprintf(&sb, promote.CommitTemplate, d.managedScriptsRepoHashes[idx][:7], idx)
 	}
 
 	return sb.String()
@@ -169,7 +169,7 @@ var _ = Describe("Service struct", func() {
 
 				Expect(data.GetAppInterfaceCommitsCount()).To(Equal(3))
 
-				data.CheckAppInterfaceCommitMessage(0, data.GetManagedScriptsRepoFormattedLog(8, 6, 4))
+				data.CheckAppInterfaceCommitMessage(0, data.GetManagedScriptsRepoFormattedLog(8, 7, 6, 5, 4, 3))
 				data.CheckAppInterfaceCommitStats(0, 1, serviceRelPath, 2, 2)
 			})
 		})

--- a/cmd/promote/saas/saas_test.go
+++ b/cmd/promote/saas/saas_test.go
@@ -132,12 +132,12 @@ var _ = Describe("Service struct", func() {
 				data.CheckAppInterfaceIsClean()
 				data.CheckAppInterfaceBranchName(fmt.Sprintf("promote-service-1-%s", data.TestRepoHashes[5]))
 
-				data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(5, 2))
+				data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(5, 4, 3, 2, 1))
 				data.CheckAppInterfaceCommitMessage(0, "?var-namespace=default-component-pipelines&")
 
 				data.CheckAppInterfaceCommitStats(0, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 2, 2)
 
-				data.CheckAppInterfaceCommitMessage(1, data.GetTestRepoFormattedLog(4, 1))
+				data.CheckAppInterfaceCommitMessage(1, data.GetTestRepoFormattedLog(5, 4, 3, 2, 1))
 				data.CheckAppInterfaceCommitStats(1, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 2, 2)
 			})
 		})
@@ -161,10 +161,10 @@ var _ = Describe("Service struct", func() {
 
 				Expect(data.GetAppInterfaceCommitsCount()).To(Equal(3))
 
-				data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(5, 2))
+				data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(8, 7, 6, 5, 4, 3, 2, 1))
 				data.CheckAppInterfaceCommitStats(0, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 1, 1)
 
-				data.CheckAppInterfaceCommitMessage(1, data.GetTestRepoFormattedLog(4, 1))
+				data.CheckAppInterfaceCommitMessage(1, data.GetTestRepoFormattedLog(8, 7, 6, 5, 4, 3, 2, 1))
 				data.CheckAppInterfaceCommitStats(1, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 1, 1)
 			})
 		})
@@ -187,7 +187,7 @@ var _ = Describe("Service struct", func() {
 
 				Expect(data.GetAppInterfaceCommitsCount()).To(Equal(2))
 
-				data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(7, 4, 1))
+				data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(9, 8, 7, 6, 5, 4, 3, 2, 1))
 				data.CheckAppInterfaceCommitStats(0, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 1, 1)
 			})
 		})
@@ -212,10 +212,10 @@ var _ = Describe("Service struct", func() {
 
 				Expect(data.GetAppInterfaceCommitsCount()).To(Equal(3))
 
-				data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(8, 5, 2))
+				data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(9, 8, 7, 6, 5, 4, 3, 2, 1))
 				data.CheckAppInterfaceCommitStats(0, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 2, 2)
 
-				data.CheckAppInterfaceCommitMessage(1, data.GetTestRepoFormattedLog(7, 4, 1))
+				data.CheckAppInterfaceCommitMessage(1, data.GetTestRepoFormattedLog(9, 8, 7, 6, 5, 4, 3, 2, 1))
 				data.CheckAppInterfaceCommitStats(1, 2, "data/services/gen-app/cicd/saas/service-1.yaml", 2, 2)
 				data.CheckAppInterfaceCommitStats(1, 2, "data/services/gen-app/app.yml", 2, 0)
 			})

--- a/pkg/promote/git_repo.go
+++ b/pkg/promote/git_repo.go
@@ -3,7 +3,6 @@ package promote
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
@@ -106,8 +105,8 @@ func (r *Repo) ResolveHash(hashOrBranchName string) string {
 	return hashOrBranchName
 }
 
-func (r *Repo) FormattedLog(fileRelPath, commonAncestorHash, targetHash string) (string, error) {
-	// Be aware that calling 'Log' as follows is not equivalent to calling 'git log commonAncestorHash..targetHash -- fileRelPath':
+func (r *Repo) FormattedLog(commonAncestorHash, targetHash string) (string, error) {
+	// Be aware that calling 'Log' as follows is not equivalent to calling 'git log commonAncestorHash..targetHash':
 	// (the 'Log' method only returns the descendants of 'commonAncestorHash' while 'git log' returns all the commits which are not ancestor of  'commonAncestorHash')
 	//
 	// r.rawRepo.Log(&git.LogOptions{
@@ -118,7 +117,6 @@ func (r *Repo) FormattedLog(fileRelPath, commonAncestorHash, targetHash string) 
 	//
 	// Hence the below code which is a bit complex but equally fast to the 'Log' method.
 
-	fileRelPath = strings.TrimPrefix(fileRelPath, string(filepath.Separator))
 	commonAncestorCommit, err := r.rawRepo.CommitObject(plumbing.NewHash(commonAncestorHash))
 	if commonAncestorCommit == nil || err != nil {
 		return "", fmt.Errorf("common ancestor commit '%s' does not exist in '%s': %v", commonAncestorHash, r.url, err)
@@ -160,15 +158,8 @@ func (r *Repo) FormattedLog(fileRelPath, commonAncestorHash, targetHash string) 
 
 		if !isAncestor {
 			if len(commit.ParentHashes) < 2 {
-				stats, err := commit.Stats()
-				if err != nil {
-					return "", fmt.Errorf("unable to get stats for commit '%s' in '%s': %v", hash.String(), r.url, err)
-				}
-				for _, stat := range stats {
-					if stat.Name == fileRelPath {
-						sb.WriteString(commit.String())
-					}
-				}
+				firstLine := strings.SplitN(strings.TrimSpace(commit.Message), "\n", 2)[0]
+				fmt.Fprintf(&sb, "%s %s\n", commit.Hash.String()[:7], firstLine)
 			}
 
 			queue = append(queue, commit.ParentHashes...)

--- a/pkg/promote/git_repo_test.go
+++ b/pkg/promote/git_repo_test.go
@@ -1,0 +1,41 @@
+package promote
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Repo.FormattedLog", func() {
+	var data *TestData
+
+	BeforeEach(func() {
+		data = CreateDefaultTestData()
+	})
+
+	AfterEach(func() {
+		CleanupAllTestDataResources()
+	})
+
+	It("returns all non-merge commits between two hashes regardless of which files they touch", func() {
+		repo, err := GetRepo(data.TestRepoPath)
+		Expect(err).ShouldNot(HaveOccurred())
+		defer repo.Cleanup()
+
+		log, err := repo.FormattedLog(data.TestRepoHashes[0], data.TestRepoHashes[7])
+		Expect(err).ShouldNot(HaveOccurred())
+
+		expectedLog := data.GetTestRepoFormattedLog(7, 6, 5, 4, 3, 2, 1)
+		Expect(log).To(Equal(expectedLog))
+	})
+
+	It("returns an empty string when target is an ancestor of the common ancestor", func() {
+		repo, err := GetRepo(data.TestRepoPath)
+		Expect(err).ShouldNot(HaveOccurred())
+		defer repo.Cleanup()
+
+		log, err := repo.FormattedLog(data.TestRepoHashes[7], data.TestRepoHashes[3])
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Expect(log).To(Equal(""))
+	})
+})

--- a/pkg/promote/service.go
+++ b/pkg/promote/service.go
@@ -348,7 +348,7 @@ func (c *DefaultPromoteCallbacks) SetTargetHash(targetNode *kyaml.RNode, newHash
 }
 
 func (c *DefaultPromoteCallbacks) ComputeCommitMessage(resourceTemplateRepo *Repo, resourceTemplatePath, oldHash, newHash string) (*CommitMessage, error) {
-	changeLog, err := resourceTemplateRepo.FormattedLog(resourceTemplatePath, oldHash, newHash)
+	changeLog, err := resourceTemplateRepo.FormattedLog(oldHash, newHash)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/promote/service_test.go
+++ b/pkg/promote/service_test.go
@@ -338,10 +338,10 @@ var _ = Describe("Service struct", func() {
 
 					Expect(data.GetAppInterfaceCommitsCount()).To(Equal(3))
 
-					data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(5, 2))
+					data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(7, 6, 5, 4, 3, 2, 1))
 					data.CheckAppInterfaceCommitStats(0, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 2, 2)
 
-					data.CheckAppInterfaceCommitMessage(1, data.GetTestRepoFormattedLog(7, 4, 1))
+					data.CheckAppInterfaceCommitMessage(1, data.GetTestRepoFormattedLog(7, 6, 5, 4, 3, 2, 1))
 					data.CheckAppInterfaceCommitStats(1, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 2, 2)
 				})
 			})
@@ -364,16 +364,16 @@ var _ = Describe("Service struct", func() {
 
 					Expect(data.GetAppInterfaceCommitsCount()).To(Equal(6))
 
-					data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(5))
+					data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(7, 6, 5, 4))
 					data.CheckAppInterfaceCommitStats(0, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 1, 1)
 
-					data.CheckAppInterfaceCommitMessage(1, data.GetTestRepoFormattedLog(5))
+					data.CheckAppInterfaceCommitMessage(1, data.GetTestRepoFormattedLog(7, 6, 5, 4))
 					data.CheckAppInterfaceCommitStats(1, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 1, 1)
 
-					data.CheckAppInterfaceCommitMessage(2, data.GetTestRepoFormattedLog(7, 4))
+					data.CheckAppInterfaceCommitMessage(2, data.GetTestRepoFormattedLog(7, 6, 5, 4, 3, 2))
 					data.CheckAppInterfaceCommitStats(2, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 1, 1)
 
-					data.CheckAppInterfaceCommitMessage(3, data.GetTestRepoFormattedLog(7, 4))
+					data.CheckAppInterfaceCommitMessage(3, data.GetTestRepoFormattedLog(7, 6, 5, 4, 3, 2))
 					data.CheckAppInterfaceCommitStats(3, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 1, 1)
 				})
 			})
@@ -435,10 +435,10 @@ var _ = Describe("Service struct", func() {
 
 					Expect(data.GetAppInterfaceCommitsCount()).To(Equal(4))
 
-					data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(5, 2))
+					data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(7, 6, 5, 4, 3, 2, 1))
 					data.CheckAppInterfaceCommitStats(0, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 2, 2)
 
-					data.CheckAppInterfaceCommitMessage(1, data.GetTestRepoFormattedLog(7, 4, 1))
+					data.CheckAppInterfaceCommitMessage(1, data.GetTestRepoFormattedLog(7, 6, 5, 4, 3, 2, 1))
 					data.CheckAppInterfaceCommitStats(1, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 2, 2)
 				})
 			})
@@ -465,10 +465,10 @@ var _ = Describe("Service struct", func() {
 
 				Expect(data.GetAppInterfaceCommitsCount()).To(Equal(3))
 
-				data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(5, 2))
+				data.CheckAppInterfaceCommitMessage(0, data.GetTestRepoFormattedLog(6, 5, 4, 3, 2, 1))
 				data.CheckAppInterfaceCommitStats(0, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 1, 1)
 
-				data.CheckAppInterfaceCommitMessage(1, data.GetTestRepoFormattedLog(4, 1))
+				data.CheckAppInterfaceCommitMessage(1, data.GetTestRepoFormattedLog(6, 5, 4, 3, 2, 1))
 				data.CheckAppInterfaceCommitStats(1, 1, "data/services/gen-app/cicd/saas/service-1.yaml", 1, 1)
 			})
 		})

--- a/pkg/promote/test_tools.go
+++ b/pkg/promote/test_tools.go
@@ -210,18 +210,13 @@ func CreateDefaultTestData() *TestData {
 	})
 }
 
-const CommitTemplate = `commit %s
-Author: John Doe <john.doe@company.com>
-Date:   Thu Jan 01 00:00:00 1970 +0000
-
-    Commit #%d
-`
+const CommitTemplate = "%s Commit #%d\n"
 
 func (d *TestData) GetTestRepoFormattedLog(hashIndexes ...int) string {
 	var sb strings.Builder
 
 	for _, idx := range hashIndexes {
-		fmt.Fprintf(&sb, CommitTemplate, d.TestRepoHashes[idx], idx)
+		fmt.Fprintf(&sb, CommitTemplate, d.TestRepoHashes[idx][:7], idx)
 	}
 
 	return sb.String()


### PR DESCRIPTION
The go-git rewrite of FormattedLog inadvertently filtered commits to only those touching the resource template file. Restore the original behavior of showing all non-merge commits between the two hashes. Switch output from full commit format to oneline with 7-char short hashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refactored commit log display format during promotion operations for enhanced readability. Commit hashes now appear in shortened form (7 characters) in promotion-generated commit messages, making them more concise and easier to scan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->