### PR TITLE
[ROSAENG-61836]Removed Dynatrae reference from rhobs cluster context

### DIFF
--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -44,8 +44,8 @@ const (
 	shortOutputConfigValue        = "short"
 	longOutputConfigValue         = "long"
 	jsonOutputConfigValue         = "json"
-	delimiter                  = ">> "
-	rhobsUnsupportedClusterMsg = "not an HCP or MC Cluster"
+	delimiter                     = ">> "
+	rhobsUnsupportedClusterMsg    = "not an HCP or MC Cluster"
 )
 
 type contextOptions struct {
@@ -280,9 +280,6 @@ func (o *contextOptions) printLongOutput(data *contextData, w io.Writer) {
 	// Print other helpful links
 	o.printOtherLinks(data, w)
 	fmt.Println()
-
-	// Print RHOBS URLs
-	printRhobsResources(data, w)
 
 	// Print RHOBS URLs
 	printRhobsResources(data, w)
@@ -648,8 +645,8 @@ func (o *contextOptions) generateContextData() (*contextData, []error) {
 				} else {
 					data.RhobsLogsURL = logsURL
 				}
+			}
 		}
-	}
 	}
 
 	GetPagerDutyAlerts := func() {
@@ -1044,7 +1041,6 @@ func printNetworkInfo(data *contextData, w io.Writer) {
 		fmt.Fprintf(w, "Error printing %s: %v\n", name, err)
 	}
 }
