### PR TITLE
ROSAENG-62330: Add osdctl ci retrigger-pipeline subcommand

### DIFF
--- a/cmd/ci/ci.go
+++ b/cmd/ci/ci.go
@@ -1,0 +1,14 @@
+package ci
+
+import "github.com/spf13/cobra"
+
+func NewCmdCI() *cobra.Command {
+	ciCmd := &cobra.Command{
+		Use:               "ci",
+		Short:             "Commands for managing CI pipelines and jobs",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+	}
+	ciCmd.AddCommand(newCmdRetriggerPipeline())
+	return ciCmd
+}

--- a/cmd/ci/retrigger_pipeline.go
+++ b/cmd/ci/retrigger_pipeline.go
@@ -1,0 +1,180 @@
+package ci
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/openshift/osdctl/pkg/k8s"
+	"github.com/openshift/osdctl/pkg/utils"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// appsrep09ue1 hosts all SAPM Tekton PipelineRuns for osd-operators. It is always in production OCM.
+const appsrep09ue1ClusterID = "29nmp5rhf8rgclg4a02lju4eld79js9e"
+
+var pipelineRunGVK = schema.GroupVersionKind{
+	Group:   "tekton.dev",
+	Version: "v1",
+	Kind:    "PipelineRun",
+}
+
+type retriggerPipelineOptions struct {
+	namespace string
+	runName   string
+	reason    string
+}
+
+func newCmdRetriggerPipeline() *cobra.Command {
+	opts := &retriggerPipelineOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "retrigger-pipeline",
+		Short: "Retrigger a failed SAPM Tekton PipelineRun on appsrep09ue1",
+		Long: `Retrigger a failed SAPM Tekton PipelineRun on appsrep09ue1.
+
+Use this when a PipelineRun fails for infrastructure reasons unrelated to the operator code
+or e2e tests (e.g. network blip, transient API failure). A successful retrigger publishes
+to the SAPM success channel, unblocking downstream promotions.
+
+To find the failed PipelineRun name:
+  ocm backplane login --multi ` + appsrep09ue1ClusterID + `
+  kubectl get pipelineruns -n <operator>-pipelines --sort-by=.metadata.creationTimestamp
+
+Common namespaces: certman-operator-pipelines, cloud-ingress-operator-pipelines,
+  rbac-permissions-operator-pipelines, ocm-agent-operator-pipelines`,
+		Example: `  # Retrigger a failed certman int PipelineRun
+  osdctl ci retrigger-pipeline -n certman-operator-pipelines \
+    -r saas-co-prow-e2e-osd-integration-hivei01ue1-abc12 \
+    --reason ROSAENG-62330`,
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return opts.run(cmd.Context())
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "", "Namespace containing the failed PipelineRun (e.g. certman-operator-pipelines)")
+	cmd.Flags().StringVarP(&opts.runName, "run", "r", "", "Name of the failed PipelineRun")
+	cmd.Flags().StringVar(&opts.reason, "reason", "", "Backplane elevation reason (Jira key, PD URL, or ITN key)")
+
+	_ = cmd.MarkFlagRequired("namespace")
+	_ = cmd.MarkFlagRequired("run")
+	_ = cmd.MarkFlagRequired("reason")
+
+	return cmd
+}
+
+func (o *retriggerPipelineOptions) run(ctx context.Context) error {
+	ocmConn, err := utils.CreateConnectionWithUrl("production")
+	if err != nil {
+		return fmt.Errorf("failed to create production OCM connection: %w", err)
+	}
+	defer ocmConn.Close()
+
+	k8sClient, err := k8s.NewAsBackplaneClusterAdminWithConn(
+		appsrep09ue1ClusterID,
+		client.Options{},
+		ocmConn,
+		o.reason,
+		"Retriggering failed SAPM PipelineRun",
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create k8s client for appsrep09ue1: %w", err)
+	}
+
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(pipelineRunGVK)
+
+	fmt.Printf("Fetching PipelineRun %s/%s...\n", o.namespace, o.runName)
+	if err := k8sClient.Get(ctx, types.NamespacedName{Name: o.runName, Namespace: o.namespace}, existing); err != nil {
+		return fmt.Errorf("failed to get PipelineRun %s: %w", o.runName, err)
+	}
+
+	if err := requireFailedPipelineRun(existing); err != nil {
+		return err
+	}
+
+	spec, found, err := unstructured.NestedMap(existing.Object, "spec")
+	if err != nil {
+		return fmt.Errorf("failed to extract spec from PipelineRun: %w", err)
+	}
+	if !found {
+		return fmt.Errorf("PipelineRun %s has no spec", o.runName)
+	}
+	// Strip spec.status control field (StoppedRunFinally, CancelledRunFinally, etc.) so the
+	// new run starts fresh. Inheriting it would cause the Tekton controller to immediately
+	// stop or cancel the retriggered run.
+	delete(spec, "status")
+
+	generateName := existing.GetGenerateName()
+	if generateName == "" {
+		// Fall back to stripping the last random suffix from the run name.
+		parts := strings.Split(o.runName, "-")
+		if len(parts) < 2 {
+			return fmt.Errorf("run name %q has no hyphen; cannot derive generateName", o.runName)
+		}
+		generateName = strings.Join(parts[:len(parts)-1], "-") + "-"
+	}
+
+	newRun := &unstructured.Unstructured{}
+	newRun.Object = map[string]interface{}{
+		"apiVersion": "tekton.dev/v1",
+		"kind":       "PipelineRun",
+		"metadata": map[string]interface{}{
+			"generateName": generateName,
+			"namespace":    o.namespace,
+		},
+		"spec": spec,
+	}
+	newRun.SetGroupVersionKind(pipelineRunGVK)
+	newRun.SetLabels(existing.GetLabels())
+	newRun.SetAnnotations(existing.GetAnnotations())
+
+	fmt.Println("Creating new PipelineRun...")
+	if err := k8sClient.Create(ctx, newRun); err != nil {
+		return fmt.Errorf("failed to create PipelineRun: %w", err)
+	}
+
+	name := newRun.GetName()
+	fmt.Printf("Created: %s\n\n", name)
+	fmt.Printf("Monitor with:\n  kubectl get pipelinerun -n %s %s -w\n", o.namespace, name)
+
+	return nil
+}
+
+// requireFailedPipelineRun returns an error if the PipelineRun is not in a
+// terminal failed state (i.e. it is still running, succeeded, or was cancelled).
+func requireFailedPipelineRun(pr *unstructured.Unstructured) error {
+	conditions, _, _ := unstructured.NestedSlice(pr.Object, "status", "conditions")
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if cond["type"] != "Succeeded" {
+			continue
+		}
+		status, _ := cond["status"].(string)
+		reason, _ := cond["reason"].(string)
+		switch status {
+		case "Unknown":
+			return fmt.Errorf("PipelineRun %s is still running (status: Unknown, reason: %s); retrigger is only allowed for failed runs", pr.GetName(), reason)
+		case "True":
+			return fmt.Errorf("PipelineRun %s already succeeded; retrigger is only allowed for failed runs", pr.GetName())
+		case "False":
+			if reason == "Cancelled" || reason == "PipelineRunCancelled" ||
+				reason == "StoppedRunFinally" || reason == "CancelledRunFinally" || reason == "PipelineRunStopped" {
+				return fmt.Errorf("PipelineRun %s was stopped/cancelled (reason: %s); retrigger is only allowed for failed runs", pr.GetName(), reason)
+			}
+			// Failed, timed out, or other terminal failure — allow retrigger.
+			return nil
+		}
+	}
+	// No Succeeded condition found (e.g. very new run); treat as unknown.
+	return fmt.Errorf("PipelineRun %s has no Succeeded condition; cannot determine state", pr.GetName())
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/osdctl/cmd/aao"
 	"github.com/openshift/osdctl/cmd/account"
 	"github.com/openshift/osdctl/cmd/alerts"
