### PR TITLE
Limit goreleaser parallel builds to 2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,8 @@
 version: 2
 project_name: osdctl
 builds:
-  - env:
+  - parallelism: 2
+    env:
       - CGO_ENABLED=0
       - "GO111MODULE=on" # make sure to use go modules
       - "GOFLAGS=-mod=readonly -trimpath" # trimpath helps with producing verifiable binaries


### PR DESCRIPTION
The v0.64.0 release workflow has failed twice with GitHub's runner receiving a shutdown signal ~11 minutes into goreleaser's cross-compilation phase. By default goreleaser runs all 4 build targets (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64) concurrently, which puts heavy parallel load on the runner.

This caps parallelism at 2 to reduce peak resource usage and avoid triggering runner preemption, while still being faster than fully sequential builds.

## Testing

Re-running the release workflow after this merges will validate the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the release build configuration to use controlled parallelism for `osdctl`.
  * Existing build environment settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->