### PR TITLE
Fix flaky link_validator test by using .invalid TLD

### DIFF
--- a/pkg/link_validator/link_validator_test.go
+++ b/pkg/link_validator/link_validator_test.go
@@ -185,7 +185,7 @@ func TestLinkValidator_ValidateLinks(t *testing.T) {
 		},
 		{
 			name:             "message with network error URL",
-			message:          "Check http://this-domain-should-not-exist-12345.com",
+			message:          "Check http://this-domain-should-not-exist-12345.invalid",
 			expectError:      true,
 			expectedWarnings: 0,
 		},


### PR DESCRIPTION
## Summary
- The `TestLinkValidator_ValidateLinks/message_with_network_error_URL` test was failing because the fake `.com` domain it relied on started resolving
- Switched the test URL from `http://this-domain-should-not-exist-12345.com` to `http://this-domain-should-not-exist-12345.invalid`, using the IANA-reserved `.invalid` TLD (RFC 2606) which is guaranteed to never resolve

## Test plan
- [x] `go test ./pkg/link_validator/ -v` passes
- [x] All other tests unaffected (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated link validation test data to use a guaranteed-invalid domain for network error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->