+	"github.com/openshift/osdctl/cmd/ci"
 	"github.com/openshift/osdctl/cmd/cloudtrail"
 	"github.com/openshift/osdctl/cmd/cluster"
 	"github.com/openshift/osdctl/cmd/cost"
@@ -112,6 +113,7 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	addToRootCmdWithOtherGlobalOpts(hcp.NewCmdHCP())
 	addToRootCmdWithOtherGlobalOpts(network.NewCmdNetwork(streams, kubeClient))
 	addToRootCmdWithOtherGlobalOpts(org.NewCmdOrg())
+	rootCmd.AddCommand(ci.NewCmdCI())
 	rootCmd.AddCommand(promote.NewCmdPromote())
 	addToRootCmdWithOtherGlobalOpts(servicelog.NewCmdServiceLog())
 	addToRootCmdWithOtherGlobalOpts(setup.NewCmdSetup())

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,8 @@
     - `expire [--cluster-id <cluster-identifier>] [--all | --silence-id <silence-id>]` - Expire Silence for alert
     - `list --cluster-id <cluster-identifier>` - List all silences
     - `org <org-id> [--all --duration --comment | --alertname --duration --comment]` - Add new silence for alert for org
+- `ci` - Commands for managing CI pipelines and jobs
+  - `retrigger-pipeline` - Retrigger a failed SAPM Tekton PipelineRun on appsrep09ue1
 - `cloudtrail` - AWS CloudTrail related utilities
   - `errors` - Prints CloudTrail error events (permission/IAM issues) to console.
   - `permission-denied-events` - Prints cloudtrail permission-denied events to console.
