### PR TITLE
fix(ROSAENG-66556): Use domain_prefix when constructing FQDNs for cluster dns-verify

### DIFF
--- a/cmd/cluster/internal/dns/analyzer.go
+++ b/cmd/cluster/internal/dns/analyzer.go
@@ -76,7 +76,7 @@ func (a *DefaultAnalyzer) Analyze(cluster *cmv1.Cluster, results []VerifyResult)
 		},
 		Results:         results,
 		Summary:         a.populateSummary(results),
-		Recommendations: a.generateRecommendations(results),
+		Recommendations: a.generateRecommendations(cluster, results),
 	}
 }
 
@@ -116,6 +116,6 @@ type summaryStats struct {
 	Skipped int `json:"skipped"`
 }
 
-func (a *DefaultAnalyzer) generateRecommendations(results []VerifyResult) []string {
-	return a.cfg.Recommender.MakeRecommendations(results)
+func (a *DefaultAnalyzer) generateRecommendations(cluster *cmv1.Cluster, results []VerifyResult) []string {
+	return a.cfg.Recommender.MakeRecommendations(results, WithCluster{Cluster: cluster})
 }

--- a/cmd/cluster/internal/dns/analyzer_test.go
+++ b/cmd/cluster/internal/dns/analyzer_test.go
@@ -279,6 +279,17 @@ func TestWithCluster(t *testing.T) {
 	assert.Equal(t, cluster, cfg.Cluster)
 }
 
+func TestDefaultAnalyzer_PassesClusterToRecommender(t *testing.T) {
+	t.Parallel()
+	cluster := createTestCluster("test", "id123", "us-east-1")
+	recommender := &recordingRecommender{}
+	analyzer := NewDefaultAnalyzer(WithRecommender{Recommender: recommender})
+
+	analyzer.Analyze(cluster, []VerifyResult{{Status: VerifyResultStatusFail}})
+
+	assert.Equal(t, cluster, recommender.cluster)
+}
+
 // Helper functions and mocks
 
 func createTestCluster(name, id, region string) *cmv1.Cluster {
@@ -296,4 +307,15 @@ type mockRecommender struct {
 
 func (m *mockRecommender) MakeRecommendations(results []VerifyResult, opts ...MakeRecommendationsOption) []string {
 	return m.recommendations
+}
+
+type recordingRecommender struct {
+	cluster *cmv1.Cluster
+}
+
+func (r *recordingRecommender) MakeRecommendations(_ []VerifyResult, opts ...MakeRecommendationsOption) []string {
+	var cfg MakeRecommendationsConfig
+	cfg.Option(opts...)
+	r.cluster = cfg.Cluster
+	return nil
 }

--- a/cmd/cluster/verify_dns_long_description.txt
+++ b/cmd/cluster/verify_dns_long_description.txt
@@ -3,13 +3,13 @@ Performs DNS resolution tests for HCP clusters.
 Note: This command should be run when on the Red Hat VPN
 
 This command tests DNS resolution for cluster public endpoints:
-- Wildcard A record: *.apps.rosa.<cluster-name>.<base-domain>
-- Apps CNAME: apps.rosa.<cluster-name>.<base-domain>
-- ACME challenge CNAME: _acme-challenge.apps.rosa.<cluster-name>.<base-domain>
-- Cluster ID CNAME: <cluster-id>.rosa.<cluster-name>.<base-domain>
-- ACME cluster CNAME: _acme-challenge.<cluster-id>.rosa.<cluster-name>.<base-domain>
-- API record: api.<cluster-name>.<base-domain> (A record or CNAME based on PrivateLink)
-- OAuth record: oauth.<cluster-name>.<base-domain> (A record or CNAME based on PrivateLink)
+- Wildcard A record: *.apps.rosa.<domain-prefix>.<base-domain>
+- Apps CNAME: apps.rosa.<domain-prefix>.<base-domain>
+- ACME challenge CNAME: _acme-challenge.apps.rosa.<domain-prefix>.<base-domain>
+- Cluster ID CNAME: <cluster-id>.rosa.<domain-prefix>.<base-domain>
+- ACME cluster CNAME: _acme-challenge.<cluster-id>.rosa.<domain-prefix>.<base-domain>
+- API record: api.<domain-prefix>.<base-domain> (A record or CNAME based on PrivateLink)
+- OAuth record: oauth.<domain-prefix>.<base-domain> (A record or CNAME based on PrivateLink)
 
 This command only supports HCP (Hosted Control Plane) clusters.
 

--- a/cmd/cluster/verifydns.go
+++ b/cmd/cluster/verifydns.go
@@ -181,40 +181,40 @@ func (v *verifyDNSOptions) buildTestCases(cluster *cmv1.Cluster) map[string]dnst
 	tests["console"] = dnstestCase{
 		name:       cluster.Console().URL(),
 		recordType: "A",
-		description: "Test Console A record: console-openshift-console.apps.rosa.<cluster-name>.<base-domain>." +
+		description: "Test Console A record: console-openshift-console.apps.rosa.<domain-prefix>.<base-domain>." +
 			"This verifies the presence of the A record for the wildcard domain " +
-			"*.apps.rosa.<cluster-name>.<base-domain>",
+			"*.apps.rosa.<domain-prefix>.<base-domain>",
 	}
 
-	name := cluster.Name()
+	domainPrefix := cluster.DomainPrefix()
 	id := cluster.ID()
 	domain := cluster.DNS().BaseDomain()
 
-	clusterSubDomain := fmt.Sprintf("%s.%s", name, domain)
-	actualChallengeRecord := fmt.Sprintf("_acme-challenge.%s.%s", name, domain)
+	clusterSubDomain := fmt.Sprintf("%s.%s", domainPrefix, domain)
+	actualChallengeRecord := fmt.Sprintf("_acme-challenge.%s.%s", domainPrefix, domain)
 
-	defaultIngressFQDN := fmt.Sprintf("apps.rosa.%s.%s", name, domain)
+	defaultIngressFQDN := fmt.Sprintf("apps.rosa.%s.%s", domainPrefix, domain)
 	tests["default_ingress"] = dnstestCase{
 		name:           defaultIngressFQDN,
 		recordType:     dns.RecordTypeCNAME,
-		description:    "Test CNAME: apps.rosa.<cluster-name>.<base-domain> -> <cluster-name>.<base-domain>",
+		description:    "Test CNAME: apps.rosa.<domain-prefix>.<base-domain> -> <domain-prefix>.<base-domain>",
 		expectedTarget: clusterSubDomain,
 	}
 
-	// 3. Test CNAME: _acme-challenge.apps.rosa.<cluster-name>.<base-domain> -> _acme-challenge.<cluster-name>.<base-domain>
-	defaultIngressChallengePointer := fmt.Sprintf("_acme-challenge.apps.rosa.%s.%s", name, domain)
+	// 3. Test CNAME: _acme-challenge.apps.rosa.<domain-prefix>.<base-domain> -> _acme-challenge.<domain-prefix>.<base-domain>
+	defaultIngressChallengePointer := fmt.Sprintf("_acme-challenge.apps.rosa.%s.%s", domainPrefix, domain)
 	tests["default_ingress_challenge"] = dnstestCase{
 		name:           defaultIngressChallengePointer,
 		recordType:     dns.RecordTypeCNAME,
-		description:    "Test CNAME: _acme-challenge.apps.rosa.<cluster-name>.<base-domain> -> _acme-challenge.<cluster-name>.<base-domain>",
+		description:    "Test CNAME: _acme-challenge.apps.rosa.<domain-prefix>.<base-domain> -> _acme-challenge.<domain-prefix>.<base-domain>",
 		expectedTarget: actualChallengeRecord,
 	}
 
-	uniqueFQDN := fmt.Sprintf("%s.rosa.%s.%s", id, name, domain)
+	uniqueFQDN := fmt.Sprintf("%s.rosa.%s.%s", id, domainPrefix, domain)
 	uniqueTest := dnstestCase{
 		name:           uniqueFQDN,
 		recordType:     dns.RecordTypeCNAME,
-		description:    "Test CNAME: <cluster-id>.rosa.<cluster-name>.<base-domain> -> <cluster-name>.<base-domain>",
+		description:    "Test CNAME: <cluster-id>.rosa.<domain-prefix>.<base-domain> -> <domain-prefix>.<base-domain>",
 		expectedTarget: clusterSubDomain,
 	}
 
@@ -224,11 +224,11 @@ func (v *verifyDNSOptions) buildTestCases(cluster *cmv1.Cluster) map[string]dnst
 	}
 	tests["unique"] = uniqueTest
 
-	uniqueChallengePointer := fmt.Sprintf("_acme-challenge.%s.rosa.%s.%s", id, name, domain)
+	uniqueChallengePointer := fmt.Sprintf("_acme-challenge.%s.rosa.%s.%s", id, domainPrefix, domain)
 	uniqueChallengeTest := dnstestCase{
 		name:           uniqueChallengePointer,
 		recordType:     dns.RecordTypeCNAME,
-		description:    "Test CNAME: _acme-challenge.<cluster-id>.rosa.<cluster-name>.<base-domain> -> _acme-challenge.<cluster-name>.<base-domain>",
+		description:    "Test CNAME: _acme-challenge.<cluster-id>.rosa.<domain-prefix>.<base-domain> -> _acme-challenge.<domain-prefix>.<base-domain>",
 		expectedTarget: actualChallengeRecord,
 	}
 	if shouldSkipUnique {
@@ -236,26 +236,26 @@ func (v *verifyDNSOptions) buildTestCases(cluster *cmv1.Cluster) map[string]dnst
 	}
 	tests["unique_challenge"] = uniqueChallengeTest
 
-	apiFQDN := fmt.Sprintf("api.%s.%s", name, domain)
+	apiFQDN := fmt.Sprintf("api.%s.%s", domainPrefix, domain)
 	apiFQDNTest := dnstestCase{
 		name: apiFQDN,
 	}
 
-	oauthFQDN := fmt.Sprintf("oauth.%s.%s", name, domain)
+	oauthFQDN := fmt.Sprintf("oauth.%s.%s", domainPrefix, domain)
 	oauthFQDNTest := dnstestCase{
 		name: oauthFQDN,
 	}
 
 	if cluster.AWS().PrivateLink() {
 		apiFQDNTest.recordType = dns.RecordTypeCNAME
-		apiFQDNTest.description = "Test CNAME: api.<cluster-name>.<base-domain>"
+		apiFQDNTest.description = "Test CNAME: api.<domain-prefix>.<base-domain>"
 		oauthFQDNTest.recordType = dns.RecordTypeCNAME
-		oauthFQDNTest.description = "Test CNAME: oauth.<cluster-name>.<base-domain>"
+		oauthFQDNTest.description = "Test CNAME: oauth.<domain-prefix>.<base-domain>"
 	} else {
 		oauthFQDNTest.recordType = dns.RecordTypeA
-		oauthFQDNTest.description = "Test A record: oauth.<cluster-name>.<base-domain>"
+		oauthFQDNTest.description = "Test A record: oauth.<domain-prefix>.<base-domain>"
 		apiFQDNTest.recordType = dns.RecordTypeA
-		apiFQDNTest.description = "Test A record: api.<cluster-name>.<base-domain>"
+		apiFQDNTest.description = "Test A record: api.<domain-prefix>.<base-domain>"
 	}
 	tests["api"] = apiFQDNTest
 	tests["oauth"] = oauthFQDNTest

--- a/cmd/cluster/verifydns.go
+++ b/cmd/cluster/verifydns.go
@@ -285,45 +285,37 @@ func (r *recommender) MakeRecommendations(results []dns.VerifyResult, opts ...dn
 	var cfg dns.MakeRecommendationsConfig
 	cfg.Option(opts...)
 
-	var recommendations []string
+	var consoleFailed, defaultIngressFailed, uniqueFailed, apiOrOAuthFailed bool
 	for _, res := range results {
 		if res.Status != dns.VerifyResultStatusFail {
 			continue
 		}
 
 		if strings.HasPrefix(res.Name, "console") {
-			recommendations = append(recommendations, strings.Join([]string{
-				"If the console FQDN is not resolving then there is likely an issue with",
-				"CIO on the HCP cluster. Check if the A record <*.apps.rosa.<cluster-name>.<base-domain>",
-				"is defined in the Route 53 Public Hosted Zone in the customer AWS account.",
-				"If not check the health of CIO in the customer cluster.",
-			}, " "))
+			consoleFailed = true
 		} else if strings.HasPrefix(res.Name, "apps.rosa") || strings.HasPrefix(res.Name, "_acme-challenge.apps.rosa") {
-			recommendations = append(recommendations, strings.Join([]string{
-				"If the default ingress FQDNs are not resolving then there is likely an issue with",
-				"the Route 53 configuration in the customer AWS account. These records are created",
-				"once during provisioning by OCM and are not reconciled afterwards. Check the Route 53",
-				"public hosted zone in the customer AWS account to ensure these records exist.",
-				"The CNAME record <_acme-challenge.apps.rosa.<cluster-name>.<base-domain> in particular",
-				"must exist for ingress certificate issuance and renewal to succeed.",
-			}, " "))
-		} else if strings.HasPrefix(res.Name, cfg.Cluster.ID()) || strings.HasPrefix(res.Name, "_acme-challenge."+cfg.Cluster.ID()) {
-			recommendations = append(recommendations, strings.Join([]string{
-				"If the unique FQDNs are not resolving then there is likely an issue with",
-				"the Route 53 configuration in the customer AWS account. These records are created",
-				"once during provisioning by OCM and are not reconciled afterwards. Check the Route 53",
-				"public hosted zone in the customer AWS account to ensure these records exist.",
-				"The both CNAME records must exist for ingress certificate issuance and renewal to succeed.",
-			}, " "))
+			defaultIngressFailed = true
+		} else if cfg.Cluster != nil && (strings.HasPrefix(res.Name, cfg.Cluster.ID()) || strings.HasPrefix(res.Name, "_acme-challenge."+cfg.Cluster.ID())) {
+			uniqueFailed = true
 		} else if strings.HasPrefix(res.Name, "api") || strings.HasPrefix(res.Name, "oauth") {
-			recommendations = append(recommendations, strings.Join([]string{
-				"If the API or OAuth FQDNs are not resolving then there is likely an issue with",
-				"the external-dns operator on the parent Management Cluster of this HCP cluster.",
-				"Check the external-dns operator in the HyperShift namespace to ensure it has valid",
-				"AWS credentials and is running.",
-			}, " "))
+			apiOrOAuthFailed = true
 		}
 	}
+
+	var recommendations []string
+	if consoleFailed {
+		recommendations = append(recommendations, "The console FQDN failed to resolve. This likely indicates an issue with CIO on the HCP cluster. Verify that the *.apps.rosa.<domain-prefix>.<base-domain> A record exists in the customer AWS account's Route 53 public hosted zone. If it does not, check CIO health in the customer cluster.")
+	}
+	if defaultIngressFailed {
+		recommendations = append(recommendations, "One or more default ingress FQDNs failed to resolve. This likely indicates an issue with the Route 53 configuration in the customer AWS account. OCM creates these records during provisioning but does not reconcile them afterwards. Verify that the records exist in the Route 53 public hosted zone. In particular, the _acme-challenge.apps.rosa.<domain-prefix>.<base-domain> CNAME record is required for ingress certificate issuance and renewal.")
+	}
+	if uniqueFailed {
+		recommendations = append(recommendations, "One or more unique FQDNs failed to resolve. This likely indicates an issue with the Route 53 configuration in the customer AWS account. OCM creates these records during provisioning but does not reconcile them afterwards. Verify that both CNAME records exist in the Route 53 public hosted zone; they are required for ingress certificate issuance and renewal.")
+	}
+	if apiOrOAuthFailed {
+		recommendations = append(recommendations, "One or more API or OAuth FQDNs failed to resolve. This likely indicates an issue with the external-dns operator on the parent management cluster. Verify that the external-dns operator in the HyperShift namespace has valid AWS credentials and is running.")
+	}
+
 	return recommendations
 }
 

--- a/cmd/cluster/verifydns_test.go
+++ b/cmd/cluster/verifydns_test.go
@@ -67,6 +67,7 @@ func TestVerifyDNSOptions_BuildTestCases(t *testing.T) {
 	tests := []struct {
 		name                string
 		clusterName         string
+		domainPrefix        string
 		clusterID           string
 		baseDomain          string
 		consoleURL          string
@@ -78,9 +79,10 @@ func TestVerifyDNSOptions_BuildTestCases(t *testing.T) {
 		{
 			name:                "HCP cluster without PrivateLink created after cutoff",
 			clusterName:         "test-cluster",
+			domainPrefix:        "test-cluster-abc123",
 			clusterID:           "abc123",
 			baseDomain:          "example.com",
-			consoleURL:          "https://console-openshift-console.apps.rosa.test-cluster.example.com",
+			consoleURL:          "https://console-openshift-console.apps.rosa.test-cluster-abc123.example.com",
 			isPrivateLink:       false,
 			creationDate:        time.Date(2025, time.March, 11, 0, 0, 0, 0, time.UTC),
 			expectedTestCount:   7,
@@ -89,9 +91,10 @@ func TestVerifyDNSOptions_BuildTestCases(t *testing.T) {
 		{
 			name:                "HCP cluster with PrivateLink created before cutoff",
 			clusterName:         "test-cluster",
+			domainPrefix:        "test-cluster-abc123",
 			clusterID:           "abc123",
 			baseDomain:          "example.com",
-			consoleURL:          "https://console-openshift-console.apps.rosa.test-cluster.example.com",
+			consoleURL:          "https://console-openshift-console.apps.rosa.test-cluster-abc123.example.com",
 			isPrivateLink:       true,
 			creationDate:        time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC),
 			expectedTestCount:   7,
@@ -100,9 +103,10 @@ func TestVerifyDNSOptions_BuildTestCases(t *testing.T) {
 		{
 			name:                "HCP cluster without PrivateLink created before cutoff",
 			clusterName:         "my-cluster",
+			domainPrefix:        "my-cluster-xyz789",
 			clusterID:           "xyz789",
 			baseDomain:          "test.io",
-			consoleURL:          "https://console-openshift-console.apps.rosa.my-cluster.test.io",
+			consoleURL:          "https://console-openshift-console.apps.rosa.my-cluster-xyz789.test.io",
 			isPrivateLink:       false,
 			creationDate:        time.Date(2024, time.December, 1, 0, 0, 0, 0, time.UTC),
 			expectedTestCount:   7,
@@ -115,6 +119,7 @@ func TestVerifyDNSOptions_BuildTestCases(t *testing.T) {
 			t.Parallel()
 			cluster := createTestHCPCluster(
 				tt.clusterName,
+				tt.domainPrefix,
 				tt.clusterID,
 				tt.baseDomain,
 				tt.consoleURL,
@@ -127,6 +132,10 @@ func TestVerifyDNSOptions_BuildTestCases(t *testing.T) {
 
 			// Verify the correct number of test cases were created
 			assert.Equal(t, tt.expectedTestCount, len(testCases))
+			for _, testCase := range testCases {
+				assert.Contains(t, testCase.description, "<domain-prefix>")
+				assert.NotContains(t, testCase.description, "<cluster-name>")
+			}
 
 			// Verify console test case
 			g.Expect(testCases).Should(HaveKey("console"))
@@ -137,38 +146,41 @@ func TestVerifyDNSOptions_BuildTestCases(t *testing.T) {
 			// Verify default ingress test case
 			g.Expect(testCases).Should(HaveKey("default_ingress"))
 			defaultIngressTest := testCases["default_ingress"]
-			expectedDefaultIngress := "apps.rosa." + tt.clusterName + "." + tt.baseDomain
+			expectedDefaultIngress := "apps.rosa." + tt.domainPrefix + "." + tt.baseDomain
 			assert.Equal(t, expectedDefaultIngress, defaultIngressTest.name)
 			assert.Equal(t, dns.RecordTypeCNAME, defaultIngressTest.recordType)
-			assert.Equal(t, tt.clusterName+"."+tt.baseDomain, defaultIngressTest.expectedTarget)
+			assert.Equal(t, tt.domainPrefix+"."+tt.baseDomain, defaultIngressTest.expectedTarget)
 
 			// Verify default ingress challenge test case
 			g.Expect(testCases).Should(HaveKey("default_ingress_challenge"))
 			defaultIngressChallengeTest := testCases["default_ingress_challenge"]
-			expectedChallenge := "_acme-challenge.apps.rosa." + tt.clusterName + "." + tt.baseDomain
+			expectedChallenge := "_acme-challenge.apps.rosa." + tt.domainPrefix + "." + tt.baseDomain
 			assert.Equal(t, expectedChallenge, defaultIngressChallengeTest.name)
 			assert.Equal(t, dns.RecordTypeCNAME, defaultIngressChallengeTest.recordType)
+			assert.Equal(t, "_acme-challenge."+tt.domainPrefix+"."+tt.baseDomain, defaultIngressChallengeTest.expectedTarget)
 
 			// Verify unique FQDN test case
 			g.Expect(testCases).Should(HaveKey("unique"))
 			uniqueTest := testCases["unique"]
-			expectedUnique := tt.clusterID + ".rosa." + tt.clusterName + "." + tt.baseDomain
+			expectedUnique := tt.clusterID + ".rosa." + tt.domainPrefix + "." + tt.baseDomain
 			assert.Equal(t, expectedUnique, uniqueTest.name)
 			assert.Equal(t, dns.RecordTypeCNAME, uniqueTest.recordType)
+			assert.Equal(t, tt.domainPrefix+"."+tt.baseDomain, uniqueTest.expectedTarget)
 			assert.Equal(t, tt.expectUniqueSkipped, uniqueTest.skip)
 
 			// Verify unique challenge test case
 			g.Expect(testCases).Should(HaveKey("unique_challenge"))
 			uniqueChallengeTest := testCases["unique_challenge"]
-			expectedUniqueChallenge := "_acme-challenge." + tt.clusterID + ".rosa." + tt.clusterName + "." + tt.baseDomain
+			expectedUniqueChallenge := "_acme-challenge." + tt.clusterID + ".rosa." + tt.domainPrefix + "." + tt.baseDomain
 			assert.Equal(t, expectedUniqueChallenge, uniqueChallengeTest.name)
 			assert.Equal(t, dns.RecordTypeCNAME, uniqueChallengeTest.recordType)
+			assert.Equal(t, "_acme-challenge."+tt.domainPrefix+"."+tt.baseDomain, uniqueChallengeTest.expectedTarget)
 			assert.Equal(t, tt.expectUniqueSkipped, uniqueChallengeTest.skip)
 
 			// Verify API and OAuth test cases based on PrivateLink
 			g.Expect(testCases).Should(HaveKey("api"))
 			apiTest := testCases["api"]
-			expectedAPI := "api." + tt.clusterName + "." + tt.baseDomain
+			expectedAPI := "api." + tt.domainPrefix + "." + tt.baseDomain
 			assert.Equal(t, expectedAPI, apiTest.name)
 			if tt.isPrivateLink {
 				assert.Equal(t, dns.RecordTypeCNAME, apiTest.recordType)
@@ -178,7 +190,7 @@ func TestVerifyDNSOptions_BuildTestCases(t *testing.T) {
 
 			g.Expect(testCases).Should(HaveKey("oauth"))
 			oauthTest := testCases["oauth"]
-			expectedOAuth := "oauth." + tt.clusterName + "." + tt.baseDomain
+			expectedOAuth := "oauth." + tt.domainPrefix + "." + tt.baseDomain
 			assert.Equal(t, expectedOAuth, oauthTest.name)
 			if tt.isPrivateLink {
 				assert.Equal(t, dns.RecordTypeCNAME, oauthTest.recordType)
@@ -359,9 +371,10 @@ func (m *MockAnalyzer) Analyze(cluster *cmv1.Cluster, results []dns.VerifyResult
 
 // Helper functions
 
-func createTestHCPCluster(name, id, baseDomain, consoleURL string, isPrivateLink bool, creationDate time.Time) *cmv1.Cluster {
+func createTestHCPCluster(name, domainPrefix, id, baseDomain, consoleURL string, isPrivateLink bool, creationDate time.Time) *cmv1.Cluster {
 	clusterBuilder := cmv1.NewCluster().
 		Name(name).
+		DomainPrefix(domainPrefix).
 		ID(id).
 		DNS(cmv1.NewDNS().BaseDomain(baseDomain)).
 		Console(cmv1.NewClusterConsole().URL(consoleURL)).
@@ -384,6 +397,8 @@ func TestNewCmdVerifyDNS(t *testing.T) {
 	g.Expect(cmd).ShouldNot(BeNil())
 	g.Expect(cmd.Use).Should(ContainSubstring("verify-dns"))
 	g.Expect(cmd.Short).Should(ContainSubstring("DNS resolution"))
+	g.Expect(cmd.Long).Should(ContainSubstring("<domain-prefix>"))
+	g.Expect(cmd.Long).ShouldNot(ContainSubstring("<cluster-name>"))
 
 	// Verify flags are registered
 	clusterIDFlag := cmd.Flags().Lookup("cluster-id")

--- a/cmd/cluster/verifydns_test.go
+++ b/cmd/cluster/verifydns_test.go
@@ -283,6 +283,26 @@ func TestRecommender_MakeRecommendations(t *testing.T) {
 			shouldContain:           []string{"default ingress", "Route 53"},
 		},
 		{
+			name: "default ingress failures produce one recommendation",
+			results: []dns.VerifyResult{
+				{Name: "apps.rosa.test.example.com", Status: dns.VerifyResultStatusFail},
+				{Name: "_acme-challenge.apps.rosa.test.example.com", Status: dns.VerifyResultStatusFail},
+			},
+			clusterID:               "test-cluster",
+			expectedRecommendations: 1,
+			shouldContain:           []string{"One or more default ingress FQDNs failed to resolve.", "OCM creates these records during provisioning", "_acme-challenge.apps.rosa.<domain-prefix>.<base-domain> CNAME record"},
+		},
+		{
+			name: "unique failures produce one recommendation",
+			results: []dns.VerifyResult{
+				{Name: "test-cluster.rosa.prefix.example.com", Status: dns.VerifyResultStatusFail},
+				{Name: "_acme-challenge.test-cluster.rosa.prefix.example.com", Status: dns.VerifyResultStatusFail},
+			},
+			clusterID:               "test-cluster",
+			expectedRecommendations: 1,
+			shouldContain:           []string{"One or more unique FQDNs failed to resolve.", "Verify that both CNAME records exist", "they are required"},
+		},
+		{
 			name: "API/OAuth failure",
 			results: []dns.VerifyResult{
 				{

--- a/docs/README.md
+++ b/docs/README.md
@@ -2774,19 +2774,20 @@ Performs DNS resolution tests for HCP clusters.
 Note: This command should be run when on the Red Hat VPN
 
 This command tests DNS resolution for cluster public endpoints:
-- Wildcard A record: *.apps.rosa.<cluster-name>.<base-domain>
-- Apps CNAME: apps.rosa.<cluster-name>.<base-domain>
-- ACME challenge CNAME: _acme-challenge.apps.rosa.<cluster-name>.<base-domain>
-- Cluster ID CNAME: <cluster-id>.rosa.<cluster-name>.<base-domain>
-- ACME cluster CNAME: _acme-challenge.<cluster-id>.rosa.<cluster-name>.<base-domain>
-- API record: api.<cluster-name>.<base-domain> (A record or CNAME based on PrivateLink)
-- OAuth record: oauth.<cluster-name>.<base-domain> (A record or CNAME based on PrivateLink)
+- Wildcard A record: *.apps.rosa.<domain-prefix>.<base-domain>
+- Apps CNAME: apps.rosa.<domain-prefix>.<base-domain>
+- ACME challenge CNAME: _acme-challenge.apps.rosa.<domain-prefix>.<base-domain>
+- Cluster ID CNAME: <cluster-id>.rosa.<domain-prefix>.<base-domain>
+- ACME cluster CNAME: _acme-challenge.<cluster-id>.rosa.<domain-prefix>.<base-domain>
+- API record: api.<domain-prefix>.<base-domain> (A record or CNAME based on PrivateLink)
+- OAuth record: oauth.<domain-prefix>.<base-domain> (A record or CNAME based on PrivateLink)
 
 This command only supports HCP (Hosted Control Plane) clusters.
 
 Output Formats:
 - table (default): Human-readable table format with summary and recommendations
 - json: JSON format for programmatic consumption
+
 
 ```
 osdctl cluster verify-dns --cluster-id <cluster-id> [flags]

--- a/docs/osdctl_cluster_verify-dns.md
+++ b/docs/osdctl_cluster_verify-dns.md
@@ -9,19 +9,20 @@ Performs DNS resolution tests for HCP clusters.
 Note: This command should be run when on the Red Hat VPN
 
 This command tests DNS resolution for cluster public endpoints:
-- Wildcard A record: *.apps.rosa.<cluster-name>.<base-domain>
-- Apps CNAME: apps.rosa.<cluster-name>.<base-domain>
-- ACME challenge CNAME: _acme-challenge.apps.rosa.<cluster-name>.<base-domain>
-- Cluster ID CNAME: <cluster-id>.rosa.<cluster-name>.<base-domain>
-- ACME cluster CNAME: _acme-challenge.<cluster-id>.rosa.<cluster-name>.<base-domain>
-- API record: api.<cluster-name>.<base-domain> (A record or CNAME based on PrivateLink)
-- OAuth record: oauth.<cluster-name>.<base-domain> (A record or CNAME based on PrivateLink)
+- Wildcard A record: *.apps.rosa.<domain-prefix>.<base-domain>
+- Apps CNAME: apps.rosa.<domain-prefix>.<base-domain>
+- ACME challenge CNAME: _acme-challenge.apps.rosa.<domain-prefix>.<base-domain>
+- Cluster ID CNAME: <cluster-id>.rosa.<domain-prefix>.<base-domain>
+- ACME cluster CNAME: _acme-challenge.<cluster-id>.rosa.<domain-prefix>.<base-domain>
+- API record: api.<domain-prefix>.<base-domain> (A record or CNAME based on PrivateLink)
+- OAuth record: oauth.<domain-prefix>.<base-domain> (A record or CNAME based on PrivateLink)
 
 This command only supports HCP (Hosted Control Plane) clusters.
 
 Output Formats:
 - table (default): Human-readable table format with summary and recommendations
 - json: JSON format for programmatic consumption
+
 
 ```
 osdctl cluster verify-dns --cluster-id <cluster-id> [flags]


### PR DESCRIPTION
### Summary

* Ensures that Route53 records are checked with `osdctl cluster verify-dns` using proper FQDNs.
* Also updates text output to be more concise when making recommendations about failures for `osdctl cluster verify-dns`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - DNS verification now builds test hostnames using the cluster’s domain prefix for more accurate checks.
  - DNS recommendations are consolidated by failure category, reducing duplicate guidance.
  - Unique-record checks safely handle missing cluster configuration.
  - Recommendations now incorporate cluster context for more relevant results.
- **Documentation**
  - DNS endpoint examples and command help now use domain-prefix terminology.
- **Tests**
  - Expanded coverage for domain-prefix hostname generation, consolidated recommendations, and cluster-aware analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->