### PR TITLE
[ROSAENG-61492] Add RHOBS details to osdctl cluster context

### DIFF
--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -24,6 +24,7 @@ import (
 	v1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 	backplaneapi "github.com/openshift/backplane-api/pkg/client"
 	"github.com/openshift/osdctl/cmd/dynatrace"
+	"github.com/openshift/osdctl/cmd/rhobs"
 	"github.com/openshift/osdctl/cmd/servicelog"
 	"github.com/openshift/osdctl/pkg/backplane"
 	"github.com/openshift/osdctl/pkg/osdCloud"
@@ -46,6 +47,7 @@ const (
 	longOutputConfigValue         = "long"
 	jsonOutputConfigValue         = "json"
 	delimiter                     = ">> "
+	rhobsUnsupportedClusterMsg   = "not an HCP or MC Cluster"
 )
 
 type contextOptions struct {
@@ -84,6 +86,10 @@ type contextData struct {
 	// Dynatrace Environment URL and Logs URL
 	DyntraceEnvURL  string
 	DyntraceLogsURL string
+
+	// RHOBS Dashboard URL and Logs URL
+	RhobsDashboardURL string
+	RhobsLogsURL      string
 
 	// limited Support Status
 	LimitedSupportReasons []*cmv1.LimitedSupportReason
@@ -283,6 +289,9 @@ func (o *contextOptions) printLongOutput(data *contextData, w io.Writer) {
 
 	// Print Dynatrace URL
 	printDynatraceResources(data, w)
+
+	// Print RHOBS URLs
+	printRhobsResources(data, w)
 
 	// Print User Banned Details
 	printUserBannedStatus(data, w)
@@ -578,6 +587,103 @@ func (o *contextOptions) generateContextData() (*contextData, []error) {
 
 	}
 
+	GetRhobsDetails := func() {
+		defer wg.Done()
+		defer utils.StartDelayTracker(o.verbose, "RHOBS URLs").End()
+
+		isHCP := o.cluster.Hypershift().Enabled()
+		isMC := false
+		if !isHCP {
+			var mcErr error
+			isMC, mcErr = utils.IsManagementCluster(o.clusterID)
+			if mcErr != nil {
+				mu.Lock()
+				dataErrors = append(dataErrors, fmt.Errorf("failed to check if cluster is a management cluster for RHOBS: %v", mcErr))
+				mu.Unlock()
+			}
+		}
+
+		if !isHCP && !isMC {
+			data.RhobsDashboardURL = rhobsUnsupportedClusterMsg
+			return
+		}
+
+		ctx := context.Background()
+
+		// Dashboard URL — same code path as 'osdctl rhobs hcp-dashboard'
+		var dashboardName string
+		if isHCP {
+			dashboardName = "hosted-cluster"
+		} else {
+			dashboardName = "management-cluster"
+		}
+		metricsFetcher, dashFetchErr := rhobs.CreateRhobsFetcher(ctx, o.clusterID, rhobs.RhobsFetchForMetrics, "production")
+		if dashFetchErr != nil {
+			mu.Lock()
+			dataErrors = append(dataErrors, fmt.Errorf("failed to get RHOBS metrics fetcher: %v", dashFetchErr))
+			mu.Unlock()
+		} else if dashboard := rhobs.GetGrafanaDashboardForShortName(dashboardName); dashboard != nil {
+			dashboardURL, dashErr := rhobs.GetGrafanaDashboardUrl(metricsFetcher, metricsFetcher, dashboard)
+			if dashErr != nil {
+				mu.Lock()
+				dataErrors = append(dataErrors, fmt.Errorf("failed to get RHOBS dashboard URL: %v", dashErr))
+				mu.Unlock()
+			} else {
+				data.RhobsDashboardURL = dashboardURL
+			}
+		}
+
+	// Logs URL
+	// NOTE: 'osdctl rhobs logs -C <hcp-cluster-id> --url' has a bug: it filters by the HCP cluster's
+	// external UUID, but HCP control-plane logs on the MC are labeled with the MC's openshift_cluster_id.
+	// We intentionally work around that bug here by using the correct MC external UUID and HCP namespace.
+	logsFetcher, logsFetchErr := rhobs.CreateRhobsFetcher(ctx, o.clusterID, rhobs.RhobsFetchForLogs, "production")
+	if logsFetchErr != nil {
+		mu.Lock()
+		dataErrors = append(dataErrors, fmt.Errorf("failed to get RHOBS logs fetcher: %v", logsFetchErr))
+		mu.Unlock()
+	} else {
+		var lokiNamespace, clusterExtID string
+		if isHCP {
+			// HCP control-plane logs live in the HCP namespace on the MC and are indexed
+			// under the MC's openshift_cluster_id, not the HCP cluster's.
+			mc, mcErr := utils.GetManagementCluster(o.clusterID)
+			if mcErr != nil {
+				mu.Lock()
+				dataErrors = append(dataErrors, fmt.Errorf("failed to get management cluster for RHOBS logs URL: %v", mcErr))
+				mu.Unlock()
+			} else {
+				clusterExtID = mc.ExternalID()
+			}
+			hcpNamespace, nsErr := utils.GetHCPNamespace(o.clusterID)
+			if nsErr != nil {
+				mu.Lock()
+				dataErrors = append(dataErrors, fmt.Errorf("failed to get HCP namespace for RHOBS logs URL: %v", nsErr))
+				mu.Unlock()
+				lokiNamespace = "default"
+			} else {
+				lokiNamespace = hcpNamespace
+			}
+		} else {
+			clusterExtID = o.cluster.ExternalID()
+			lokiNamespace = "default"
+		}
+
+		if clusterExtID != "" {
+			lokiExpr := fmt.Sprintf(`{k8s_namespace_name="%s"} | json json_kind="kind" | json_kind != "Event" | openshift_cluster_id = "%s"`, lokiNamespace, clusterExtID)
+			now := time.Now()
+			logsURL, logsErr := logsFetcher.GetGrafanaLogsUrl(lokiExpr, now.Add(-5*time.Minute), now, false)
+			if logsErr != nil {
+				mu.Lock()
+				dataErrors = append(dataErrors, fmt.Errorf("failed to get RHOBS logs URL: %v", logsErr))
+				mu.Unlock()
+			} else {
+				data.RhobsLogsURL = logsURL
+			}
+		}
+	}
+}
+
 	GetPagerDutyAlerts := func() {
 		defer wg.Done()
 		defer pdwg.Done()
@@ -662,6 +768,7 @@ func (o *contextOptions) generateContextData() (*contextData, []error) {
 		GetSupportExceptions,
 		GetPagerDutyAlerts,
 		GetDynatraceDetails,
+		GetRhobsDetails,
 		GetBannedUser,
 		GetMigrationInfo,
 		GetClusterReports,
@@ -992,6 +1099,37 @@ func printDynatraceResources(data *contextData, w io.Writer) {
 		url := strings.TrimSpace(links[link])
 		if url == dynatrace.ErrUnsupportedCluster.Error() {
 			fmt.Fprintln(w, dynatrace.ErrUnsupportedCluster.Error())
+			break
+		} else if url != "" {
+			table.AddRow([]string{link, url})
+		}
+	}
+
+	if err := table.Flush(); err != nil {
+		fmt.Fprintf(w, "Error printing %s: %v\n", name, err)
+	}
+}
+
+func printRhobsResources(data *contextData, w io.Writer) {
+	var name string = "RHOBS Details"
+	fmt.Fprintln(w, "\n"+delimiter+name)
+
+	links := map[string]string{
+		"Cluster Dashboard URL": data.RhobsDashboardURL,
+		"Logs URL":             data.RhobsLogsURL,
+	}
+
+	var keys []string
+	for k := range links {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	table := printer.NewTablePrinter(w, 20, 1, 3, ' ')
+	for _, link := range keys {
+		url := strings.TrimSpace(links[link])
+		if url == rhobsUnsupportedClusterMsg {
+			fmt.Fprintln(w, rhobsUnsupportedClusterMsg)
 			break
 		} else if url != "" {
 			table.AddRow([]string{link, url})

--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -47,7 +47,7 @@ const (
 	longOutputConfigValue         = "long"
 	jsonOutputConfigValue         = "json"
 	delimiter                     = ">> "
-	rhobsUnsupportedClusterMsg   = "not an HCP or MC Cluster"
+	rhobsUnsupportedClusterMsg    = "not an HCP or MC Cluster"
 )
 
 type contextOptions struct {
@@ -633,56 +633,56 @@ func (o *contextOptions) generateContextData() (*contextData, []error) {
 			}
 		}
 
-	// Logs URL
-	// NOTE: 'osdctl rhobs logs -C <hcp-cluster-id> --url' has a bug: it filters by the HCP cluster's
-	// external UUID, but HCP control-plane logs on the MC are labeled with the MC's openshift_cluster_id.
-	// We intentionally work around that bug here by using the correct MC external UUID and HCP namespace.
-	logsFetcher, logsFetchErr := rhobs.CreateRhobsFetcher(ctx, o.clusterID, rhobs.RhobsFetchForLogs, "production")
-	if logsFetchErr != nil {
-		mu.Lock()
-		dataErrors = append(dataErrors, fmt.Errorf("failed to get RHOBS logs fetcher: %v", logsFetchErr))
-		mu.Unlock()
-	} else {
-		var lokiNamespace, clusterExtID string
-		if isHCP {
-			// HCP control-plane logs live in the HCP namespace on the MC and are indexed
-			// under the MC's openshift_cluster_id, not the HCP cluster's.
-			mc, mcErr := utils.GetManagementCluster(o.clusterID)
-			if mcErr != nil {
-				mu.Lock()
-				dataErrors = append(dataErrors, fmt.Errorf("failed to get management cluster for RHOBS logs URL: %v", mcErr))
-				mu.Unlock()
-			} else {
-				clusterExtID = mc.ExternalID()
-			}
-			hcpNamespace, nsErr := utils.GetHCPNamespace(o.clusterID)
-			if nsErr != nil {
-				mu.Lock()
-				dataErrors = append(dataErrors, fmt.Errorf("failed to get HCP namespace for RHOBS logs URL: %v", nsErr))
-				mu.Unlock()
-				lokiNamespace = "default"
-			} else {
-				lokiNamespace = hcpNamespace
-			}
+		// Logs URL
+		// NOTE: 'osdctl rhobs logs -C <hcp-cluster-id> --url' has a bug: it filters by the HCP cluster's
+		// external UUID, but HCP control-plane logs on the MC are labeled with the MC's openshift_cluster_id.
+		// We intentionally work around that bug here by using the correct MC external UUID and HCP namespace.
+		logsFetcher, logsFetchErr := rhobs.CreateRhobsFetcher(ctx, o.clusterID, rhobs.RhobsFetchForLogs, "production")
+		if logsFetchErr != nil {
+			mu.Lock()
+			dataErrors = append(dataErrors, fmt.Errorf("failed to get RHOBS logs fetcher: %v", logsFetchErr))
+			mu.Unlock()
 		} else {
-			clusterExtID = o.cluster.ExternalID()
-			lokiNamespace = "default"
-		}
-
-		if clusterExtID != "" {
-			lokiExpr := fmt.Sprintf(`{k8s_namespace_name="%s"} | json json_kind="kind" | json_kind != "Event" | openshift_cluster_id = "%s"`, lokiNamespace, clusterExtID)
-			now := time.Now()
-			logsURL, logsErr := logsFetcher.GetGrafanaLogsUrl(lokiExpr, now.Add(-5*time.Minute), now, false)
-			if logsErr != nil {
-				mu.Lock()
-				dataErrors = append(dataErrors, fmt.Errorf("failed to get RHOBS logs URL: %v", logsErr))
-				mu.Unlock()
+			var lokiNamespace, clusterExtID string
+			if isHCP {
+				// HCP control-plane logs live in the HCP namespace on the MC and are indexed
+				// under the MC's openshift_cluster_id, not the HCP cluster's.
+				mc, mcErr := utils.GetManagementCluster(o.clusterID)
+				if mcErr != nil {
+					mu.Lock()
+					dataErrors = append(dataErrors, fmt.Errorf("failed to get management cluster for RHOBS logs URL: %v", mcErr))
+					mu.Unlock()
+				} else {
+					clusterExtID = mc.ExternalID()
+				}
+				hcpNamespace, nsErr := utils.GetHCPNamespace(o.clusterID)
+				if nsErr != nil {
+					mu.Lock()
+					dataErrors = append(dataErrors, fmt.Errorf("failed to get HCP namespace for RHOBS logs URL: %v", nsErr))
+					mu.Unlock()
+					lokiNamespace = "default"
+				} else {
+					lokiNamespace = hcpNamespace
+				}
 			} else {
-				data.RhobsLogsURL = logsURL
+				clusterExtID = o.cluster.ExternalID()
+				lokiNamespace = "default"
+			}
+
+			if clusterExtID != "" {
+				lokiExpr := fmt.Sprintf(`{k8s_namespace_name="%s"} | json json_kind="kind" | json_kind != "Event" | openshift_cluster_id = "%s"`, lokiNamespace, clusterExtID)
+				now := time.Now()
+				logsURL, logsErr := logsFetcher.GetGrafanaLogsUrl(lokiExpr, now.Add(-5*time.Minute), now, false)
+				if logsErr != nil {
+					mu.Lock()
+					dataErrors = append(dataErrors, fmt.Errorf("failed to get RHOBS logs URL: %v", logsErr))
+					mu.Unlock()
+				} else {
+					data.RhobsLogsURL = logsURL
+				}
 			}
 		}
 	}
-}
 
 	GetPagerDutyAlerts := func() {
 		defer wg.Done()
@@ -1111,12 +1111,12 @@ func printDynatraceResources(data *contextData, w io.Writer) {
 }
 
 func printRhobsResources(data *contextData, w io.Writer) {
-	var name string = "RHOBS Details"
+	name := "RHOBS Details"
 	fmt.Fprintln(w, "\n"+delimiter+name)
 
 	links := map[string]string{
 		"Cluster Dashboard URL": data.RhobsDashboardURL,
-		"Logs URL":             data.RhobsLogsURL,
+		"Logs URL":              data.RhobsLogsURL,
 	}
 
 	var keys []string

--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -600,6 +600,8 @@ func (o *contextOptions) generateContextData() (*contextData, []error) {
 				mu.Lock()
 				dataErrors = append(dataErrors, fmt.Errorf("failed to check if cluster is a management cluster for RHOBS: %v", mcErr))
 				mu.Unlock()
+				// Return early: can't determine cluster type, so don't mislabel as unsupported.
+				return
 			}
 		}
 
@@ -608,22 +610,31 @@ func (o *contextOptions) generateContextData() (*contextData, []error) {
 			return
 		}
 
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 
-		// Dashboard URL — same code path as 'osdctl rhobs hcp-dashboard'
+		// Create both fetchers up front so the logs fetcher can be passed to
+		// GetGrafanaDashboardUrl (some dashboards use it for the logs datasource).
 		var dashboardName string
 		if isHCP {
 			dashboardName = "hosted-cluster"
 		} else {
 			dashboardName = "management-cluster"
 		}
-		metricsFetcher, dashFetchErr := rhobs.CreateRhobsFetcher(ctx, o.clusterID, rhobs.RhobsFetchForMetrics, "production")
-		if dashFetchErr != nil {
+		metricsFetcher, metricsFetchErr := rhobs.CreateRhobsFetcher(ctx, o.clusterID, rhobs.RhobsFetchForMetrics, data.OCMEnv)
+		logsFetcher, logsFetchErr := rhobs.CreateRhobsFetcher(ctx, o.clusterID, rhobs.RhobsFetchForLogs, data.OCMEnv)
+
+		// Dashboard URL — same code path as 'osdctl rhobs hcp-dashboard'
+		if metricsFetchErr != nil {
 			mu.Lock()
-			dataErrors = append(dataErrors, fmt.Errorf("failed to get RHOBS metrics fetcher: %v", dashFetchErr))
+			dataErrors = append(dataErrors, fmt.Errorf("failed to get RHOBS metrics fetcher: %v", metricsFetchErr))
 			mu.Unlock()
 		} else if dashboard := rhobs.GetGrafanaDashboardForShortName(dashboardName); dashboard != nil {
-			dashboardURL, dashErr := rhobs.GetGrafanaDashboardUrl(metricsFetcher, metricsFetcher, dashboard)
+			logsF := metricsFetcher // fallback if logs fetcher unavailable
+			if logsFetchErr == nil {
+				logsF = logsFetcher
+			}
+			dashboardURL, dashErr := rhobs.GetGrafanaDashboardUrl(metricsFetcher, logsF, dashboard)
 			if dashErr != nil {
 				mu.Lock()
 				dataErrors = append(dataErrors, fmt.Errorf("failed to get RHOBS dashboard URL: %v", dashErr))
@@ -634,10 +645,9 @@ func (o *contextOptions) generateContextData() (*contextData, []error) {
 		}
 
 		// Logs URL
-		// NOTE: 'osdctl rhobs logs -C <hcp-cluster-id> --url' has a bug: it filters by the HCP cluster's
-		// external UUID, but HCP control-plane logs on the MC are labeled with the MC's openshift_cluster_id.
-		// We intentionally work around that bug here by using the correct MC external UUID and HCP namespace.
-		logsFetcher, logsFetchErr := rhobs.CreateRhobsFetcher(ctx, o.clusterID, rhobs.RhobsFetchForLogs, "production")
+		// NOTE: 'osdctl rhobs logs -C <hcp-cluster-id> --url' has a bug: it filters by the HCP
+		// cluster's external UUID, but HCP control-plane logs on the MC are labeled with the MC's
+		// openshift_cluster_id. We intentionally work around that bug here (tracked in #932).
 		if logsFetchErr != nil {
 			mu.Lock()
 			dataErrors = append(dataErrors, fmt.Errorf("failed to get RHOBS logs fetcher: %v", logsFetchErr))
@@ -660,7 +670,9 @@ func (o *contextOptions) generateContextData() (*contextData, []error) {
 					mu.Lock()
 					dataErrors = append(dataErrors, fmt.Errorf("failed to get HCP namespace for RHOBS logs URL: %v", nsErr))
 					mu.Unlock()
-					lokiNamespace = "default"
+					// Don't fall back to "default": for HCP clusters that namespace won't
+					// contain control-plane logs, so a URL would silently show no results.
+					clusterExtID = ""
 				} else {
 					lokiNamespace = hcpNamespace
 				}

--- a/cmd/cluster/context_test.go
+++ b/cmd/cluster/context_test.go
@@ -105,6 +105,70 @@ func TestPrintDynatraceResources(t *testing.T) {
 	}
 }
 
+func TestPrintRhobsResources(t *testing.T) {
+	tests := []struct {
+		name            string
+		data            contextData
+		expectedStrings []string
+		absentStrings   []string
+	}{
+		{
+			name: "both URLs populated",
+			data: contextData{
+				RhobsDashboardURL: "https://grafana.example.com/dashboard",
+				RhobsLogsURL:      "https://grafana.example.com/logs",
+			},
+			expectedStrings: []string{
+				"RHOBS Details",
+				"Cluster Dashboard URL",
+				"https://grafana.example.com/dashboard",
+				"Logs URL",
+				"https://grafana.example.com/logs",
+			},
+			absentStrings: []string{rhobsUnsupportedClusterMsg},
+		},
+		{
+			name: "unsupported cluster type",
+			data: contextData{
+				RhobsDashboardURL: rhobsUnsupportedClusterMsg,
+			},
+			expectedStrings: []string{
+				"RHOBS Details",
+				rhobsUnsupportedClusterMsg,
+			},
+			absentStrings: []string{
+				"Cluster Dashboard URL",
+				"Logs URL",
+			},
+		},
+		{
+			name:            "no data set",
+			data:            contextData{},
+			expectedStrings: []string{"RHOBS Details"},
+			absentStrings: []string{
+				"Cluster Dashboard URL",
+				"Logs URL",
+				rhobsUnsupportedClusterMsg,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printRhobsResources(&tt.data, &buf)
+			output := buf.String()
+
+			for _, expected := range tt.expectedStrings {
+				assert.Contains(t, output, expected, "output should contain %q", expected)
+			}
+			for _, absent := range tt.absentStrings {
+				assert.NotContains(t, output, absent, "output should not contain %q", absent)
+			}
+		})
+	}
+}
+
 func TestSkippableEvent(t *testing.T) {
 	testCases := []struct {
 		eventName string


### PR DESCRIPTION
Add RHOBS details to osdctl cluster context
Display a ">> RHOBS Details" section in the long output of
`osdctl cluster context`, showing a Grafana dashboard URL and a
Grafana logs explore URL for HCP and management clusters.
For HCP clusters, the logs URL correctly uses the management
cluster's external ID as the openshift_cluster_id label and scopes
to the HCP control-plane namespace, working around a bug in
`osdctl rhobs logs` (tracked in #932).
Classic ROSA clusters display "not an HCP or MC Cluster", consistent
with the existing Dynatrace section behavior.

https://redhat.atlassian.net/issues?filter=-1&selectedIssue=[ROSAENG-61492](https://redhat.atlassian.net/browse/ROSAENG-61492)

[ROSAENG-61492]: https://redhat.atlassian.net/browse/ROSAENG-61492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RHOBS dashboard and logs links to the `osdctl cluster context` output.
  * Generates links for supported hosted control plane and management clusters, including correct handling for hosted control plane log URL construction.
  * Adds a dedicated “RHOBS Details” section to the human-readable context view.
  * Displays an explicit message when RHOBS details are unavailable.
* **Tests**
  * Added coverage for RHOBS output rendering across supported, unsupported, and missing-data scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->