### PR TITLE
[ROSAENG-61780] Fix osdctl rhobs logs --url for HCP clusters

### DIFF
--- a/cmd/rhobs/fetcher.go
+++ b/cmd/rhobs/fetcher.go
@@ -45,12 +45,34 @@ const (
 type RhobsFetcher struct {
 	clusterId           string
 	clusterExternalId   string
+	mcExternalId        string // MC's external UUID; set for HCP clusters, used for Loki openshift_cluster_id filter
 	clusterName         string
 	IsHostedCluster     bool
 	isManagementCluster bool
 	ocmEnvName          string
 	RhobsCell           string
+	HcpNamespace        string // HCP control-plane namespace on the MC; set for HCP clusters
 	tokenProvider       ocmutils.AccessTokenProvider
+}
+
+// logsClusterExtId returns the cluster external UUID to use in Loki's openshift_cluster_id filter.
+// HCP control-plane logs are indexed in RHOBS under the MC's openshift_cluster_id, not the HCP
+// cluster's own UUID, so for HCP clusters this returns the MC's external UUID.
+func (f *RhobsFetcher) logsClusterExtId() string {
+	if f.IsHostedCluster && f.mcExternalId != "" {
+		return f.mcExternalId
+	}
+	return f.clusterExternalId
+}
+
+// resolveLogsNamespace returns the namespace to use in the Loki stream selector.
+// When the caller has not explicitly set a namespace and the fetcher belongs to an HCP cluster,
+// the HCP control-plane namespace on the MC is returned so that logs are actually found.
+func resolveLogsNamespace(fetcher *RhobsFetcher, namespaceExplicitlySet bool, defaultNamespace string) string {
+	if !namespaceExplicitlySet && fetcher.IsHostedCluster && fetcher.HcpNamespace != "" {
+		return fetcher.HcpNamespace
+	}
+	return defaultNamespace
 }
 
 func getRhobsCellFromConfigMap(ctx context.Context, clusterId string, ocmConn *sdk.Connection, configMapNamespace, configMapName, configMapAnnotationKey string) (string, error) {
@@ -139,6 +161,8 @@ func populateRhobsFetchers(ctx context.Context, clusterKey string, hiveOcmUrl st
 	}
 
 	var monitoredClusterId string
+	var mcExtId string
+	var hcpNamespace string
 	isHcp := cluster.Hypershift().Enabled()
 	isMC := false
 
@@ -148,7 +172,15 @@ func populateRhobsFetchers(ctx context.Context, clusterKey string, hiveOcmUrl st
 			return fmt.Errorf("failed to retrieve management cluster for cluster '%s': %v", cluster.ID(), err)
 		}
 		monitoredClusterId = managementCluster.ID()
+		mcExtId = managementCluster.ExternalID()
 		log.Infof("Cluster %s is managed by MC cluster %s - using the MC cluster for RHOBS cell resolution\n", cluster.ID(), monitoredClusterId)
+
+		hcpNs, nsErr := ocmutils.GetHCPNamespace(cluster.ID())
+		if nsErr != nil {
+			log.Warnf("Failed to get HCP namespace for cluster '%s': %v\n", cluster.ID(), nsErr)
+		} else {
+			hcpNamespace = hcpNs
+		}
 	} else {
 		monitoredClusterId = cluster.ID()
 		isMC, err = ocmutils.IsManagementCluster(cluster.ID())
@@ -220,10 +252,12 @@ func populateRhobsFetchers(ctx context.Context, clusterKey string, hiveOcmUrl st
 	baseFetcher := RhobsFetcher{
 		clusterId:           cluster.ID(),
 		clusterExternalId:   cluster.ExternalID(),
+		mcExternalId:        mcExtId,
 		clusterName:         cluster.Name(),
 		IsHostedCluster:     isHcp,
 		isManagementCluster: isMC,
 		ocmEnvName:          ocmutils.GetCurrentOCMEnv(ocmConn),
+		HcpNamespace:        hcpNamespace,
 	}
 
 	var resolveErr error

--- a/cmd/rhobs/logs_cmd.go
+++ b/cmd/rhobs/logs_cmd.go
@@ -239,7 +239,19 @@ func newCmdLogs() *cobra.Command {
 			}
 
 			if !cmd.Flags().Changed("query") {
-				lokiExpr += fmt.Sprintf(` | openshift_cluster_id = "%s"`, rhobsFetcher.clusterExternalId)
+				if rhobsFetcher.IsHostedCluster {
+					log.Infof("HCP cluster: MC external UUID = %q, HCP namespace = %q\n",
+						rhobsFetcher.mcExternalId, rhobsFetcher.HcpNamespace)
+				}
+				effectiveNs := resolveLogsNamespace(rhobsFetcher, cmd.Flags().Changed("namespace"), namespace)
+				if effectiveNs != namespace {
+					log.Infof("HCP cluster detected - using namespace '%s' for logs query\n", effectiveNs)
+					lokiExpr = strings.Replace(lokiExpr,
+						fmt.Sprintf(`{k8s_namespace_name="%s"}`, namespace),
+						fmt.Sprintf(`{k8s_namespace_name="%s"}`, effectiveNs),
+						1)
+				}
+				lokiExpr += fmt.Sprintf(` | openshift_cluster_id = "%s"`, rhobsFetcher.logsClusterExtId())
 			}
 
 			if isComputingGrafanaUrl {

--- a/cmd/rhobs/logs_test.go
+++ b/cmd/rhobs/logs_test.go
@@ -1,0 +1,226 @@
+package rhobs
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- logsClusterExtId ---
+
+func TestLogsClusterExtId(t *testing.T) {
+	tests := []struct {
+		name              string
+		clusterExternalId string
+		mcExternalId      string
+		isHostedCluster   bool
+		want              string
+	}{
+		{
+			name:              "non-HCP cluster uses its own external ID",
+			clusterExternalId: "cluster-ext-id",
+			mcExternalId:      "",
+			isHostedCluster:   false,
+			want:              "cluster-ext-id",
+		},
+		{
+			name:              "MC cluster uses its own external ID",
+			clusterExternalId: "mc-ext-id",
+			mcExternalId:      "",
+			isHostedCluster:   false,
+			want:              "mc-ext-id",
+		},
+		{
+			name:              "HCP cluster with MC external ID uses MC's UUID",
+			clusterExternalId: "hcp-ext-id",
+			mcExternalId:      "mc-ext-id",
+			isHostedCluster:   true,
+			want:              "mc-ext-id",
+		},
+		{
+			name:              "HCP cluster without MC external ID falls back to own UUID",
+			clusterExternalId: "hcp-ext-id",
+			mcExternalId:      "",
+			isHostedCluster:   true,
+			want:              "hcp-ext-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &RhobsFetcher{
+				clusterExternalId: tt.clusterExternalId,
+				mcExternalId:      tt.mcExternalId,
+				IsHostedCluster:   tt.isHostedCluster,
+			}
+			got := f.logsClusterExtId()
+			if got != tt.want {
+				t.Errorf("logsClusterExtId() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- resolveLogsNamespace ---
+
+func TestResolveLogsNamespace(t *testing.T) {
+	tests := []struct {
+		name                   string
+		isHostedCluster        bool
+		hcpNamespace           string
+		namespaceExplicitlySet bool
+		defaultNamespace       string
+		want                   string
+	}{
+		{
+			name:                   "non-HCP cluster keeps default namespace",
+			isHostedCluster:        false,
+			hcpNamespace:           "",
+			namespaceExplicitlySet: false,
+			defaultNamespace:       "default",
+			want:                   "default",
+		},
+		{
+			name:                   "HCP cluster without HcpNamespace keeps default",
+			isHostedCluster:        true,
+			hcpNamespace:           "",
+			namespaceExplicitlySet: false,
+			defaultNamespace:       "default",
+			want:                   "default",
+		},
+		{
+			name:                   "HCP cluster uses HCP control-plane namespace",
+			isHostedCluster:        true,
+			hcpNamespace:           "ocm-production-abc123-ns",
+			namespaceExplicitlySet: false,
+			defaultNamespace:       "default",
+			want:                   "ocm-production-abc123-ns",
+		},
+		{
+			name:                   "HCP cluster respects explicit namespace override",
+			isHostedCluster:        true,
+			hcpNamespace:           "ocm-production-abc123-ns",
+			namespaceExplicitlySet: true,
+			defaultNamespace:       "custom-ns",
+			want:                   "custom-ns",
+		},
+		{
+			name:                   "non-HCP cluster respects explicit namespace override",
+			isHostedCluster:        false,
+			hcpNamespace:           "",
+			namespaceExplicitlySet: true,
+			defaultNamespace:       "openshift-monitoring",
+			want:                   "openshift-monitoring",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &RhobsFetcher{
+				IsHostedCluster: tt.isHostedCluster,
+				HcpNamespace:    tt.hcpNamespace,
+			}
+			got := resolveLogsNamespace(f, tt.namespaceExplicitlySet, tt.defaultNamespace)
+			if got != tt.want {
+				t.Errorf("resolveLogsNamespace() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- GetGrafanaLogsUrl ---
+
+func TestGetGrafanaLogsUrl(t *testing.T) {
+	f := &RhobsFetcher{
+		RhobsCell:  "https://eu-central-1-0.rhobs.api.openshift.com",
+		ocmEnvName: "production",
+	}
+
+	now := time.Now()
+	start := now.Add(-5 * time.Minute)
+
+	tests := []struct {
+		name           string
+		lokiExpr       string
+		isGoingForward bool
+	}{
+		{
+			name:           "HCP corrected query - backward",
+			lokiExpr:       `{k8s_namespace_name="ocm-production-abc123-ns"} | json json_kind="kind" | json_kind != "Event" | openshift_cluster_id = "mc-ext-uuid"`,
+			isGoingForward: false,
+		},
+		{
+			name:           "MC query - forward",
+			lokiExpr:       `{k8s_namespace_name="default"} | json json_kind="kind" | json_kind != "Event" | openshift_cluster_id = "mc-ext-uuid"`,
+			isGoingForward: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, err := f.GetGrafanaLogsUrl(tt.lokiExpr, start, now, tt.isGoingForward)
+			if err != nil {
+				t.Fatalf("GetGrafanaLogsUrl returned error: %v", err)
+			}
+			if gotURL == "" {
+				t.Fatal("expected non-empty URL")
+			}
+			if !strings.Contains(gotURL, "grafana.app-sre.devshift.net") {
+				t.Errorf("URL should point to Grafana, got: %s", gotURL)
+			}
+			if !strings.Contains(gotURL, "explore") {
+				t.Errorf("URL should be an explore URL, got: %s", gotURL)
+			}
+		})
+	}
+}
+
+// TestGetGrafanaLogsUrl_EncodesLokiExpr verifies that the Loki expression ends up
+// URL-encoded in the produced Grafana URL (not literally embedded as plain text).
+func TestGetGrafanaLogsUrl_EncodesLokiExpr(t *testing.T) {
+	f := &RhobsFetcher{
+		RhobsCell:  "https://eu-central-1-0.rhobs.api.openshift.com",
+		ocmEnvName: "production",
+	}
+
+	expr := `{k8s_namespace_name="ocm-production-abc123-ns"} | openshift_cluster_id = "mc-uuid"`
+	now := time.Now()
+
+	gotURL, err := f.GetGrafanaLogsUrl(expr, now.Add(-5*time.Minute), now, false)
+	if err != nil {
+		t.Fatalf("GetGrafanaLogsUrl returned error: %v", err)
+	}
+
+	// The raw expression must not appear verbatim: it should be JSON/URL-encoded.
+	if strings.Contains(gotURL, `{k8s_namespace_name=`) {
+		t.Errorf("Loki expression appears unencoded in URL: %s", gotURL)
+	}
+}
+
+// TestHcpLogsQueryDiffersFromStandard verifies the two code-paths produce different
+// Grafana URLs — confirming that the HCP fix actually changes the output.
+func TestHcpLogsQueryDiffersFromStandard(t *testing.T) {
+	f := &RhobsFetcher{
+		RhobsCell:  "https://us-east-1-1.rhobs.api.openshift.com",
+		ocmEnvName: "production",
+	}
+
+	now := time.Now()
+	start := now.Add(-5 * time.Minute)
+
+	brokenExpr := `{k8s_namespace_name="default"} | json json_kind="kind" | json_kind != "Event" | openshift_cluster_id = "hcp-ext-uuid"`
+	fixedExpr := `{k8s_namespace_name="ocm-production-abc123-ns"} | json json_kind="kind" | json_kind != "Event" | openshift_cluster_id = "mc-ext-uuid"`
+
+	brokenURL, err := f.GetGrafanaLogsUrl(brokenExpr, start, now, false)
+	if err != nil {
+		t.Fatalf("broken URL generation failed: %v", err)
+	}
+	fixedURL, err := f.GetGrafanaLogsUrl(fixedExpr, start, now, false)
+	if err != nil {
+		t.Fatalf("fixed URL generation failed: %v", err)
+	}
+
+	if brokenURL == fixedURL {
+		t.Error("broken and fixed Loki expressions should produce different Grafana URLs")
+	}
+}

--- a/cmd/rhobs/mcp_tools.go
+++ b/cmd/rhobs/mcp_tools.go
@@ -231,7 +231,7 @@ func handleLogs(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolRes
 		if containRegex != "" {
 			lokiExpr += fmt.Sprintf(` |~ "%s"`, containRegex)
 		}
-		lokiExpr += fmt.Sprintf(` | openshift_cluster_id = "%s"`, fetcher.clusterExternalId)
+		lokiExpr += fmt.Sprintf(` | openshift_cluster_id = "%s"`, fetcher.logsClusterExtId())
 	}
 
 	now := time.Now()

--- a/cmd/rhobs/mcp_tools.go
+++ b/cmd/rhobs/mcp_tools.go
@@ -227,7 +227,8 @@ func handleLogs(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolRes
 	if rawQuery != "" {
 		lokiExpr = rawQuery
 	} else {
-		lokiExpr = fmt.Sprintf(`{k8s_namespace_name="%s"}`, namespace)
+		effectiveNs := resolveLogsNamespace(fetcher, namespace != "default" && namespace != "", namespace)
+		lokiExpr = fmt.Sprintf(`{k8s_namespace_name="%s"}`, effectiveNs)
 		if containRegex != "" {
 			lokiExpr += fmt.Sprintf(` |~ "%s"`, containRegex)
 		}


### PR DESCRIPTION
https://redhat.atlassian.net/issues?filter=-1&selectedIssue=[ROSAENG-61780](https://redhat.atlassian.net/browse/ROSAENG-61780)

Summary

osdctl rhobs logs -C <hcp-cluster-id> --url was generating a Grafana URL that returned no logs when opened. This PR fixes the two root causes.

Root cause

When given an HCP cluster ID, the command correctly resolved the RHOBS cell via the management cluster (MC), but built the wrong Loki query:

openshift_cluster_id was set to the HCP cluster's external UUID. HCP control-plane logs are indexed in RHOBS under the MC's openshift_cluster_id, not the HCP cluster's.
k8s_namespace_name defaulted to "default". HCP control-plane logs live in the HCP namespace on the MC (e.g. ocm-production-<hcp-id>-...), not in default.
Broken query (before):

{k8s_namespace_name="default"} | json json_kind="kind" | json_kind != "Event" | openshift_cluster_id = "<hcp-external-uuid>"
Fixed query (after):

{k8s_namespace_name="ocm-production-<hcp-id>-<suffix>"} | json json_kind="kind" | json_kind != "Event" | openshift_cluster_id = "<mc-external-uuid>"
Changes

cmd/rhobs/fetcher.go — added mcExternalId and HcpNamespace fields to RhobsFetcher. For HCP clusters, populateRhobsFetchers now also resolves the MC's external UUID (GetManagementCluster(...).ExternalID()) and the HCP control-plane namespace (GetHCPNamespace). Two helper functions are extracted: logsClusterExtId() and resolveLogsNamespace().
cmd/rhobs/logs_cmd.go — uses the helpers to apply the correct namespace and cluster UUID when building the Loki query for HCP clusters. Explicit -n and --query flags are always respected and bypass the auto-resolution. An INFO log line prints the resolved MC UUID and HCP namespace so the behaviour is transparent.
cmd/rhobs/mcp_tools.go — same fix applied to the MCP logs tool.
cmd/rhobs/logs_test.go — 10 unit tests covering all branches of logsClusterExtId(), resolveLogsNamespace(), and GetGrafanaLogsUrl().
Testing

Tested manually against a live HCP cluster. The generated URL now shows logs in Grafana. 

[ROSAENG-61780]: https://redhat.atlassian.net/browse/ROSAENG-61780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log retrieval for hosted (HCP) clusters by using the correct management-cluster identifier when building Loki queries.
  * Automatically resolves the effective logs namespace for hosted clusters when no namespace is provided.
  * Kept existing behavior for explicitly specified namespaces, with consistent query construction across CLI and tool-based workflows.

* **Tests**
  * Added/expanded tests covering hosted-cluster identifier selection, namespace resolution rules, Loki expression encoding, and Grafana URL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->