@@ -1196,6 +1198,50 @@ osdctl alert silence org <org-id> [--all --duration --comment | --alertname --du
   -s, --server string                    The address and port of the Kubernetes API server
       --skip-aws-proxy-check aws_proxy   Don't use the configured aws_proxy value
   -S, --skip-version-check               skip checking to see if this is the most recent release
+```
+
+### osdctl ci
+
+Commands for managing CI pipelines and jobs
+
+```
+osdctl ci [flags]
+```
+
+#### Flags
+
+```
+  -h, --help                 help for ci
+  -S, --skip-version-check   skip checking to see if this is the most recent release
+```
+
+### osdctl ci retrigger-pipeline
+
+Retrigger a failed SAPM Tekton PipelineRun on appsrep09ue1.
+
+Use this when a PipelineRun fails for infrastructure reasons unrelated to the operator code
+or e2e tests (e.g. network blip, transient API failure). A successful retrigger publishes
+to the SAPM success channel, unblocking downstream promotions.
+
+To find the failed PipelineRun name:
+  ocm backplane login --multi 29nmp5rhf8rgclg4a02lju4eld79js9e
+  kubectl get pipelineruns -n <operator>-pipelines --sort-by=.metadata.creationTimestamp
+
+Common namespaces: certman-operator-pipelines, cloud-ingress-operator-pipelines,
+  rbac-permissions-operator-pipelines, ocm-agent-operator-pipelines
+
+```
+osdctl ci retrigger-pipeline [flags]
+```
+
+#### Flags
+
+```
+  -h, --help                 help for retrigger-pipeline
+  -n, --namespace string     Namespace containing the failed PipelineRun (e.g. certman-operator-pipelines)
+      --reason string        Backplane elevation reason (Jira key, PD URL, or ITN key)
+  -r, --run string           Name of the failed PipelineRun
+  -S, --skip-version-check   skip checking to see if this is the most recent release
 ```
 
 ### osdctl cloudtrail

--- a/docs/osdctl.md
+++ b/docs/osdctl.md
@@ -18,6 +18,7 @@ CLI tool to provide OSD related utilities
 * [osdctl aao](osdctl_aao.md)	 - AWS Account Operator Debugging Utilities
 * [osdctl account](osdctl_account.md)	 - AWS Account related utilities
 * [osdctl alert](osdctl_alert.md)	 - List alerts
+* [osdctl ci](osdctl_ci.md)	 - Commands for managing CI pipelines and jobs
 * [osdctl cloudtrail](osdctl_cloudtrail.md)	 - AWS CloudTrail related utilities
 * [osdctl cluster](osdctl_cluster.md)	 - Provides information for a specified cluster
 * [osdctl cost](osdctl_cost.md)	 - Cost Management related utilities

--- a/docs/osdctl_ci.md
+++ b/docs/osdctl_ci.md
@@ -1,0 +1,21 @@
+## osdctl ci
+
+Commands for managing CI pipelines and jobs
+
+### Options
+
+```
+  -h, --help   help for ci
+```
+
+### Options inherited from parent commands
+
+```
+  -S, --skip-version-check   skip checking to see if this is the most recent release
+```
+
+### SEE ALSO
+
+* [osdctl](osdctl.md)	 - OSD CLI
+* [osdctl ci retrigger-pipeline](osdctl_ci_retrigger-pipeline.md)	 - Retrigger a failed SAPM Tekton PipelineRun on appsrep09ue1
+

--- a/docs/osdctl_ci_retrigger-pipeline.md
+++ b/docs/osdctl_ci_retrigger-pipeline.md
@@ -1,0 +1,51 @@
+## osdctl ci retrigger-pipeline
+
+Retrigger a failed SAPM Tekton PipelineRun on appsrep09ue1
+
+### Synopsis
+
+Retrigger a failed SAPM Tekton PipelineRun on appsrep09ue1.
+
+Use this when a PipelineRun fails for infrastructure reasons unrelated to the operator code
+or e2e tests (e.g. network blip, transient API failure). A successful retrigger publishes
+to the SAPM success channel, unblocking downstream promotions.
+
+To find the failed PipelineRun name:
+  ocm backplane login --multi 29nmp5rhf8rgclg4a02lju4eld79js9e
+  kubectl get pipelineruns -n <operator>-pipelines --sort-by=.metadata.creationTimestamp
+
+Common namespaces: certman-operator-pipelines, cloud-ingress-operator-pipelines,
+  rbac-permissions-operator-pipelines, ocm-agent-operator-pipelines
+
+```
+osdctl ci retrigger-pipeline [flags]
+```
+
+### Examples
+
+```
+  # Retrigger a failed certman int PipelineRun
+  osdctl ci retrigger-pipeline -n certman-operator-pipelines \
+    -r saas-co-prow-e2e-osd-integration-hivei01ue1-abc12 \
+    --reason ROSAENG-62330
+```
+
+### Options
+
+```
+  -h, --help               help for retrigger-pipeline
+  -n, --namespace string   Namespace containing the failed PipelineRun (e.g. certman-operator-pipelines)
+      --reason string      Backplane elevation reason (Jira key, PD URL, or ITN key)
+  -r, --run string         Name of the failed PipelineRun
+```
+
+### Options inherited from parent commands
+
+```
+  -S, --skip-version-check   skip checking to see if this is the most recent release
+```
+
+### SEE ALSO
+
+* [osdctl ci](osdctl_ci.md)	 - Commands for managing CI pipelines and jobs
+


### PR DESCRIPTION
## Summary

Adds a new `osdctl ci` subcommand group with a `retrigger-pipeline` command for retriggering failed SAPM Tekton PipelineRuns on `appsrep09ue1`.

## Problem

SAPM creates Tekton PipelineRuns in `<operator>-pipelines` namespaces on `appsrep09ue1` to deploy gangway-bridge Jobs to hive clusters. These Jobs call the Gangway API to trigger Prow periodics and publish to SAPM success channels when they pass, unblocking downstream promotions.

PipelineRuns sometimes fail for infrastructure reasons (network blip, transient API error) unrelated to the operator code or e2e tests. Today fixing this requires manual steps: backplane login, kubectl get + strip + apply.

## Solution

```
osdctl ci retrigger-pipeline   -n certman-operator-pipelines   -r saas-co-prow-e2e-osd-integration-hivei01ue1-abc12   --reason ROSAENG-62330
```

The command:
1. Logs into `appsrep09ue1` via backplane (production OCM, cluster ID `29nmp5rhf8rgclg4a02lju4eld79js9e`)
2. Fetches the failed PipelineRun
3. Strips it to a fresh `generateName` form (preserves `labels` and `spec`, strips last random suffix)
4. Creates a new PipelineRun that goes through SAPM channels normally, unblocking downstream promotions

## Implementation notes

- Ports `hcm-design/cicd/scripts/retrigger-sapm-pipeline.sh` to Go
- Uses the same backplane client pattern as `cmd/cluster/cad/run.go` (`k8s.NewAsBackplaneClusterAdminWithConn`)
- `appsrep09ue1` is always production OCM (same reasoning as CAD clusters)

Jira: https://redhat.atlassian.net/browse/ROSAENG-62330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CI command group for pipeline operations.
  * Added the ability to retrigger eligible failed pipeline runs by specifying the namespace, run name, and access-elevation reason.
  * New runs retain the original pipeline configuration and metadata while receiving a new run name.
  * Added validation and clear error messages for missing inputs and pipeline operation failures.

* **Documentation**
  * Added command reference documentation, usage guidance, prerequisites, options, and examples for CI pipeline management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->