-
 
 func printRhobsResources(data *contextData, w io.Writer) {
 	name := "RHOBS Details"

--- a/cmd/cluster/context.go
+++ b/cmd/cluster/context.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -23,7 +22,6 @@ import (
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	v1 "github.com/openshift-online/ocm-sdk-go/servicelogs/v1"
 	backplaneapi "github.com/openshift/backplane-api/pkg/client"
-	"github.com/openshift/osdctl/cmd/dynatrace"
 	"github.com/openshift/osdctl/cmd/rhobs"
 	"github.com/openshift/osdctl/cmd/servicelog"
 	"github.com/openshift/osdctl/pkg/backplane"
@@ -46,8 +44,8 @@ const (
 	shortOutputConfigValue        = "short"
 	longOutputConfigValue         = "long"
 	jsonOutputConfigValue         = "json"
-	delimiter                     = ">> "
-	rhobsUnsupportedClusterMsg    = "not an HCP or MC Cluster"
+	delimiter                  = ">> "
+	rhobsUnsupportedClusterMsg = "not an HCP or MC Cluster"
 )
 
 type contextOptions struct {
@@ -82,10 +80,6 @@ type contextData struct {
 
 	// RegionID (used for region-locked clusters)
 	RegionID string
-
-	// Dynatrace Environment URL and Logs URL
-	DyntraceEnvURL  string
-	DyntraceLogsURL string
 
 	// RHOBS Dashboard URL and Logs URL
 	RhobsDashboardURL string
@@ -287,8 +281,8 @@ func (o *contextOptions) printLongOutput(data *contextData, w io.Writer) {
 	o.printOtherLinks(data, w)
 	fmt.Println()
 
-	// Print Dynatrace URL
-	printDynatraceResources(data, w)
+	// Print RHOBS URLs
+	printRhobsResources(data, w)
 
 	// Print RHOBS URLs
 	printRhobsResources(data, w)
@@ -549,44 +543,6 @@ func (o *contextOptions) generateContextData() (*contextData, []error) {
 		}
 	}
 
-	GetDynatraceDetails := func() {
-		var clusterID string = o.clusterID
-		defer wg.Done()
-		defer utils.StartDelayTracker(o.verbose, "Dynatrace URL").End()
-
-		hcpCluster, err := dynatrace.FetchClusterDetails(clusterID)
-		if err != nil {
-			if errors.Is(err, dynatrace.ErrUnsupportedCluster) {
-				data.DyntraceEnvURL = dynatrace.ErrUnsupportedCluster.Error()
-			} else {
-				mu.Lock()
-				dataErrors = append(dataErrors, fmt.Errorf("failed to acquire cluster details %v", err))
-				mu.Unlock()
-				data.DyntraceEnvURL = "Failed to fetch Dynatrace URL"
-			}
-			return
-		}
-		query, err := dynatrace.GetQuery(hcpCluster, time.Time{}, time.Time{}, 1) // passing nil from/to values to use --since behaviour
-		if err != nil {
-			mu.Lock()
-			dataErrors = append(dataErrors, fmt.Errorf("failed to build query for Dynatrace %v", err))
-			mu.Unlock()
-			data.DyntraceEnvURL = fmt.Sprintf("Failed to build Dynatrace query: %v", err)
-			return
-		}
-		queryTxt := query.Build()
-		data.DyntraceEnvURL = hcpCluster.DynatraceURL
-		logsURL, dtErr := dynatrace.GetLinkToWebConsole(hcpCluster.DynatraceURL, "now()-10h", "now()", queryTxt)
-		if dtErr != nil {
-			mu.Lock()
-			dataErrors = append(dataErrors, fmt.Errorf("failed to get url: %v", dtErr))
-			mu.Unlock()
-		} else {
-			data.DyntraceLogsURL = logsURL
-		}
-
-	}
-
 	GetRhobsDetails := func() {
 		defer wg.Done()
 		defer utils.StartDelayTracker(o.verbose, "RHOBS URLs").End()
@@ -692,8 +648,8 @@ func (o *contextOptions) generateContextData() (*contextData, []error) {
 				} else {
 					data.RhobsLogsURL = logsURL
 				}
-			}
 		}
+	}
 	}
 
 	GetPagerDutyAlerts := func() {
@@ -779,7 +735,6 @@ func (o *contextOptions) generateContextData() (*contextData, []error) {
 		GetHandoverAnnouncements,
 		GetSupportExceptions,
 		GetPagerDutyAlerts,
-		GetDynatraceDetails,
 		GetRhobsDetails,
 		GetBannedUser,
 		GetMigrationInfo,
@@ -1090,37 +1045,6 @@ func printNetworkInfo(data *contextData, w io.Writer) {
 	}
 }
 
-func printDynatraceResources(data *contextData, w io.Writer) {
-	var name string = "Dynatrace Details"
-	fmt.Fprintln(w, delimiter+name)
-
-	links := map[string]string{
-		"Dynatrace Tenant URL": data.DyntraceEnvURL,
-		"Logs App URL":         data.DyntraceLogsURL,
-	}
-
-	// Sort, so it's always a predictable order
-	var keys []string
-	for k := range links {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	table := printer.NewTablePrinter(w, 20, 1, 3, ' ')
-	for _, link := range keys {
-		url := strings.TrimSpace(links[link])
-		if url == dynatrace.ErrUnsupportedCluster.Error() {
-			fmt.Fprintln(w, dynatrace.ErrUnsupportedCluster.Error())
-			break
-		} else if url != "" {
-			table.AddRow([]string{link, url})
-		}
-	}
-
-	if err := table.Flush(); err != nil {
-		fmt.Fprintf(w, "Error printing %s: %v\n", name, err)
-	}
-}
 
 func printRhobsResources(data *contextData, w io.Writer) {
 	name := "RHOBS Details"

--- a/cmd/cluster/context_test.go
+++ b/cmd/cluster/context_test.go
@@ -77,33 +77,6 @@ func TestPrintClusterHeader(t *testing.T) {
 	}
 }
 
-func TestPrintDynatraceResources(t *testing.T) {
-	data := &contextData{
-		DyntraceEnvURL:  "https://dynatrace.com/env",
-		DyntraceLogsURL: "https://dynatrace.com/logs",
-	}
-
-	var buf bytes.Buffer
-	printDynatraceResources(data, &buf)
-	output := buf.String()
-
-	expectedHeader := "Dynatrace Details"
-	expectedLines := []string{
-		"Dynatrace Tenant URL   https://dynatrace.com/env",
-		"Logs App URL           https://dynatrace.com/logs",
-	}
-
-	outputStr := string(output)
-	if !strings.Contains(outputStr, expectedHeader) {
-		t.Errorf("Expected output to contain header:\n%s\nGot:\n%s", expectedHeader, outputStr)
-	}
-
-	for _, expectedLine := range expectedLines {
-		if !strings.Contains(outputStr, expectedLine) {
-			t.Errorf("Expected output to contain:\n%s\nGot:\n%s", expectedLine, outputStr)
-		}
-	}
-}
 
 func TestPrintRhobsResources(t *testing.T) {
 	tests := []struct {
@@ -523,9 +496,7 @@ func TestPrintLongOutput(t *testing.T) {
 		ClusterName:     "ClusterABC",
 		ClusterVersion:  "1.2.3",
 		ClusterID:       "cluster-123",
-		OCMEnv:          "production",
-		DyntraceEnvURL:  "http://dynatrace.example.com",
-		DyntraceLogsURL: "http://logs.dynatrace.example.com",
+		OCMEnv: "production",
 		LimitedSupportReasons: []*v1.LimitedSupportReason{
 			limitedSupportReason1},
 		ServiceLogs: []*v2.LogEntry{serviceLog1, serviceLog2},

--- a/cmd/cluster/context_test.go
+++ b/cmd/cluster/context_test.go
@@ -77,7 +77,6 @@ func TestPrintClusterHeader(t *testing.T) {
 	}
 }
 
-
 func TestPrintRhobsResources(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -493,10 +492,10 @@ func TestPrintLongOutput(t *testing.T) {
 	eventTime := time.Now()
 
 	mockData := &contextData{
-		ClusterName:     "ClusterABC",
-		ClusterVersion:  "1.2.3",
-		ClusterID:       "cluster-123",
-		OCMEnv: "production",
+		ClusterName:    "ClusterABC",
+		ClusterVersion: "1.2.3",
+		ClusterID:      "cluster-123",
+		OCMEnv:         "production",
 		LimitedSupportReasons: []*v1.LimitedSupportReason{
 			limitedSupportReason1},
 		ServiceLogs: []*v2.LogEntry{serviceLog1, serviceLog2},


### PR DESCRIPTION
https://redhat.atlassian.net/issues?filter=-1&selectedIssue=[ROSAENG-61836](https://redhat.atlassian.net/browse/ROSAENG-61836)

Summary
Removes the >> Dynatrace Details section from osdctl cluster context as Dynatrace is being decommissioned.

This includes removing the GetDynatraceDetails goroutine, printDynatraceResources function, the DyntraceEnvURL/DyntraceLogsURL fields from contextData, the dynatrace package import, and the associated test.

RHOBS details were added as a replacement in #933.

Test plan
 osdctl cluster context -C <cluster-id> no longer shows a >> Dynatrace Details section
 Unit tests pass: go test ./cmd/cluster/...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed Dynatrace environment and log links from the `cluster context` output.
  * Cluster context generation no longer retrieves or displays Dynatrace details.
  * RHOBS links remain available in the command output.
  * Updated output validation to reflect the removed Dynatrace information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ROSAENG-61836]: https://redhat.atlassian.net/browse/ROSAENG-61836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