### PR TITLE
ROSAENG-65671: add validation for --reason field if egress-verificati…

### DIFF
--- a/cmd/network/verification.go
+++ b/cmd/network/verification.go
@@ -253,6 +253,9 @@ func (e *EgressVerification) Run(ctx context.Context) {
 	}
 
 	if !e.PodMode && platform == cloud.AWSHCP {
+		if e.ClusterId != "" && e.Reason == "" && e.KubeConfig == "" {
+			log.Fatalf("HCP cluster detected (pod mode required). Please provide --reason for elevation (write operations need backplane-cluster-admin). Example: --reason 'OHSS-12345'")
+		}
 		e.log.Info(ctx, "Cluster is HCP - forcing pod mode.")
 		e.PodMode = true
 	}


### PR DESCRIPTION
…on is run against an HCP cluster

- Fix validation gap where `osdctl network verify-egress --cluster-id <id>` against an HCP cluster fails with an opaque Kubernetes RBAC error instead of telling the user to provide `--reason`
- The `--reason` check in `validateInput()` only fires when `--pod-mode` is explicitly passed, but HCP clusters auto-force pod mode after validation has already run
- Added an early `--reason` check inside the HCP pod-mode forcing block so users get a clear error 

  Fixes: [ROSAENG-65671](https://redhat.atlassian.net/browse/ROSAENG-65671)


[ROSAENG-65671]: https://redhat.atlassian.net/browse/ROSAENG-65671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent forcing pod mode for an HCP cluster without an elevation reason or explicit kubeconfig when a cluster ID is provided.
  * Displays an error instead of proceeding with incomplete authorization details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->