### PR TITLE
chore: add Dependabot cooldown (~3 days)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,7 @@ updates:
       - dependency-name: "github.com/openshift/backplane-cli"
     schedule:
       interval: 'weekly'
+    # Align with MintMaker minimumReleaseAge (~3 days) for supply-chain delay
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Add Dependabot `cooldown.default-days: 3` for gomod updates
- Aligns Path B version updates with MintMaker `minimumReleaseAge` (~3 days) for supply-chain delay
- Does not change schedule, allow-list, or auto-merge workflow

## Test plan
- [ ] Confirm `dependabot.yml` validates in GitHub Dependabot settings / next Dependabot run
- [ ] Confirm only cooldown was added (no other config drift)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update scheduling to wait three days before proposing Go module updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->