### PR TITLE
Fix goreleaser parallel builds (use CLI flag, not config field)

### DIFF
--- a/.github/workflows/release-on-version-bump.yaml
+++ b/.github/workflows/release-on-version-bump.yaml
@@ -148,7 +148,7 @@ jobs:
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: "v2.11.2" # keep in sync with the Makefile download-goreleaser target
-          args: release --clean
+          args: release --clean --parallelism 2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,6 @@ jobs:
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: "v2.11.2" # keep in sync with the Makefile download-goreleaser target
-          args: release --clean
+          args: release --clean --parallelism 2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,7 @@
 version: 2
 project_name: osdctl
 builds:
-  - parallelism: 2
-    env:
+  - env:
       - CGO_ENABLED=0
       - "GO111MODULE=on" # make sure to use go modules
       - "GOFLAGS=-mod=readonly -trimpath" # trimpath helps with producing verifiable binaries


### PR DESCRIPTION
Follow-up to #955. The `parallelism` field doesn't exist in goreleaser's build config schema -- it needs to be passed as a CLI flag instead. This caused the release to fail immediately with a YAML unmarshal error.

Changes:
- Reverts the invalid `parallelism: 2` from `.goreleaser.yml`
- Passes `--parallelism 2` via the goreleaser action `args` in both `release.yaml` and `release-on-version-bump.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Limited release build parallelism to improve build stability.
  - Applied the same release configuration consistently across automated release workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->