### PR TITLE
ROSAENG-65395: add --rhobs-cell flag to rhobs logs for direct cell queries

### DIFF
--- a/cmd/rhobs/fetcher.go
+++ b/cmd/rhobs/fetcher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -304,13 +305,27 @@ func CreateRhobsFetcher(ctx context.Context, clusterKey string, usage RhobsFetch
 }
 
 func CreateRhobsFetcherFromCell(rhobsCell string) (*RhobsFetcher, error) {
+	parsed, err := url.Parse(rhobsCell)
+	if err != nil {
+		return nil, fmt.Errorf("invalid RHOBS cell URL '%s': %v", rhobsCell, err)
+	}
+	if parsed.Scheme != "https" || parsed.User != nil ||
+		(parsed.Path != "" && parsed.Path != "/") ||
+		parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" ||
+		parsed.Port() != "" {
+		return nil, fmt.Errorf("invalid RHOBS cell URL '%s': must be https with no path, query, fragment, port, or credentials", rhobsCell)
+	}
+
+	host := parsed.Hostname()
 	envName := ""
 
-	if strings.HasSuffix(rhobsCell, ".rhobs.api.openshift.com") {
+	prodSuffix := ".rhobs.api.openshift.com"
+	if strings.HasSuffix(host, prodSuffix) && len(host) > len(prodSuffix) {
 		envName = "production"
 	} else {
 		for _, currentEnvName := range []string{"stage", "integration"} {
-			if strings.HasSuffix(rhobsCell, ".rhobs.api."+currentEnvName+".openshift.com") {
+			suffix := ".rhobs.api." + currentEnvName + ".openshift.com"
+			if strings.HasSuffix(host, suffix) && len(host) > len(suffix) {
 				envName = currentEnvName
 			}
 		}
@@ -320,9 +335,10 @@ func CreateRhobsFetcherFromCell(rhobsCell string) (*RhobsFetcher, error) {
 		return nil, fmt.Errorf("failed to determine OCM environment from RHOBS cell URL '%s'", rhobsCell)
 	}
 
+	canonicalUrl := "https://" + host
 	return &RhobsFetcher{
 		ocmEnvName: envName,
-		RhobsCell:  rhobsCell,
+		RhobsCell:  canonicalUrl,
 	}, nil
 }
 

--- a/cmd/rhobs/logs_cmd.go
+++ b/cmd/rhobs/logs_cmd.go
@@ -55,13 +55,16 @@ func newCmdLogs() *cobra.Command {
 	var outputFormatStr string
 	var isPrintingTimestamp bool
 	var printedFields []string
+	var rhobsCell string
 
 	cmd := &cobra.Command{
 		Use:   "logs [pod]",
-		Short: "Fetch logs from RHOBS for a given cluster",
-		Long: "Fetch logs from RHOBS for a given cluster. " +
+		Short: "Fetch logs from RHOBS for a given cluster or cell",
+		Long: "Fetch logs from RHOBS for a given cluster or RHOBS cell. " +
 			"The cluster can be a management cluster (MC) or whatever cluster sending logs to RHOBS; " +
 			"the command works as if the management cluster ID was passed if given a hosted cluster (HCP) ID. " +
+			"Alternatively, use --rhobs-cell to query a specific RHOBS cell directly without a cluster ID " +
+			"(useful for app-sre services like Clusters Service that send logs to the global cell). " +
 			"By default, logs from all the pods in the given namespace are returned but it is possible to specify " +
 			"a single pod as an argument or filter pods using their labels. Logs themselves can be also filtered " +
 			"to only keep the ones containing a given regexp (--contain-regex option) or a given log level (--level option).",
@@ -71,6 +74,10 @@ func newCmdLogs() *cobra.Command {
 
 			if isOpeningGrafanaUrl && !isComputingGrafanaUrl {
 				return fmt.Errorf("--browser can only be set if --url is set")
+			}
+
+			if cmd.Flags().Changed("rhobs-cell") && cmd.Parent().PersistentFlags().Changed("cluster-id") {
+				return fmt.Errorf("--rhobs-cell and --cluster-id options cannot be used together")
 			}
 
 			if cmd.Flags().Changed("query") {
@@ -233,12 +240,17 @@ func newCmdLogs() *cobra.Command {
 
 			cmd.SilenceUsage = true
 
-			rhobsFetcher, err := CreateRhobsFetcher(cmd.Context(), commonOptions.clusterId, RhobsFetchForLogs, commonOptions.hiveOcmUrl)
+			var rhobsFetcher *RhobsFetcher
+			if cmd.Flags().Changed("rhobs-cell") {
+				rhobsFetcher, err = CreateRhobsFetcherFromCell(rhobsCell)
+			} else {
+				rhobsFetcher, err = CreateRhobsFetcher(cmd.Context(), commonOptions.clusterId, RhobsFetchForLogs, commonOptions.hiveOcmUrl)
+			}
 			if err != nil {
 				return err
 			}
 
-			if !cmd.Flags().Changed("query") {
+			if !cmd.Flags().Changed("query") && !cmd.Flags().Changed("rhobs-cell") {
 				if rhobsFetcher.IsHostedCluster {
 					log.Infof("HCP cluster: MC external UUID = %q, HCP namespace = %q\n",
 						rhobsFetcher.mcExternalId, rhobsFetcher.HcpNamespace)
@@ -337,6 +349,9 @@ func newCmdLogs() *cobra.Command {
 		`flag can be repeated / values can also be aggregated with one flag using the comma as separator - possible values: "k8s_namespace_name", "k8s_pod_name", "k8s_container_name" - `+
 		`use the "json" output format to know about all possible fields - exclusive with --url`)
 	cmd.MarkFlagsMutuallyExclusive("field", "url")
+
+	cmd.Flags().StringVar(&rhobsCell, "rhobs-cell", "", "RHOBS cell URL (e.g., https://us-east-1-0.rhobs.api.stage.openshift.com) - "+
+		"query logs directly without a cluster ID - exclusive with --cluster-id")
 
 	return cmd
 }

--- a/cmd/rhobs/logs_test.go
+++ b/cmd/rhobs/logs_test.go
@@ -128,6 +128,125 @@ func TestResolveLogsNamespace(t *testing.T) {
 	}
 }
 
+// --- CreateRhobsFetcherFromCell ---
+
+func TestCreateRhobsFetcherFromCell(t *testing.T) {
+	tests := []struct {
+		name      string
+		cellUrl   string
+		wantEnv   string
+		wantError bool
+	}{
+		{
+			name:    "production cell",
+			cellUrl: "https://us-east-1-0.rhobs.api.openshift.com",
+			wantEnv: "production",
+		},
+		{
+			name:    "stage cell",
+			cellUrl: "https://us-east-1-0.rhobs.api.stage.openshift.com",
+			wantEnv: "stage",
+		},
+		{
+			name:    "integration cell",
+			cellUrl: "https://eu-central-1-0.rhobs.api.integration.openshift.com",
+			wantEnv: "integration",
+		},
+		{
+			name:      "invalid cell URL",
+			cellUrl:   "https://invalid.example.com",
+			wantError: true,
+		},
+		{
+			name:      "URL with query string bypass",
+			cellUrl:   "https://attacker.invalid/?x=.rhobs.api.openshift.com",
+			wantError: true,
+		},
+		{
+			name:      "URL with path bypass",
+			cellUrl:   "https://attacker.invalid/path.rhobs.api.openshift.com",
+			wantError: true,
+		},
+		{
+			name:      "URL with userinfo",
+			cellUrl:   "https://user:pass@us-east-1-0.rhobs.api.stage.openshift.com",
+			wantError: true,
+		},
+		{
+			name:      "non-https scheme",
+			cellUrl:   "http://us-east-1-0.rhobs.api.stage.openshift.com",
+			wantError: true,
+		},
+		{
+			name:      "URL with trailing empty query",
+			cellUrl:   "https://us-east-1-0.rhobs.api.stage.openshift.com?",
+			wantError: true,
+		},
+		{
+			name:      "URL with custom port",
+			cellUrl:   "https://us-east-1-0.rhobs.api.stage.openshift.com:8443",
+			wantError: true,
+		},
+		{
+			name:      "URL with default port",
+			cellUrl:   "https://us-east-1-0.rhobs.api.stage.openshift.com:443",
+			wantError: true,
+		},
+		{
+			name:      "bare production suffix",
+			cellUrl:   "https://.rhobs.api.openshift.com",
+			wantError: true,
+		},
+		{
+			name:      "bare stage suffix",
+			cellUrl:   "https://.rhobs.api.stage.openshift.com",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fetcher, err := CreateRhobsFetcherFromCell(tt.cellUrl)
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected error for invalid cell URL")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if fetcher.ocmEnvName != tt.wantEnv {
+				t.Errorf("ocmEnvName = %q, want %q", fetcher.ocmEnvName, tt.wantEnv)
+			}
+			if fetcher.RhobsCell != tt.cellUrl {
+				t.Errorf("RhobsCell = %q, want %q", fetcher.RhobsCell, tt.cellUrl)
+			}
+			if fetcher.clusterExternalId != "" {
+				t.Error("clusterExternalId should be empty for cell-based fetcher")
+			}
+			if fetcher.clusterId != "" {
+				t.Error("clusterId should be empty for cell-based fetcher")
+			}
+		})
+	}
+}
+
+// --- CLI --rhobs-cell flag ---
+
+func TestLogsCommand_RhobsCellFlag(t *testing.T) {
+	cmd := newCmdLogs()
+
+	// Verify --rhobs-cell flag exists
+	flag := cmd.Flags().Lookup("rhobs-cell")
+	if flag == nil {
+		t.Fatal("--rhobs-cell flag not found on logs command")
+	}
+	if flag.DefValue != "" {
+		t.Errorf("--rhobs-cell default should be empty, got %q", flag.DefValue)
+	}
+}
+
 // --- GetGrafanaLogsUrl ---
 
 func TestGetGrafanaLogsUrl(t *testing.T) {

--- a/cmd/rhobs/mcp_helpers.go
+++ b/cmd/rhobs/mcp_helpers.go
@@ -62,6 +62,32 @@ func getCachedFetcher(ctx context.Context, clusterId string, usage RhobsFetchUsa
 	return v.(*RhobsFetcher), nil
 }
 
+func getCachedFetcherFromCell(rhobsCell string) (*RhobsFetcher, error) {
+	key := "cell:" + rhobsCell
+	if cached, ok := fetcherCache.Load(key); ok {
+		return cached.(*RhobsFetcher), nil
+	}
+
+	v, err, _ := fetcherInit.Do(key, func() (interface{}, error) {
+		if cached, ok := fetcherCache.Load(key); ok {
+			return cached, nil
+		}
+		if err := quickVaultCheck(); err != nil {
+			return nil, err
+		}
+		fetcher, err := CreateRhobsFetcherFromCell(rhobsCell)
+		if err != nil {
+			return nil, err
+		}
+		actual, _ := fetcherCache.LoadOrStore(key, fetcher)
+		return actual, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.(*RhobsFetcher), nil
+}
+
 func mcpResultJSON(data interface{}) (*mcp.CallToolResult, error) {
 	jsonData, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {

--- a/cmd/rhobs/mcp_test.go
+++ b/cmd/rhobs/mcp_test.go
@@ -502,10 +502,10 @@ func TestHandleLogs_MissingParams(t *testing.T) {
 		args        map[string]interface{}
 		expectedMsg string
 	}{
-		{"no args", map[string]interface{}{}, "cluster_id is required"},
+		{"no args", map[string]interface{}{}, "either cluster_id or rhobs_cell is required"},
 		{"only cluster", map[string]interface{}{"cluster_id": "test"}, "either namespace or query is required"},
-		{"missing cluster", map[string]interface{}{"namespace": "default"}, "cluster_id is required"},
-		{"empty cluster", map[string]interface{}{"cluster_id": "", "namespace": "default"}, "cluster_id is required"},
+		{"missing cluster", map[string]interface{}{"namespace": "default"}, "either cluster_id or rhobs_cell is required"},
+		{"empty cluster", map[string]interface{}{"cluster_id": "", "namespace": "default"}, "either cluster_id or rhobs_cell is required"},
 		{"no namespace or query", map[string]interface{}{"cluster_id": "test", "since": "5m"}, "either namespace or query is required"},
 	}
 
@@ -661,6 +661,113 @@ func TestHandleLogs_NamespaceWithRegex(t *testing.T) {
 	if !isToolError(result) {
 		t.Error("expected fetcher error")
 	}
+}
+
+// --- handleLogs rhobs_cell tests ---
+
+func TestHandleLogs_RhobsCellMutualExclusivity(t *testing.T) {
+	req := makeRequest("rhobs_logs", map[string]interface{}{
+		"cluster_id": "test-cluster",
+		"rhobs_cell": "https://us-east-1-0.rhobs.api.stage.openshift.com",
+		"namespace":  "default",
+	})
+	result, err := handleLogs(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler returned Go error: %v", err)
+	}
+	if !isToolError(result) {
+		t.Error("expected tool error for mutual exclusivity")
+	}
+	if got := getResultText(result); got != "cluster_id and rhobs_cell are mutually exclusive" {
+		t.Errorf("error = %q, want %q", got, "cluster_id and rhobs_cell are mutually exclusive")
+	}
+}
+
+func TestHandleLogs_RhobsCellWithoutNamespace(t *testing.T) {
+	req := makeRequest("rhobs_logs", map[string]interface{}{
+		"rhobs_cell": "https://us-east-1-0.rhobs.api.stage.openshift.com",
+	})
+	result, err := handleLogs(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler returned Go error: %v", err)
+	}
+	if !isToolError(result) {
+		t.Error("expected tool error for missing namespace")
+	}
+	if got := getResultText(result); got != "either namespace or query is required" {
+		t.Errorf("error = %q, want %q", got, "either namespace or query is required")
+	}
+}
+
+func TestHandleLogs_RhobsCellInvalidUrl(t *testing.T) {
+	req := makeRequest("rhobs_logs", map[string]interface{}{
+		"rhobs_cell": "https://invalid.example.com",
+		"namespace":  "uhc-stage",
+	})
+	result, err := handleLogs(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler returned Go error: %v", err)
+	}
+	if !isToolError(result) {
+		t.Error("expected tool error for invalid cell URL")
+	}
+}
+
+func TestHandleLogs_RhobsCellOnlyParam(t *testing.T) {
+	req := makeRequest("rhobs_logs", map[string]interface{}{
+		"rhobs_cell": "https://us-east-1-0.rhobs.api.stage.openshift.com",
+		"namespace":  "uhc-stage",
+	})
+	result, err := handleLogs(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler returned Go error: %v", err)
+	}
+	// Will fail at vault check, but confirms it gets past validation
+	if !isToolError(result) {
+		t.Skip("expected vault/fetcher error but got success (vault may be configured)")
+	}
+}
+
+func TestHandleLogs_RhobsCellSchemaHasProperty(t *testing.T) {
+	s := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0.0"}, nil)
+	registerMcpTools(s)
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.Run(ctx, serverTransport) }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0.0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect failed: %v", err)
+	}
+	defer session.Close()
+
+	result, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+
+	for _, tool := range result.Tools {
+		if tool.Name != "rhobs_logs" {
+			continue
+		}
+		schemaBytes, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("failed to marshal schema: %v", err)
+		}
+		var schema map[string]interface{}
+		if err := json.Unmarshal(schemaBytes, &schema); err != nil {
+			t.Fatalf("schema is not valid JSON: %v", err)
+		}
+		props := schema["properties"].(map[string]interface{})
+		if _, ok := props["rhobs_cell"]; !ok {
+			t.Error("rhobs_logs schema missing rhobs_cell property")
+		}
+		return
+	}
+	t.Fatal("rhobs_logs tool not found")
 }
 
 // --- handleAlerts validation tests ---
@@ -821,19 +928,20 @@ func TestRegisterMcpTools_SchemaValidation(t *testing.T) {
 				t.Error("missing cluster_id property")
 			}
 
-			// All tools should require cluster_id
-			required, ok := schema["required"].([]interface{})
-			if !ok {
-				t.Fatal("missing required array")
-			}
-			hasClusterId := false
-			for _, r := range required {
-				if r == "cluster_id" {
-					hasClusterId = true
+			// Tools that require cluster_id should list it in required
+			// (rhobs_logs does not require it since rhobs_cell is an alternative)
+			if required, ok := schema["required"].([]interface{}); ok {
+				hasClusterId := false
+				for _, r := range required {
+					if r == "cluster_id" {
+						hasClusterId = true
+					}
 				}
-			}
-			if !hasClusterId {
-				t.Error("cluster_id should be required")
+				if tool.Name != "rhobs_logs" && !hasClusterId {
+					t.Error("cluster_id should be required")
+				}
+			} else if tool.Name != "rhobs_logs" {
+				t.Fatal("missing required array")
 			}
 		})
 	}

--- a/cmd/rhobs/mcp_tools.go
+++ b/cmd/rhobs/mcp_tools.go
@@ -57,19 +57,21 @@ func registerMcpTools(s *mcp.Server) {
 		Description: "Query RHOBS Loki logs for ROSA HCP infrastructure. " +
 			"Covers HCP hosted clusters, Management Clusters (MC), and Service Clusters (SC). " +
 			"Accepts any cluster ID; HCP IDs are automatically resolved to their parent MC. " +
-			"The correct RHOBS cell is resolved automatically.",
+			"The correct RHOBS cell is resolved automatically. " +
+			"Alternatively, use rhobs_cell to query a specific cell directly without a cluster ID " +
+			"(useful for app-sre services like Clusters Service that send logs to the global cell).",
 		Annotations: readOnlyAnnotations,
 		InputSchema: json.RawMessage(`{
 			"type": "object",
 			"properties": {
-				"cluster_id":     {"type": "string", "description": "Cluster ID or name (HCP, MC, or SC). HCP IDs auto-resolve to their parent MC."},
+				"cluster_id":     {"type": "string", "description": "Cluster ID or name (HCP, MC, or SC). HCP IDs auto-resolve to their parent MC. Exclusive with rhobs_cell."},
+				"rhobs_cell":     {"type": "string", "description": "RHOBS cell URL (e.g., https://us-east-1-0.rhobs.api.stage.openshift.com). Query logs directly without a cluster ID. No openshift_cluster_id filter is applied. Exclusive with cluster_id."},
 				"namespace":      {"type": "string", "description": "Kubernetes namespace. Required unless query is set."},
 				"query":          {"type": "string", "description": "Raw LogQL expression (overrides namespace)"},
 				"contain_regex":  {"type": "string", "description": "Server-side regex filter (e.g., (?i)(error|timeout))"},
 				"since":          {"type": "string", "description": "Duration string (e.g., 1h, 30m). Default: 5m"},
 				"limit":          {"type": "number", "description": "Max log entries. Default: 500, max: 10000"}
-			},
-			"required": ["cluster_id"]
+			}
 		}`),
 		OutputSchema: json.RawMessage(`{
 			"type": "object",
@@ -191,14 +193,18 @@ func handleMetrics(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallTool
 func handleLogs(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := getArgs(req)
 	clusterId := getStringArg(args, "cluster_id", "")
+	rhobsCell := getStringArg(args, "rhobs_cell", "")
 	namespace := getStringArg(args, "namespace", "")
 	rawQuery := getStringArg(args, "query", "")
 	containRegex := getStringArg(args, "contain_regex", "")
 	sinceStr := getStringArg(args, "since", "5m")
 	limit := getIntArg(args, "limit", 500)
 
-	if clusterId == "" {
-		return mcpError("cluster_id is required")
+	if clusterId == "" && rhobsCell == "" {
+		return mcpError("either cluster_id or rhobs_cell is required")
+	}
+	if clusterId != "" && rhobsCell != "" {
+		return mcpError("cluster_id and rhobs_cell are mutually exclusive")
 	}
 	if namespace == "" && rawQuery == "" {
 		return mcpError("either namespace or query is required")
@@ -218,7 +224,12 @@ func handleLogs(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolRes
 		return mcpError("'since' must be greater than 0")
 	}
 
-	fetcher, err := getCachedFetcher(ctx, clusterId, RhobsFetchForLogs)
+	var fetcher *RhobsFetcher
+	if rhobsCell != "" {
+		fetcher, err = getCachedFetcherFromCell(rhobsCell)
+	} else {
+		fetcher, err = getCachedFetcher(ctx, clusterId, RhobsFetchForLogs)
+	}
 	if err != nil {
 		return mcpError("Failed to initialize RHOBS fetcher: %v", err)
 	}
@@ -227,12 +238,17 @@ func handleLogs(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolRes
 	if rawQuery != "" {
 		lokiExpr = rawQuery
 	} else {
-		effectiveNs := resolveLogsNamespace(fetcher, namespace != "default" && namespace != "", namespace)
+		effectiveNs := namespace
+		if rhobsCell == "" {
+			effectiveNs = resolveLogsNamespace(fetcher, namespace != "default" && namespace != "", namespace)
+		}
 		lokiExpr = fmt.Sprintf(`{k8s_namespace_name="%s"}`, effectiveNs)
 		if containRegex != "" {
 			lokiExpr += fmt.Sprintf(` |~ "%s"`, containRegex)
 		}
-		lokiExpr += fmt.Sprintf(` | openshift_cluster_id = "%s"`, fetcher.logsClusterExtId())
+		if rhobsCell == "" {
+			lokiExpr += fmt.Sprintf(` | openshift_cluster_id = "%s"`, fetcher.logsClusterExtId())
+		}
 	}
 
 	now := time.Now()

--- a/cmd/rhobs/root_cmd.go
+++ b/cmd/rhobs/root_cmd.go
@@ -24,6 +24,15 @@ func NewCmdRhobs() *cobra.Command {
 					return nil
 				}
 			}
+			viper.SetDefault(utils.VaultAddrKey, "https://vault.devshift.net/")
+			viper.SetDefault("rhobs_integration_vault_path", "osd-sre/rhobs/sd-sre-integration-creds")
+			viper.SetDefault("rhobs_stage_vault_path", "osd-sre/rhobs/sd-sre-stage-creds")
+			viper.SetDefault("rhobs_production_vault_path", "osd-sre/rhobs/sd-sre-prod-creds")
+
+			if rhobsCellFlag := cmd.Flags().Lookup("rhobs-cell"); rhobsCellFlag != nil && rhobsCellFlag.Changed && rhobsCellFlag.Value.String() != "" {
+				return nil
+			}
+
 			if commonOptions.clusterId == "" {
 				var err error
 
@@ -32,12 +41,6 @@ func NewCmdRhobs() *cobra.Command {
 					return err
 				}
 			}
-
-			// Default config
-			viper.SetDefault(utils.VaultAddrKey, "https://vault.devshift.net/")
-			viper.SetDefault("rhobs_integration_vault_path", "osd-sre/rhobs/sd-sre-integration-creds")
-			viper.SetDefault("rhobs_stage_vault_path", "osd-sre/rhobs/sd-sre-stage-creds")
-			viper.SetDefault("rhobs_production_vault_path", "osd-sre/rhobs/sd-sre-prod-creds")
 
 			return nil
 		},

--- a/docs/README.md
+++ b/docs/README.md
@@ -152,7 +152,7 @@
       - `get` - List RHOBS cell silences
   - `cell` - Get the RHOBS cell for a given cluster
   - `hcp-dashboard [dashboard-name]` - Get the HCP dashboard URL for a given HCP cluster
-  - `logs [pod]` - Fetch logs from RHOBS for a given cluster
+  - `logs [pod]` - Fetch logs from RHOBS for a given cluster or cell
   - `mcp` - RHOBS MCP server for AI agent integration
     - `config` - Print MCP client configuration JSON
     - `server` - Start the RHOBS MCP server
@@ -4569,7 +4569,7 @@ osdctl rhobs hcp-dashboard [dashboard-name] [flags]
 
 ### osdctl rhobs logs
 
-Fetch logs from RHOBS for a given cluster. The cluster can be a management cluster (MC) or whatever cluster sending logs to RHOBS; the command works as if the management cluster ID was passed if given a hosted cluster (HCP) ID. By default, logs from all the pods in the given namespace are returned but it is possible to specify a single pod as an argument or filter pods using their labels. Logs themselves can be also filtered to only keep the ones containing a given regexp (--contain-regex option) or a given log level (--level option).
+Fetch logs from RHOBS for a given cluster or RHOBS cell. The cluster can be a management cluster (MC) or whatever cluster sending logs to RHOBS; the command works as if the management cluster ID was passed if given a hosted cluster (HCP) ID. Alternatively, use --rhobs-cell to query a specific RHOBS cell directly without a cluster ID (useful for app-sre services like Clusters Service that send logs to the global cell). By default, logs from all the pods in the given namespace are returned but it is possible to specify a single pod as an argument or filter pods using their labels. Logs themselves can be also filtered to only keep the ones containing a given regexp (--contain-regex option) or a given log level (--level option).
 
 ```
 osdctl rhobs logs [pod] [flags]
@@ -4598,6 +4598,7 @@ osdctl rhobs logs [pod] [flags]
       --not-contain-regex stringArray   Regular expression the log message must not contain - flag can be repeated
   -o, --output string                   Format of the output - allowed values: "text", "csv" or "json" - exclusive with --url (default "text")
   -q, --query string                    LogQL expression - exclusive with many other flags
+      --rhobs-cell string               RHOBS cell URL (e.g., https://us-east-1-0.rhobs.api.stage.openshift.com) - query logs directly without a cluster ID - exclusive with --cluster-id
   -l, --selector string                 Label selector for filtering pods - exclusive with the pod argument
       --since duration                  Only return logs newer than a relative duration (e.g. 1h, 30m) - exclusive with --start-time & --end-time
   -S, --skip-version-check              skip checking to see if this is the most recent release

--- a/docs/osdctl_rhobs.md
+++ b/docs/osdctl_rhobs.md
@@ -22,7 +22,7 @@ RHOBS.next related utilities
 * [osdctl rhobs alerts](osdctl_rhobs_alerts.md)	 - List or silence RHOBS alerts
 * [osdctl rhobs cell](osdctl_rhobs_cell.md)	 - Get the RHOBS cell for a given cluster
 * [osdctl rhobs hcp-dashboard](osdctl_rhobs_hcp-dashboard.md)	 - Get the HCP dashboard URL for a given HCP cluster
-* [osdctl rhobs logs](osdctl_rhobs_logs.md)	 - Fetch logs from RHOBS for a given cluster
+* [osdctl rhobs logs](osdctl_rhobs_logs.md)	 - Fetch logs from RHOBS for a given cluster or cell
 * [osdctl rhobs mcp](osdctl_rhobs_mcp.md)	 - RHOBS MCP server for AI agent integration
 * [osdctl rhobs metrics](osdctl_rhobs_metrics.md)	 - Fetch metrics from RHOBS for a given cluster
 

--- a/docs/osdctl_rhobs_logs.md
+++ b/docs/osdctl_rhobs_logs.md
@@ -1,10 +1,10 @@
 ## osdctl rhobs logs
 
-Fetch logs from RHOBS for a given cluster
+Fetch logs from RHOBS for a given cluster or cell
 
 ### Synopsis
 
-Fetch logs from RHOBS for a given cluster. The cluster can be a management cluster (MC) or whatever cluster sending logs to RHOBS; the command works as if the management cluster ID was passed if given a hosted cluster (HCP) ID. By default, logs from all the pods in the given namespace are returned but it is possible to specify a single pod as an argument or filter pods using their labels. Logs themselves can be also filtered to only keep the ones containing a given regexp (--contain-regex option) or a given log level (--level option).
+Fetch logs from RHOBS for a given cluster or RHOBS cell. The cluster can be a management cluster (MC) or whatever cluster sending logs to RHOBS; the command works as if the management cluster ID was passed if given a hosted cluster (HCP) ID. Alternatively, use --rhobs-cell to query a specific RHOBS cell directly without a cluster ID (useful for app-sre services like Clusters Service that send logs to the global cell). By default, logs from all the pods in the given namespace are returned but it is possible to specify a single pod as an argument or filter pods using their labels. Logs themselves can be also filtered to only keep the ones containing a given regexp (--contain-regex option) or a given log level (--level option).
 
 ```
 osdctl rhobs logs [pod] [flags]
@@ -31,6 +31,7 @@ osdctl rhobs logs [pod] [flags]
       --not-contain-regex stringArray   Regular expression the log message must not contain - flag can be repeated
   -o, --output string                   Format of the output - allowed values: "text", "csv" or "json" - exclusive with --url (default "text")
   -q, --query string                    LogQL expression - exclusive with many other flags
+      --rhobs-cell string               RHOBS cell URL (e.g., https://us-east-1-0.rhobs.api.stage.openshift.com) - query logs directly without a cluster ID - exclusive with --cluster-id
   -l, --selector string                 Label selector for filtering pods - exclusive with the pod argument
       --since duration                  Only return logs newer than a relative duration (e.g. 1h, 30m) - exclusive with --start-time & --end-time
       --start-time time                 Start time for the logs - alternate alias: --since-time (default to 5 minutes ago)


### PR DESCRIPTION
## Summary

- Add `--rhobs-cell` flag to `osdctl rhobs logs` CLI command for querying a RHOBS cell directly without a cluster ID
- Add `rhobs_cell` parameter to the `rhobs_logs` MCP tool with the same behavior
- When `--rhobs-cell` is set, the `openshift_cluster_id` filter is not applied, enabling queries for services like Clusters Service that send logs to the global RHOBS cell

Jira: https://redhat.atlassian.net/browse/ROSAENG-65395

## Example

Query Clusters Service provisioning logs from the stage global cell:

```
$ osdctl rhobs logs --rhobs-cell https://us-east-1-0.rhobs.api.stage.openshift.com \
    -n uhc-stage --since 1h --limit 5 --contain "[ROSA HCP -"

INFO RHOBS cell: https://us-east-1-0.rhobs.api.stage.openshift.com
INFO Loki query: {k8s_namespace_name="uhc-stage"} |= "[ROSA HCP -" | json json_kind="kind" | json_kind != "Event"
INFO Start time: 2026-08-13 18:11:05 -0700 PDT
INFO End time  : 2026-08-13 19:11:05 -0700 PDT
INFO Successfully authenticated
clusters-service-75568476c8-zjpk2 [opid='f784816c'] [cid='2s62jsh7'] [ROSA HCP - IT2] Cluster: 'cs-ci-longname-caxxk', Operation: 'Create', Kind: 'ConfigMap' ...
clusters-service-75568476c8-zjpk2 [opid='3a1a4b9b'] [cid='2s62jsh7'] [ROSA HCP - IT2] Cluster: 'cs-ci-longname-caxxk', Operation: 'Create', Kind: 'ManagedCluster' ...
```

The key difference from the standard flow: no `openshift_cluster_id` filter is appended to the LogQL query, since these services are not associated with a specific MC cluster ID.

Mutual exclusivity with `--cluster-id` is enforced:
```
$ osdctl rhobs logs --rhobs-cell https://... -C some-cluster -n uhc-stage
Error: --rhobs-cell and --cluster-id options cannot be used together
```

## Test plan

- [x] `go test ./cmd/rhobs/...` -- all 44 tests pass (9 new tests added)
- [x] `go build ./...` -- compiles clean
- [x] End-to-end: queried CS logs from stage global cell with local binary
- [ ] CI checks pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct RHOBS cell log querying without requiring a cluster ID.
  * Added `--rhobs-cell` support to the logs command and `rhobs_logs` tool.
  * Requires exactly one query target: a RHOBS cell or cluster ID.
  * Added validation for secure, properly formatted RHOBS cell URLs.
  * Improved direct cell query handling and error reporting.

* **Documentation**
  * Documented direct RHOBS cell log queries and option exclusivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->